### PR TITLE
Worktree v2 bullmq wire compat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 /target
 .env
 ./redis-logs
+.wolf/
+.codegraph/
+.claude/
+docs/superpowers/
+CLAUDE.md

--- a/BULLMQ_V5_PARITY.md
+++ b/BULLMQ_V5_PARITY.md
@@ -1,0 +1,178 @@
+# BullMQ v5 Parity
+
+This document describes the parity status of the current branch,
+`worktree-v2-bullmq-wire-compat`, relative to BullMQ Node.js v5.x.
+
+It does **not** describe the state of `main`.
+
+## Goal
+
+The goal of this branch is BullMQ v5 wire compatibility plus the core queue,
+worker, events, and flow behavior needed for real interoperability between
+Rust and Node.
+
+In practice, that means:
+
+- Node BullMQ producers can enqueue work that Rust workers can process
+- Rust producers can enqueue work that Node BullMQ can inspect and process
+- Bull Board and other BullMQ ecosystem tools can operate against Redis data
+  created by `bullmq-rs`
+- Core parent/child flow state uses BullMQ-compatible Redis structures
+
+## Implemented on This Branch
+
+### Wire-compatible Redis layout
+
+- BullMQ-compatible queue keys and data structures:
+  - `wait`, `active`, `paused` as lists
+  - `prioritized`, `delayed`, `completed`, `failed`, `waiting-children`,
+    `marker` as sorted sets
+  - `meta` as hash
+  - `events` as stream
+- BullMQ-compatible job hash fields such as:
+  - `atm`, `ats`, `processedOn`, `finishedOn`, `failedReason`,
+    `returnvalue`, `pb`, `opts`
+
+### Lua-script-driven state transitions
+
+- BullMQ-style atomic Lua script ports for core queue and worker transitions
+- Script loader with BullMQ-style include resolution
+- Marker-based wakeup model for workers
+
+### Queue surface
+
+- `add`
+- `get_job`
+- `get_job_counts`
+- `count`
+- `get_job_ids`
+- `get_jobs`
+- `get_waiting`
+- `get_active`
+- `get_delayed`
+- `get_prioritized`
+- `get_completed`
+- `get_failed`
+- `get_waiting_children`
+- `remove`
+- `drain`
+- `pause`
+- `resume`
+- `is_paused`
+- `add_log`
+- `get_logs`
+
+### Worker/runtime behavior
+
+- Marker-based blocking loop using `BZPOPMIN`
+- Token-based job locks with lock extension
+- Stalled job recovery
+- `moveToFinished` fast-path
+- Startup recovery for pre-existing backlog
+- Timeout recovery for missed marker wakeups
+- Prefetch-channel fixes so prefetched jobs are not orphaned in `active`
+
+### Job active-handle methods
+
+- `update_progress`
+- `log`
+- `update_data`
+- `clear_logs`
+- `get_state`
+- state helpers (`is_completed`, `is_failed`, etc.)
+- `change_delay`
+- `retry`
+- `remove`
+- `change_priority`
+- `promote`
+- `wait_until_finished`
+
+### Queue events
+
+- `QueueEvents` stream consumer via `XREAD BLOCK`
+- typed `QueueEvent` enum
+- `QueueEventsProducer` custom event publishing
+
+### Core Flows parity
+
+- `FlowProducer`
+- same-queue flow creation
+- cross-queue flow creation
+- `waiting-children` lifecycle
+- parent release on child completion
+- delayed parent release
+- prioritized parent release
+- paused parent release
+- `Job::get_dependencies()`
+- `Job::get_children_values()`
+
+## Deliberately Excluded From This Branch
+
+This branch does **not** try to implement every BullMQ v5 subsystem.
+The following areas are intentionally left out of scope for this pass:
+
+- `JobScheduler` / repeatable jobs
+- advanced Flows APIs and policies such as:
+  - `getFlow(...)`
+  - dependency pagination / cursors
+  - ignored-dependency-on-failure and related failure-policy variants
+- rate limiting
+- metrics / Prometheus-style reporting
+- deduplication
+- debounce
+- automated Node.js conformance harness
+
+## Still Missing for Broader BullMQ v5 Parity
+
+These are the main gaps that remain if the goal is broader BullMQ API parity,
+not just wire compatibility and core runtime behavior:
+
+### Scheduler / repeatable jobs
+
+- `JobScheduler`
+- repeatable job support
+- cron / interval scheduling semantics
+
+### Remaining Queue API surface
+
+- `addBulk`
+- `clean`
+- `obliterate`
+- `retryJobs`
+- `promoteJobs`
+
+### Remaining Worker API/control surface
+
+- Worker pause / resume controls
+- Worker status helpers such as `isPaused` / `isRunning`
+- richer close / cancellation / rate-limit controls
+- BullMQ-style listener / emitter surface beyond current Rust APIs
+
+### Advanced Flows surface
+
+- `getFlow(...)`
+- richer dependency introspection
+- ignored / failed dependency buckets
+- failure-policy variants for parent/child flows
+
+### Conformance / confidence work
+
+- broader automated Node.js conformance testing
+- more end-to-end compatibility coverage beyond the current targeted checks
+
+## What This Branch Should Be Considered
+
+This branch should be considered:
+
+- BullMQ v5 wire-compatible for the implemented queue, worker, events, and
+  core flow behavior
+- suitable for Rust <-> Node interoperability on the implemented surface
+- not yet full BullMQ v5 API parity
+
+## Verification Snapshot
+
+Latest branch-local verification for the flow slice:
+
+- `cargo test --test unit_tests`
+- `cargo test --test integration_tests -- --ignored --test-threads=1 test_flow_`
+- `cargo test --test integration_tests -- --ignored --test-threads=1 test_job_get_dependencies_and_children_values`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,13 +3,10 @@
 version = 4
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
+name = "anyhow"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
@@ -18,6 +15,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "arcstr"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -43,15 +57,15 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bullmq-rs"
-version = "1.1.0"
+version = "2.0.0"
 dependencies = [
- "chrono",
  "redis",
  "serde",
  "serde_json",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -67,34 +81,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
-name = "cc"
-version = "1.2.56"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
-dependencies = [
- "find-msvc-tools",
- "shlex",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "chrono"
-version = "0.4.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
-dependencies = [
- "iana-time-zone",
- "js-sys",
- "num-traits",
- "serde",
- "wasm-bindgen",
- "windows-link",
-]
 
 [[package]]
 name = "combine"
@@ -111,10 +101,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
+name = "concurrent-queue"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "displaydoc"
@@ -128,6 +127,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,16 +143,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "find-msvc-tools"
-version = "0.1.9"
+name = "foldhash"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -199,28 +225,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.65"
+name = "getrandom"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
+name = "hashbrown"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "cc",
+ "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "icu_collections"
@@ -304,6 +340,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,6 +364,18 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -345,6 +399,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -434,6 +494,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,6 +544,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,14 +572,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "redis"
-version = "0.28.2"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e37ec3fd44bea2ec947ba6cc7634d7999a6590aca7c35827c250bc0de502bda6"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "redis"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f44e94c96d8870a387d88ce3de3fdd608cbfc0705f03cb343cdde91509d3e49a"
 dependencies = [
  "arc-swap",
+ "arcstr",
+ "async-lock",
  "backon",
  "bytes",
+ "cfg-if",
  "combine",
  "futures-channel",
  "futures-util",
@@ -513,10 +598,11 @@ dependencies = [
  "pin-project-lite",
  "ryu",
  "sha1_smol",
- "socket2 0.5.10",
+ "socket2",
  "tokio",
  "tokio-util",
  "url",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -545,6 +631,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -605,12 +697,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -631,16 +717,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "socket2"
@@ -711,7 +787,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -804,6 +880,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,6 +904,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "uuid"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+dependencies = [
+ "getrandom",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -832,6 +925,24 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -879,38 +990,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.62.2"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "leb128fmt",
+ "wasmparser",
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.60.2"
+name = "wasm-metadata"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
-name = "windows-interface"
-version = "0.59.3"
+name = "wasmparser"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -920,39 +1030,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -966,42 +1049,20 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1011,21 +1072,9 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1035,21 +1084,9 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1059,21 +1096,9 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1083,21 +1108,109 @@ checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bullmq-rs"
-version = "1.1.0"
+version = "2.0.0"
 edition = "2021"
 authors = ["Thomas Bogard <thom.bogard@gmail.com>"]
 license = "MIT OR Apache-2.0"
@@ -13,10 +13,10 @@ categories = ["asynchronous", "database"]
 
 [dependencies]
 tokio = { version = "1", features = ["rt", "sync", "time", "macros"] }
-redis = { version = "0.28", features = ["tokio-comp", "connection-manager"] }
+redis = { version = "1", features = ["tokio-comp", "connection-manager"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-chrono = { version = "0.4", features = ["serde"] }
+uuid = { version = "1", features = ["v4"] }
 tracing = "0.1"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -158,4 +158,8 @@ cargo run --example basic_worker
 
 ## License
 
-MIT OR Apache-2.0
+This project is licensed under `MIT OR Apache-2.0`.
+
+Parts of the BullMQ wire-compatibility layer are ported or adapted from
+[BullMQ](https://github.com/taskforcesh/bullmq), which is licensed under MIT.
+See [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,39 @@
+# Third-Party Notices
+
+This project includes Redis/Lua compatibility logic ported or adapted from
+[BullMQ](https://github.com/taskforcesh/bullmq).
+
+## BullMQ
+
+- Project: `taskforcesh/bullmq`
+- Repository: <https://github.com/taskforcesh/bullmq>
+- License: MIT
+
+Portions of this repository's BullMQ wire-compatibility layer, including Lua
+scripts and related wrappers, are derived from or closely adapted from BullMQ.
+
+### BullMQ MIT License
+
+```text
+MIT License
+
+Copyright (c) 2018 BullForce Labs AB and contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   redis:
     image: redis:latest
     container_name: redis
+    restart: "no"
     ports:
       - "6379:6379"
     volumes:

--- a/examples/basic_queue.rs
+++ b/examples/basic_queue.rs
@@ -30,7 +30,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             None,
         )
         .await?;
-    println!("Added job: {} (id: {}, state: {})", job.name, job.id, job.state);
+    println!(
+        "Added job: {} (id: {}, state: {})",
+        job.name, job.id, job.state
+    );
 
     // Add a delayed job (30 second delay)
     let delayed_job = queue
@@ -99,12 +102,30 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Get job counts
     let counts = queue.get_job_counts().await?;
     println!("\nJob counts:");
-    println!("  Wait:        {}", counts.get(&JobState::Wait).unwrap_or(&0));
-    println!("  Prioritized: {}", counts.get(&JobState::Prioritized).unwrap_or(&0));
-    println!("  Delayed:     {}", counts.get(&JobState::Delayed).unwrap_or(&0));
-    println!("  Active:      {}", counts.get(&JobState::Active).unwrap_or(&0));
-    println!("  Completed:   {}", counts.get(&JobState::Completed).unwrap_or(&0));
-    println!("  Failed:      {}", counts.get(&JobState::Failed).unwrap_or(&0));
+    println!(
+        "  Wait:        {}",
+        counts.get(&JobState::Wait).unwrap_or(&0)
+    );
+    println!(
+        "  Prioritized: {}",
+        counts.get(&JobState::Prioritized).unwrap_or(&0)
+    );
+    println!(
+        "  Delayed:     {}",
+        counts.get(&JobState::Delayed).unwrap_or(&0)
+    );
+    println!(
+        "  Active:      {}",
+        counts.get(&JobState::Active).unwrap_or(&0)
+    );
+    println!(
+        "  Completed:   {}",
+        counts.get(&JobState::Completed).unwrap_or(&0)
+    );
+    println!(
+        "  Failed:      {}",
+        counts.get(&JobState::Failed).unwrap_or(&0)
+    );
 
     Ok(())
 }

--- a/examples/basic_queue.rs
+++ b/examples/basic_queue.rs
@@ -1,4 +1,4 @@
-use bullmq_rs::{JobOptions, QueueBuilder, RedisConnection};
+use bullmq_rs::{JobOptions, JobState, QueueBuilder, RedisConnection};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
@@ -30,9 +30,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             None,
         )
         .await?;
-    println!("Added job: {} (id: {})", job.name, job.id);
+    println!("Added job: {} (id: {}, state: {})", job.name, job.id, job.state);
 
-    // Add a delayed job
+    // Add a delayed job (30 second delay)
     let delayed_job = queue
         .add(
             "reminder",
@@ -52,7 +52,27 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         delayed_job.name, delayed_job.id, delayed_job.state
     );
 
-    // Add a job with retries
+    // Add a prioritized job (priority 5)
+    let priority_job = queue
+        .add(
+            "urgent",
+            Email {
+                to: "vip@example.com".into(),
+                subject: "Priority mail".into(),
+                body: "This is a high-priority message.".into(),
+            },
+            Some(JobOptions {
+                priority: Some(5u32),
+                ..Default::default()
+            }),
+        )
+        .await?;
+    println!(
+        "Added priority job: {} (id: {}, priority: {})",
+        priority_job.name, priority_job.id, priority_job.priority
+    );
+
+    // Add a job with retries and exponential backoff
     let retry_job = queue
         .add(
             "notification",
@@ -72,13 +92,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
     println!(
-        "Added retry job: {} (id: {}, max_attempts: {})",
-        retry_job.name, retry_job.id, retry_job.max_attempts
+        "Added retry job: {} (id: {}, max_attempts: {:?})",
+        retry_job.name, retry_job.id, retry_job.opts.attempts
     );
 
     // Get job counts
     let counts = queue.get_job_counts().await?;
-    println!("\nJob counts: {:?}", counts);
+    println!("\nJob counts:");
+    println!("  Wait:        {}", counts.get(&JobState::Wait).unwrap_or(&0));
+    println!("  Prioritized: {}", counts.get(&JobState::Prioritized).unwrap_or(&0));
+    println!("  Delayed:     {}", counts.get(&JobState::Delayed).unwrap_or(&0));
+    println!("  Active:      {}", counts.get(&JobState::Active).unwrap_or(&0));
+    println!("  Completed:   {}", counts.get(&JobState::Completed).unwrap_or(&0));
+    println!("  Failed:      {}", counts.get(&JobState::Failed).unwrap_or(&0));
 
     Ok(())
 }

--- a/examples/basic_worker.rs
+++ b/examples/basic_worker.rs
@@ -34,20 +34,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     println!("Added 5 jobs to the queue");
 
-    // Create a worker with concurrency
+    // Create a worker with concurrency and lock_duration.
+    // WorkerBuilder::build() is synchronous — connections are established on start().
     let worker = WorkerBuilder::new("tasks")
         .connection(conn)
         .concurrency(2)
-        .poll_interval(Duration::from_millis(500))
+        .lock_duration(Duration::from_secs(30))
         .on_completed(|job| {
             println!("[completed] Job {} done", job.id);
         })
         .on_failed(|job, err| {
             println!("[failed] Job {} failed: {}", job.id, err);
         })
-        .build::<Task>()
-        .await?;
+        .build::<Task>();
 
+    // start() is async — it establishes Redis connections and begins processing.
+    // The handler returns Result<(), Box<dyn Error + Send + Sync>>.
     let handle = worker
         .start(|job| async move {
             println!(

--- a/lua/addDelayedJob-6.lua
+++ b/lua/addDelayedJob-6.lua
@@ -1,0 +1,3 @@
+-- Placeholder: addDelayedJob-6
+-- Will be ported from BullMQ Node.js
+return 0

--- a/lua/addDelayedJob-6.lua
+++ b/lua/addDelayedJob-6.lua
@@ -15,6 +15,8 @@
   ARGV[5] = opts (JSON string)
   ARGV[6] = maxEvents
   ARGV[7] = delayedTimestamp (the target timestamp when the job should run)
+  ARGV[8] = parentKey (optional)
+  ARGV[9] = parent (optional)
 
   Returns: jobId
 
@@ -40,6 +42,15 @@ local jobId = ARGV[4]
 local opts = cjson.decode(ARGV[5])
 local maxEvents = tonumber(ARGV[6]) or 10000
 local delayedTimestamp = tonumber(ARGV[7])
+local parentKey = ARGV[8]
+local parentData = ARGV[9]
+
+if parentKey == "" then
+  parentKey = nil
+end
+if parentData == "" then
+  parentData = nil
+end
 
 -- Idempotent: if job hash already exists, return the jobId
 if rcall("EXISTS", jobIdKey) == 1 then
@@ -47,7 +58,7 @@ if rcall("EXISTS", jobIdKey) == 1 then
 end
 
 local delay = opts['delay'] or 0
-storeJob(eventsKey, jobIdKey, jobId, name, data, opts, timestamp)
+storeJob(eventsKey, jobIdKey, jobId, name, data, opts, timestamp, parentKey, parentData)
 
 local score = getDelayedScore(delayedKey, timestamp, delay)
 rcall("ZADD", delayedKey, score, jobId)

--- a/lua/addDelayedJob-6.lua
+++ b/lua/addDelayedJob-6.lua
@@ -1,3 +1,61 @@
--- Placeholder: addDelayedJob-6
--- Will be ported from BullMQ Node.js
-return 0
+--[[
+  Add a delayed job.
+
+  KEYS[1] = delayed sorted set
+  KEYS[2] = meta hash
+  KEYS[3] = id counter key
+  KEYS[4] = events stream
+  KEYS[5] = marker sorted set
+  KEYS[6] = job hash key (prefix:queueName:jobId)
+
+  ARGV[1] = name
+  ARGV[2] = data (JSON string)
+  ARGV[3] = timestamp
+  ARGV[4] = jobId
+  ARGV[5] = opts (JSON string)
+  ARGV[6] = maxEvents
+  ARGV[7] = delayedTimestamp (the target timestamp when the job should run)
+
+  Returns: jobId
+
+  Ported from BullMQ (stripped: parent/flow, dedup, repeat, debounce).
+]]
+local rcall = redis.call
+
+--@include "storeJob"
+--@include "getDelayedScore"
+--@include "addDelayMarkerIfNeeded"
+
+local delayedKey = KEYS[1]
+local metaKey = KEYS[2]
+-- local idKey = KEYS[3]
+local eventsKey = KEYS[4]
+local markerKey = KEYS[5]
+local jobIdKey = KEYS[6]
+
+local name = ARGV[1]
+local data = ARGV[2]
+local timestamp = ARGV[3]
+local jobId = ARGV[4]
+local opts = cjson.decode(ARGV[5])
+local maxEvents = tonumber(ARGV[6]) or 10000
+local delayedTimestamp = tonumber(ARGV[7])
+
+-- Idempotent: if job hash already exists, return the jobId
+if rcall("EXISTS", jobIdKey) == 1 then
+  return jobId
+end
+
+local delay = opts['delay'] or 0
+storeJob(eventsKey, jobIdKey, jobId, name, data, opts, timestamp)
+
+local score = getDelayedScore(delayedKey, timestamp, delay)
+rcall("ZADD", delayedKey, score, jobId)
+
+-- Emit delayed event
+rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*",
+      "event", "delayed", "jobId", jobId, "delay", delayedTimestamp)
+
+addDelayMarkerIfNeeded(markerKey, delayedKey)
+
+return jobId

--- a/lua/addLog-2.lua
+++ b/lua/addLog-2.lua
@@ -1,0 +1,3 @@
+-- Placeholder: addLog-2
+-- Will be ported from BullMQ Node.js
+return 0

--- a/lua/addLog-2.lua
+++ b/lua/addLog-2.lua
@@ -1,3 +1,29 @@
--- Placeholder: addLog-2
--- Will be ported from BullMQ Node.js
-return 0
+--[[
+  Add a log entry to a job's log list.
+
+  KEYS[1] = job logs key (jobKey:logs)
+  KEYS[2] = meta hash
+
+  ARGV[1] = log line (string)
+  ARGV[2] = maxLogCount (optional, 0 or absent = unlimited)
+
+  Returns: current log count (LLEN)
+
+  Ported from BullMQ.
+]]
+local rcall = redis.call
+
+local logsKey = KEYS[1]
+-- local metaKey = KEYS[2]
+
+local logLine = ARGV[1]
+local maxLogCount = tonumber(ARGV[2]) or 0
+
+rcall("RPUSH", logsKey, logLine)
+
+if maxLogCount > 0 then
+  -- Keep only the last maxLogCount entries
+  rcall("LTRIM", logsKey, -maxLogCount, -1)
+end
+
+return rcall("LLEN", logsKey)

--- a/lua/addParentJob-6.lua
+++ b/lua/addParentJob-6.lua
@@ -1,0 +1,65 @@
+--[[
+  Add a parent job directly into the waiting-children state.
+
+  KEYS[1] = waiting-children sorted set
+  KEYS[2] = meta hash
+  KEYS[3] = id counter key
+  KEYS[4] = events stream
+  KEYS[5] = job hash key (prefix:queueName:jobId)
+  KEYS[6] = parent dependencies key (optional)
+
+  ARGV[1] = name
+  ARGV[2] = data (JSON string)
+  ARGV[3] = timestamp
+  ARGV[4] = jobId
+  ARGV[5] = opts (JSON string)
+  ARGV[6] = maxEvents
+  ARGV[7] = parentKey (optional)
+  ARGV[8] = parent (optional)
+
+  Returns: jobId
+]]
+local rcall = redis.call
+
+--@include "storeJob"
+
+local waitChildrenKey = KEYS[1]
+local eventsKey = KEYS[4]
+local jobIdKey = KEYS[5]
+local parentDependenciesKey = KEYS[6]
+
+local name = ARGV[1]
+local data = ARGV[2]
+local timestamp = ARGV[3]
+local jobId = ARGV[4]
+local opts = cjson.decode(ARGV[5])
+local maxEvents = tonumber(ARGV[6]) or 10000
+local parentKey = ARGV[7]
+local parentData = ARGV[8]
+
+if parentDependenciesKey == "" then
+  parentDependenciesKey = nil
+end
+if parentKey == "" then
+  parentKey = nil
+end
+if parentData == "" then
+  parentData = nil
+end
+
+if rcall("EXISTS", jobIdKey) == 1 then
+  return jobId
+end
+
+storeJob(eventsKey, jobIdKey, jobId, name, data, opts, timestamp, parentKey, parentData)
+rcall("HSET", jobIdKey, "state", "waiting-children")
+
+rcall("ZADD", waitChildrenKey, timestamp, jobId)
+rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*", "event",
+      "waiting-children", "jobId", jobId)
+
+if parentDependenciesKey ~= nil then
+  rcall("SADD", parentDependenciesKey, jobIdKey)
+end
+
+return jobId

--- a/lua/addParentJob-6.lua
+++ b/lua/addParentJob-6.lua
@@ -6,7 +6,7 @@
   KEYS[3] = id counter key
   KEYS[4] = events stream
   KEYS[5] = job hash key (prefix:queueName:jobId)
-  KEYS[6] = parent dependencies key (optional)
+  KEYS[6] = parent dependencies key (optional, stores fully-qualified child job keys)
 
   ARGV[1] = name
   ARGV[2] = data (JSON string)
@@ -26,6 +26,7 @@ local rcall = redis.call
 local waitChildrenKey = KEYS[1]
 local eventsKey = KEYS[4]
 local jobIdKey = KEYS[5]
+local childJobKey = jobIdKey
 local parentDependenciesKey = KEYS[6]
 
 local name = ARGV[1]
@@ -59,7 +60,7 @@ rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*", "event",
       "waiting-children", "jobId", jobId)
 
 if parentDependenciesKey ~= nil then
-  rcall("SADD", parentDependenciesKey, jobIdKey)
+  rcall("SADD", parentDependenciesKey, childJobKey)
 end
 
 return jobId

--- a/lua/addPrioritizedJob-9.lua
+++ b/lua/addPrioritizedJob-9.lua
@@ -1,0 +1,3 @@
+-- Placeholder: addPrioritizedJob-9
+-- Will be ported from BullMQ Node.js
+return 0

--- a/lua/addPrioritizedJob-9.lua
+++ b/lua/addPrioritizedJob-9.lua
@@ -19,6 +19,8 @@
   ARGV[6] = maxEvents
   ARGV[7] = prioritizedKey
   ARGV[8] = priorityCounterKey
+  ARGV[9] = parentKey (optional)
+  ARGV[10] = parent (optional)
 
   Returns: jobId
 
@@ -46,13 +48,23 @@ local opts = cjson.decode(ARGV[5])
 local maxEvents = tonumber(ARGV[6]) or 10000
 local prioritizedKey = ARGV[7]
 local pcKey = ARGV[8]
+local parentKey = ARGV[9]
+local parentData = ARGV[10]
+
+if parentKey == "" then
+  parentKey = nil
+end
+if parentData == "" then
+  parentData = nil
+end
 
 -- Idempotent: if job hash already exists, return the jobId
 if rcall("EXISTS", jobIdKey) == 1 then
   return jobId
 end
 
-local delay, priority = storeJob(eventsKey, jobIdKey, jobId, name, data, opts, timestamp)
+local delay, priority = storeJob(eventsKey, jobIdKey, jobId, name, data, opts, timestamp,
+                                 parentKey, parentData)
 
 -- Add to prioritized sorted set
 local score = getPriorityScore(priority, pcKey)

--- a/lua/addPrioritizedJob-9.lua
+++ b/lua/addPrioritizedJob-9.lua
@@ -1,3 +1,71 @@
--- Placeholder: addPrioritizedJob-9
--- Will be ported from BullMQ Node.js
-return 0
+--[[
+  Add a prioritized job.
+
+  KEYS[1] = wait list
+  KEYS[2] = meta hash
+  KEYS[3] = id counter key
+  KEYS[4] = events stream
+  KEYS[5] = marker sorted set
+  KEYS[6] = stalled set
+  KEYS[7] = job hash key (prefix:queueName:jobId)
+  KEYS[8] = active list
+  KEYS[9] = completed sorted set
+
+  ARGV[1] = name
+  ARGV[2] = data (JSON string)
+  ARGV[3] = timestamp
+  ARGV[4] = jobId
+  ARGV[5] = opts (JSON string)
+  ARGV[6] = maxEvents
+  ARGV[7] = prioritizedKey
+  ARGV[8] = priorityCounterKey
+
+  Returns: jobId
+
+  Ported from BullMQ (stripped: parent/flow, dedup, repeat, debounce).
+]]
+local rcall = redis.call
+
+--@include "storeJob"
+--@include "addBaseMarkerIfNeeded"
+--@include "getPriorityScore"
+
+local waitKey = KEYS[1]
+local metaKey = KEYS[2]
+-- local idKey = KEYS[3]
+local eventsKey = KEYS[4]
+local markerKey = KEYS[5]
+-- local stalledKey = KEYS[6]
+local jobIdKey = KEYS[7]
+
+local name = ARGV[1]
+local data = ARGV[2]
+local timestamp = ARGV[3]
+local jobId = ARGV[4]
+local opts = cjson.decode(ARGV[5])
+local maxEvents = tonumber(ARGV[6]) or 10000
+local prioritizedKey = ARGV[7]
+local pcKey = ARGV[8]
+
+-- Idempotent: if job hash already exists, return the jobId
+if rcall("EXISTS", jobIdKey) == 1 then
+  return jobId
+end
+
+local delay, priority = storeJob(eventsKey, jobIdKey, jobId, name, data, opts, timestamp)
+
+-- Add to prioritized sorted set
+local score = getPriorityScore(priority, pcKey)
+rcall("ZADD", prioritizedKey, score, jobId)
+
+-- Emit waiting event
+rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*",
+      "event", "waiting", "jobId", jobId, "prev", "")
+
+-- Signal workers if not paused
+local paused = rcall("HEXISTS", metaKey, "paused") == 1
+if not paused then
+  addBaseMarkerIfNeeded(markerKey)
+end
+
+return jobId

--- a/lua/addStandardJob-9.lua
+++ b/lua/addStandardJob-9.lua
@@ -1,0 +1,3 @@
+-- Placeholder: addStandardJob-9
+-- Will be ported from BullMQ Node.js
+return 0

--- a/lua/addStandardJob-9.lua
+++ b/lua/addStandardJob-9.lua
@@ -17,6 +17,8 @@
   ARGV[4] = jobId
   ARGV[5] = opts (JSON string)
   ARGV[6] = maxEvents
+  ARGV[7] = parentKey (optional)
+  ARGV[8] = parent (optional)
 
   Returns: jobId
 
@@ -41,13 +43,23 @@ local timestamp = ARGV[3]
 local jobId = ARGV[4]
 local opts = cjson.decode(ARGV[5])
 local maxEvents = tonumber(ARGV[6]) or 10000
+local parentKey = ARGV[7]
+local parentData = ARGV[8]
+
+if parentKey == "" then
+  parentKey = nil
+end
+if parentData == "" then
+  parentData = nil
+end
 
 -- Idempotent: if job hash already exists, return the jobId
 if rcall("EXISTS", jobIdKey) == 1 then
   return jobId
 end
 
-local delay, priority = storeJob(eventsKey, jobIdKey, jobId, name, data, opts, timestamp)
+local delay, priority = storeJob(eventsKey, jobIdKey, jobId, name, data, opts, timestamp,
+                                 parentKey, parentData)
 
 -- Check if paused
 local paused = rcall("HEXISTS", metaKey, "paused") == 1

--- a/lua/addStandardJob-9.lua
+++ b/lua/addStandardJob-9.lua
@@ -52,9 +52,13 @@ local delay, priority = storeJob(eventsKey, jobIdKey, jobId, name, data, opts, t
 -- Check if paused
 local paused = rcall("HEXISTS", metaKey, "paused") == 1
 
--- Push to wait list (LIFO push = LPUSH, so newest jobs are processed first;
--- use RPUSH if you want strict FIFO)
-rcall("LPUSH", waitKey, jobId)
+-- Push to wait list or paused list depending on queue state
+local targetKey = waitKey
+if paused then
+  -- Derive paused key: replace ":wait" suffix with ":paused"
+  targetKey = string.gsub(waitKey, ":wait$", ":paused")
+end
+rcall("LPUSH", targetKey, jobId)
 
 -- Emit waiting event
 rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*",

--- a/lua/addStandardJob-9.lua
+++ b/lua/addStandardJob-9.lua
@@ -1,3 +1,68 @@
--- Placeholder: addStandardJob-9
--- Will be ported from BullMQ Node.js
-return 0
+--[[
+  Add a standard (non-prioritized, non-delayed) job.
+
+  KEYS[1] = wait list
+  KEYS[2] = meta hash
+  KEYS[3] = id counter key
+  KEYS[4] = events stream
+  KEYS[5] = marker sorted set
+  KEYS[6] = stalled set
+  KEYS[7] = job hash key (prefix:queueName:jobId)
+  KEYS[8] = active list
+  KEYS[9] = completed sorted set
+
+  ARGV[1] = name
+  ARGV[2] = data (JSON string)
+  ARGV[3] = timestamp
+  ARGV[4] = jobId
+  ARGV[5] = opts (JSON string)
+  ARGV[6] = maxEvents
+
+  Returns: jobId
+
+  Ported from BullMQ (stripped: parent/flow, dedup, repeat, debounce).
+]]
+local rcall = redis.call
+
+--@include "storeJob"
+--@include "addBaseMarkerIfNeeded"
+
+local waitKey = KEYS[1]
+local metaKey = KEYS[2]
+-- local idKey = KEYS[3]
+local eventsKey = KEYS[4]
+local markerKey = KEYS[5]
+-- local stalledKey = KEYS[6]
+local jobIdKey = KEYS[7]
+
+local name = ARGV[1]
+local data = ARGV[2]
+local timestamp = ARGV[3]
+local jobId = ARGV[4]
+local opts = cjson.decode(ARGV[5])
+local maxEvents = tonumber(ARGV[6]) or 10000
+
+-- Idempotent: if job hash already exists, return the jobId
+if rcall("EXISTS", jobIdKey) == 1 then
+  return jobId
+end
+
+local delay, priority = storeJob(eventsKey, jobIdKey, jobId, name, data, opts, timestamp)
+
+-- Check if paused
+local paused = rcall("HEXISTS", metaKey, "paused") == 1
+
+-- Push to wait list (LIFO push = LPUSH, so newest jobs are processed first;
+-- use RPUSH if you want strict FIFO)
+rcall("LPUSH", waitKey, jobId)
+
+-- Emit waiting event
+rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*",
+      "event", "waiting", "jobId", jobId, "prev", "")
+
+-- Signal workers if not paused
+if not paused then
+  addBaseMarkerIfNeeded(markerKey)
+end
+
+return jobId

--- a/lua/changePriority-7.lua
+++ b/lua/changePriority-7.lua
@@ -1,0 +1,94 @@
+--[[
+  Change the priority of a job.
+
+  Moves job between wait list and prioritized sorted set as needed.
+  Updates the priority field on the job hash.
+
+  Input:
+    KEYS[1] meta
+    KEYS[2] prioritized
+    KEYS[3] wait
+    KEYS[4] paused
+    KEYS[5] active
+    KEYS[6] pc (priority counter)
+    KEYS[7] marker
+
+    ARGV[1] priority (new value)
+    ARGV[2] jobId
+    ARGV[3] jobKey
+    ARGV[4] events prefix key (e.g. "bull:queueName:events")
+    ARGV[5] timestamp
+    ARGV[6] maxEvents
+
+  Output:
+    0  - OK
+    -1 - Job not found
+
+  Ported from BullMQ (stripped: flows, groups).
+]]
+local rcall = redis.call
+
+--@include "addBaseMarkerIfNeeded"
+--@include "getPriorityScore"
+
+local metaKey = KEYS[1]
+local prioritizedKey = KEYS[2]
+local waitKey = KEYS[3]
+local pausedKey = KEYS[4]
+local activeKey = KEYS[5]
+local pcKey = KEYS[6]
+local markerKey = KEYS[7]
+
+local priority = tonumber(ARGV[1])
+local jobId = ARGV[2]
+local jobKey = ARGV[3]
+local eventsKey = ARGV[4]
+local timestamp = ARGV[5]
+local maxEvents = tonumber(ARGV[6])
+
+if rcall("EXISTS", jobKey) ~= 1 then
+  return -1
+end
+
+local currentPriority = tonumber(rcall("HGET", jobKey, "priority")) or 0
+
+-- Determine if the queue is paused
+local queueAttributes = rcall("HMGET", metaKey, "paused", "concurrency")
+local isPaused = queueAttributes[1]
+
+if priority > 0 then
+  -- Move to prioritized set
+  if currentPriority == 0 then
+    -- Was in wait list, move to prioritized
+    local removed = rcall("LREM", waitKey, 0, jobId)
+    if removed == 0 and isPaused then
+      rcall("LREM", pausedKey, 0, jobId)
+    end
+  else
+    -- Already in prioritized, remove old entry
+    rcall("ZREM", prioritizedKey, jobId)
+  end
+
+  local score = getPriorityScore(priority, pcKey)
+  rcall("ZADD", prioritizedKey, score, jobId)
+elseif currentPriority > 0 then
+  -- Was prioritized, move to wait/paused list
+  rcall("ZREM", prioritizedKey, jobId)
+  if isPaused then
+    rcall("RPUSH", pausedKey, jobId)
+  else
+    rcall("RPUSH", waitKey, jobId)
+  end
+end
+
+-- Update the priority field on the job hash
+rcall("HSET", jobKey, "priority", priority)
+
+-- Emit priority event
+rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*",
+  "event", "priority", "jobId", jobId, "priority", priority)
+
+-- Signal workers
+addBaseMarkerIfNeeded(markerKey, isPaused)
+
+return 0

--- a/lua/extendLock-2.lua
+++ b/lua/extendLock-2.lua
@@ -1,0 +1,3 @@
+-- Placeholder: extendLock-2
+-- Will be ported from BullMQ Node.js
+return 0

--- a/lua/extendLock-2.lua
+++ b/lua/extendLock-2.lua
@@ -1,3 +1,33 @@
--- Placeholder: extendLock-2
--- Will be ported from BullMQ Node.js
-return 0
+--[[
+  Extend the lock on a job.
+
+  KEYS[1] = job lock key (jobKey:lock)
+  KEYS[2] = stalled set
+
+  ARGV[1] = token
+  ARGV[2] = lockDuration (milliseconds)
+  ARGV[3] = jobId
+
+  Returns:
+    0   on success
+    -2  if lock does not exist or token does not match
+
+  Ported from BullMQ.
+]]
+local rcall = redis.call
+
+local lockKey = KEYS[1]
+local stalledKey = KEYS[2]
+
+local token = ARGV[1]
+local lockDuration = tonumber(ARGV[2])
+local jobId = ARGV[3]
+
+local lockToken = rcall("GET", lockKey)
+if lockToken == token then
+  rcall("SET", lockKey, token, "PX", lockDuration)
+  rcall("SREM", stalledKey, jobId)
+  return 0
+end
+
+return -2

--- a/lua/includes/addBaseMarkerIfNeeded.lua
+++ b/lua/includes/addBaseMarkerIfNeeded.lua
@@ -1,0 +1,3 @@
+-- Placeholder: addBaseMarkerIfNeeded
+-- Will be ported from BullMQ Node.js
+return 0

--- a/lua/includes/addBaseMarkerIfNeeded.lua
+++ b/lua/includes/addBaseMarkerIfNeeded.lua
@@ -1,3 +1,12 @@
--- Placeholder: addBaseMarkerIfNeeded
--- Will be ported from BullMQ Node.js
-return 0
+--[[
+  Add base marker if needed.
+  Signal workers that immediate work is available by adding a "0" marker
+  to the marker sorted set.
+
+  Ported from BullMQ (stripped: rate limiter checks, max concurrency checks).
+]]
+local function addBaseMarkerIfNeeded(markerKey, isPausedOrMaxed)
+  if not isPausedOrMaxed then
+    rcall("ZADD", markerKey, 0, "0")
+  end
+end

--- a/lua/includes/addDelayMarkerIfNeeded.lua
+++ b/lua/includes/addDelayMarkerIfNeeded.lua
@@ -1,0 +1,3 @@
+-- Placeholder: addDelayMarkerIfNeeded
+-- Will be ported from BullMQ Node.js
+return 0

--- a/lua/includes/addDelayMarkerIfNeeded.lua
+++ b/lua/includes/addDelayMarkerIfNeeded.lua
@@ -1,3 +1,27 @@
--- Placeholder: addDelayMarkerIfNeeded
--- Will be ported from BullMQ Node.js
-return 0
+--[[
+  Add delay marker if needed.
+  Signal workers about the next delayed job by adding a "1" marker
+  to the marker sorted set with the next delayed timestamp as score.
+
+  Ported from BullMQ.
+  Inlines getNextDelayedTimestamp (not registered as a separate include).
+]]
+
+local function getNextDelayedTimestamp(delayedKey)
+  local result = rcall("ZRANGE", delayedKey, 0, 0, "WITHSCORES")
+  if #result then
+    local nextTimestamp = tonumber(result[2])
+    if nextTimestamp ~= nil then
+      return nextTimestamp / 0x1000
+    end
+  end
+end
+
+local function addDelayMarkerIfNeeded(markerKey, delayedKey)
+  local nextTimestamp = getNextDelayedTimestamp(delayedKey)
+  if nextTimestamp ~= nil then
+    -- Replace the score of the marker with the newest known
+    -- next timestamp.
+    rcall("ZADD", markerKey, nextTimestamp, "1")
+  end
+end

--- a/lua/includes/addJobInTargetList.lua
+++ b/lua/includes/addJobInTargetList.lua
@@ -1,0 +1,7 @@
+--[[
+  Push a job into the target list and emit a worker marker when applicable.
+]]
+local function addJobInTargetList(targetKey, markerKey, pushCmd, isPausedOrMaxed, jobId)
+  rcall(pushCmd, targetKey, jobId)
+  addBaseMarkerIfNeeded(markerKey, isPausedOrMaxed)
+end

--- a/lua/includes/addJobWithPriority.lua
+++ b/lua/includes/addJobWithPriority.lua
@@ -1,0 +1,9 @@
+--[[
+  Add a job to the prioritized sorted set and emit a worker marker when applicable.
+]]
+local function addJobWithPriority(markerKey, prioritizedKey, priority, jobId,
+  priorityCounterKey, isPausedOrMaxed)
+  local score = getPriorityScore(priority, priorityCounterKey)
+  rcall("ZADD", prioritizedKey, score, jobId)
+  addBaseMarkerIfNeeded(markerKey, isPausedOrMaxed)
+end

--- a/lua/includes/getDelayedScore.lua
+++ b/lua/includes/getDelayedScore.lua
@@ -1,0 +1,3 @@
+-- Placeholder: getDelayedScore
+-- Will be ported from BullMQ Node.js
+return 0

--- a/lua/includes/getDelayedScore.lua
+++ b/lua/includes/getDelayedScore.lua
@@ -1,3 +1,32 @@
--- Placeholder: getDelayedScore
--- Will be ported from BullMQ Node.js
-return 0
+--[[
+  Dynamically allocate a score within a timestamp bucket for delayed jobs.
+
+  Algorithm:
+    1. minScore = delayedTimestamp * 0x1000
+    2. maxScore = (delayedTimestamp + 1) * 0x1000 - 1
+    3. ZREVRANGEBYSCORE delayed maxScore minScore LIMIT 0 1
+    4. If empty: use minScore
+    5. If highest < maxScore: use highest + 1
+    6. If full: use maxScore
+
+  Ported from BullMQ.
+]]
+local function getDelayedScore(delayedKey, timestamp, delay)
+  local delayedTimestamp = (delay > 0 and (tonumber(timestamp) + delay)) or tonumber(timestamp)
+  local minScore = delayedTimestamp * 0x1000
+  local maxScore = (delayedTimestamp + 1) * 0x1000 - 1
+
+  local result = rcall("ZREVRANGEBYSCORE", delayedKey, maxScore,
+    minScore, "WITHSCORES", "LIMIT", 0, 1)
+  if #result then
+    local currentMaxScore = tonumber(result[2])
+    if currentMaxScore ~= nil then
+      if currentMaxScore >= maxScore then
+        return maxScore, delayedTimestamp
+      else
+        return currentMaxScore + 1, delayedTimestamp
+      end
+    end
+  end
+  return minScore, delayedTimestamp
+end

--- a/lua/includes/getPriorityScore.lua
+++ b/lua/includes/getPriorityScore.lua
@@ -1,0 +1,3 @@
+-- Placeholder: getPriorityScore
+-- Will be ported from BullMQ Node.js
+return 0

--- a/lua/includes/getPriorityScore.lua
+++ b/lua/includes/getPriorityScore.lua
@@ -1,3 +1,14 @@
--- Placeholder: getPriorityScore
--- Will be ported from BullMQ Node.js
-return 0
+--[[
+  Compute priority-based score.
+
+  Formula: priority * 0x100000000 + (INCR priorityCounterKey) % 0x100000000
+
+  This ensures that within the same priority level, jobs are ordered
+  by insertion order (FIFO) via the counter.
+
+  Ported from BullMQ.
+]]
+local function getPriorityScore(priority, priorityCounterKey)
+  local prioCounter = rcall("INCR", priorityCounterKey)
+  return priority * 0x100000000 + prioCounter % 0x100000000
+end

--- a/lua/includes/getTargetQueueList.lua
+++ b/lua/includes/getTargetQueueList.lua
@@ -4,14 +4,16 @@
 ]]
 local function getTargetQueueList(queueMetaKey, activeKey, waitKey, pausedKey)
   local queueAttributes = rcall("HMGET", queueMetaKey, "paused", "concurrency")
+  local isPaused = queueAttributes[1]
+  local concurrency = tonumber(queueAttributes[2])
 
-  if queueAttributes[1] then
+  if isPaused then
     return pausedKey, true
   end
 
-  if queueAttributes[2] then
+  if concurrency then
     local activeCount = rcall("LLEN", activeKey)
-    if activeCount >= tonumber(queueAttributes[2]) then
+    if activeCount >= concurrency then
       return waitKey, true
     end
   end

--- a/lua/includes/getTargetQueueList.lua
+++ b/lua/includes/getTargetQueueList.lua
@@ -1,0 +1,20 @@
+--[[
+  Resolve whether a job should go to the wait or paused list, and whether
+  workers should be signaled immediately.
+]]
+local function getTargetQueueList(queueMetaKey, activeKey, waitKey, pausedKey)
+  local queueAttributes = rcall("HMGET", queueMetaKey, "paused", "concurrency")
+
+  if queueAttributes[1] then
+    return pausedKey, true
+  end
+
+  if queueAttributes[2] then
+    local activeCount = rcall("LLEN", activeKey)
+    if activeCount >= tonumber(queueAttributes[2]) then
+      return waitKey, true
+    end
+  end
+
+  return waitKey, false
+end

--- a/lua/includes/moveJobToWait.lua
+++ b/lua/includes/moveJobToWait.lua
@@ -1,0 +1,3 @@
+-- Placeholder: moveJobToWait
+-- Will be ported from BullMQ Node.js
+return 0

--- a/lua/includes/moveJobToWait.lua
+++ b/lua/includes/moveJobToWait.lua
@@ -1,3 +1,64 @@
--- Placeholder: moveJobToWait
--- Will be ported from BullMQ Node.js
-return 0
+--[[
+  Move a job to the wait list or prioritized set.
+
+  If priority > 0, ZADD to prioritized set (using getPriorityScore).
+  Otherwise, LPUSH (FIFO default) or RPUSH (retried jobs) to wait list
+  (or paused list if queue is paused).
+  Then signal workers via addBaseMarkerIfNeeded.
+
+  Ported from BullMQ (stripped: flow/parent logic).
+  Inlines getTargetQueueList and addJobInTargetList (not registered as
+  separate includes). Depends on addBaseMarkerIfNeeded and getPriorityScore
+  being inlined before this include.
+]]
+
+--- getTargetQueueList: determine target list and whether the queue is
+--- paused or at max concurrency.
+local function getTargetQueueList(queueMetaKey, activeKey, waitKey, pausedKey)
+  local queueAttributes = rcall("HMGET", queueMetaKey, "paused", "concurrency")
+
+  if queueAttributes[1] then
+    -- Queue is paused
+    return pausedKey, true
+  else
+    if queueAttributes[2] then
+      local activeCount = rcall("LLEN", activeKey)
+      if activeCount >= tonumber(queueAttributes[2]) then
+        return waitKey, true
+      else
+        return waitKey, false
+      end
+    end
+  end
+  return waitKey, false
+end
+
+--- addJobInTargetList: push a job into the target list and add marker.
+local function addJobInTargetList(targetKey, markerKey, pushCmd, isPausedOrMaxed, jobId)
+  rcall(pushCmd, targetKey, jobId)
+  addBaseMarkerIfNeeded(markerKey, isPausedOrMaxed)
+end
+
+--- addJobWithPriority: add a job to the prioritized sorted set.
+local function addJobWithPriority(markerKey, prioritizedKey, priority, jobId,
+  priorityCounterKey, isPausedOrMaxed)
+  local score = getPriorityScore(priority, priorityCounterKey)
+  rcall("ZADD", prioritizedKey, score, jobId)
+  addBaseMarkerIfNeeded(markerKey, isPausedOrMaxed)
+end
+
+local function moveJobToWait(prefixKey, metaKey, activeKey, waitKey, pausedKey,
+  prioritizedKey, markerKey, eventStreamKey, jobId, pushCmd, priorityCounterKey)
+  local jobKey = prefixKey .. jobId
+  local priority = tonumber(rcall("HGET", jobKey, "priority")) or 0
+
+  if priority > 0 then
+    addJobWithPriority(markerKey, prioritizedKey, priority, jobId,
+      priorityCounterKey, false)
+  else
+    local target, isPausedOrMaxed = getTargetQueueList(metaKey, activeKey, waitKey, pausedKey)
+    addJobInTargetList(target, markerKey, pushCmd, isPausedOrMaxed, jobId)
+  end
+
+  rcall("XADD", eventStreamKey, "*", "event", "waiting", "jobId", jobId, "prev", "active")
+end

--- a/lua/includes/moveParentToWait.lua
+++ b/lua/includes/moveParentToWait.lua
@@ -26,7 +26,9 @@ local function moveParentToWait(parentQueueKey, parentKey, parentId, timestamp)
     rcall("XADD", eventsKey, "*", "event", "delayed", "jobId", parentId, "delay", delayedTimestamp)
     addDelayMarkerIfNeeded(markerKey, delayedKey)
   elseif priority > 0 then
-    addJobWithPriority(markerKey, prioritizedKey, priority, parentId, pcKey, isPausedOrMaxed)
+    local score = getPriorityScore(priority, pcKey)
+    rcall("ZADD", prioritizedKey, score, parentId)
+    addBaseMarkerIfNeeded(markerKey, isPausedOrMaxed)
   else
     addJobInTargetList(target, markerKey, "RPUSH", isPausedOrMaxed, parentId)
   end

--- a/lua/includes/moveParentToWait.lua
+++ b/lua/includes/moveParentToWait.lua
@@ -1,0 +1,27 @@
+--[[
+  Release a parent from waiting-children into the correct target queue.
+]]
+local function moveParentToWait(parentQueueKey, parentKey, parentId, timestamp)
+  local waitKey = parentQueueKey .. ":wait"
+  local activeKey = parentQueueKey .. ":active"
+  local pausedKey = parentQueueKey .. ":paused"
+  local prioritizedKey = parentQueueKey .. ":prioritized"
+  local waitingChildrenKey = parentQueueKey .. ":waiting-children"
+  local eventsKey = parentQueueKey .. ":events"
+  local metaKey = parentQueueKey .. ":meta"
+  local markerKey = parentQueueKey .. ":marker"
+  local pcKey = parentQueueKey .. ":pc"
+
+  local target, isPausedOrMaxed = getTargetQueueList(metaKey, activeKey, waitKey, pausedKey)
+  local priority = tonumber(rcall("HGET", parentKey, "priority")) or 0
+
+  rcall("ZREM", waitingChildrenKey, parentId)
+
+  if priority > 0 then
+    addJobWithPriority(markerKey, prioritizedKey, priority, parentId, pcKey, isPausedOrMaxed)
+  else
+    addJobInTargetList(target, markerKey, "LPUSH", isPausedOrMaxed, parentId)
+  end
+
+  rcall("XADD", eventsKey, "*", "event", "waiting", "jobId", parentId, "prev", "waiting-children")
+end

--- a/lua/includes/moveParentToWait.lua
+++ b/lua/includes/moveParentToWait.lua
@@ -6,6 +6,7 @@ local function moveParentToWait(parentQueueKey, parentKey, parentId, timestamp)
   local activeKey = parentQueueKey .. ":active"
   local pausedKey = parentQueueKey .. ":paused"
   local prioritizedKey = parentQueueKey .. ":prioritized"
+  local delayedKey = parentQueueKey .. ":delayed"
   local waitingChildrenKey = parentQueueKey .. ":waiting-children"
   local eventsKey = parentQueueKey .. ":events"
   local metaKey = parentQueueKey .. ":meta"
@@ -13,15 +14,24 @@ local function moveParentToWait(parentQueueKey, parentKey, parentId, timestamp)
   local pcKey = parentQueueKey .. ":pc"
 
   local target, isPausedOrMaxed = getTargetQueueList(metaKey, activeKey, waitKey, pausedKey)
-  local priority = tonumber(rcall("HGET", parentKey, "priority")) or 0
+  local jobAttributes = rcall("HMGET", parentKey, "priority", "delay")
+  local priority = tonumber(jobAttributes[1]) or 0
+  local delay = tonumber(jobAttributes[2]) or 0
 
   rcall("ZREM", waitingChildrenKey, parentId)
 
-  if priority > 0 then
+  if delay > 0 then
+    local score, delayedTimestamp = getDelayedScore(delayedKey, timestamp, delay)
+    rcall("ZADD", delayedKey, score, parentId)
+    rcall("XADD", eventsKey, "*", "event", "delayed", "jobId", parentId, "delay", delayedTimestamp)
+    addDelayMarkerIfNeeded(markerKey, delayedKey)
+  elseif priority > 0 then
     addJobWithPriority(markerKey, prioritizedKey, priority, parentId, pcKey, isPausedOrMaxed)
   else
-    addJobInTargetList(target, markerKey, "LPUSH", isPausedOrMaxed, parentId)
+    addJobInTargetList(target, markerKey, "RPUSH", isPausedOrMaxed, parentId)
   end
 
-  rcall("XADD", eventsKey, "*", "event", "waiting", "jobId", parentId, "prev", "waiting-children")
+  if delay == 0 then
+    rcall("XADD", eventsKey, "*", "event", "waiting", "jobId", parentId, "prev", "waiting-children")
+  end
 end

--- a/lua/includes/moveParentToWaitIfNeeded.lua
+++ b/lua/includes/moveParentToWaitIfNeeded.lua
@@ -1,0 +1,9 @@
+--[[
+  Move the parent only if it still exists and is still blocked in waiting-children.
+]]
+local function moveParentToWaitIfNeeded(parentQueueKey, parentKey, parentId, timestamp)
+  if rcall("EXISTS", parentKey) == 1 and
+    rcall("ZSCORE", parentQueueKey .. ":waiting-children", parentId) then
+    moveParentToWait(parentQueueKey, parentKey, parentId, timestamp)
+  end
+end

--- a/lua/includes/moveParentToWaitIfNoPendingDependencies.lua
+++ b/lua/includes/moveParentToWaitIfNoPendingDependencies.lua
@@ -1,0 +1,9 @@
+--[[
+  Release the parent only after the dependency set becomes empty.
+]]
+local function moveParentToWaitIfNoPendingDependencies(parentQueueKey, parentDependenciesKey,
+  parentKey, parentId, timestamp)
+  if redis.call("SCARD", parentDependenciesKey) == 0 then
+    moveParentToWaitIfNeeded(parentQueueKey, parentKey, parentId, timestamp)
+  end
+end

--- a/lua/includes/promoteDelayedJobs.lua
+++ b/lua/includes/promoteDelayedJobs.lua
@@ -1,0 +1,3 @@
+-- Placeholder: promoteDelayedJobs
+-- Will be ported from BullMQ Node.js
+return 0

--- a/lua/includes/promoteDelayedJobs.lua
+++ b/lua/includes/promoteDelayedJobs.lua
@@ -1,3 +1,45 @@
--- Placeholder: promoteDelayedJobs
--- Will be ported from BullMQ Node.js
-return 0
+--[[
+  Promote delayed jobs that are ready to be processed.
+
+  Moves delayed jobs whose score <= now from the delayed sorted set
+  into the wait list (or prioritized set for priority jobs).
+
+  Events emitted: 'waiting'
+
+  Ported from BullMQ.
+  Depends on addBaseMarkerIfNeeded and getPriorityScore being inlined
+  before this include.
+]]
+
+-- Try to get as much as 1000 jobs at once
+local function promoteDelayedJobs(delayedKey, markerKey, targetKey, prioritizedKey,
+                                  eventStreamKey, prefix, timestamp, priorityCounterKey,
+                                  isPaused)
+  local jobs = rcall("ZRANGEBYSCORE", delayedKey, 0,
+    (timestamp + 1) * 0x1000 - 1, "LIMIT", 0, 1000)
+
+  if (#jobs > 0) then
+    rcall("ZREM", delayedKey, unpack(jobs))
+
+    for _, jobId in ipairs(jobs) do
+      local jobKey = prefix .. jobId
+      local priority =
+        tonumber(rcall("HGET", jobKey, "priority")) or 0
+
+      if priority == 0 then
+        -- LIFO or FIFO
+        rcall("LPUSH", targetKey, jobId)
+      else
+        local score = getPriorityScore(priority, priorityCounterKey)
+        rcall("ZADD", prioritizedKey, score, jobId)
+      end
+
+      -- Emit waiting event
+      rcall("XADD", eventStreamKey, "*", "event", "waiting", "jobId",
+            jobId, "prev", "delayed")
+      rcall("HSET", jobKey, "delay", 0)
+    end
+
+    addBaseMarkerIfNeeded(markerKey, isPaused)
+  end
+end

--- a/lua/includes/removeLock.lua
+++ b/lua/includes/removeLock.lua
@@ -1,0 +1,3 @@
+-- Placeholder: removeLock
+-- Will be ported from BullMQ Node.js
+return 0

--- a/lua/includes/removeLock.lua
+++ b/lua/includes/removeLock.lua
@@ -1,3 +1,29 @@
--- Placeholder: removeLock
--- Will be ported from BullMQ Node.js
-return 0
+--[[
+  Remove a job's lock after verifying the token.
+
+  Returns:
+    0   - success (lock removed or token was "0" meaning no lock needed)
+    -6  - lock exists but token does not match
+    -2  - lock is missing completely
+
+  Ported from BullMQ.
+]]
+local function removeLock(jobKey, stalledKey, token, jobId)
+  if token ~= "0" then
+    local lockKey = jobKey .. ':lock'
+    local lockToken = rcall("GET", lockKey)
+    if lockToken == token then
+      rcall("DEL", lockKey)
+      rcall("SREM", stalledKey, jobId)
+    else
+      if lockToken then
+        -- Lock exists but token does not match
+        return -6
+      else
+        -- Lock is missing completely
+        return -2
+      end
+    end
+  end
+  return 0
+end

--- a/lua/includes/storeJob.lua
+++ b/lua/includes/storeJob.lua
@@ -9,7 +9,8 @@ local function storeJob(eventsKey, jobIdKey, jobId, name, data, opts, timestamp)
   local priority = opts['priority'] or 0
 
   rcall("HMSET", jobIdKey, "name", name, "data", data, "opts", jsonOpts,
-        "timestamp", timestamp, "delay", delay, "priority", priority)
+        "timestamp", timestamp, "delay", delay, "priority", priority,
+        "atm", 0, "ats", 0)
 
   rcall("XADD", eventsKey, "*", "event", "added", "jobId", jobId, "name", name)
 

--- a/lua/includes/storeJob.lua
+++ b/lua/includes/storeJob.lua
@@ -3,7 +3,7 @@
 
   Ported from BullMQ (stripped: parent/dependency, dedup, debounce, repeat).
 ]]
-local function storeJob(eventsKey, jobIdKey, jobId, name, data, opts, timestamp)
+local function storeJob(eventsKey, jobIdKey, jobId, name, data, opts, timestamp, parentKey, parentData)
   local jsonOpts = cjson.encode(opts)
   local delay = opts['delay'] or 0
   local priority = opts['priority'] or 0
@@ -11,6 +11,14 @@ local function storeJob(eventsKey, jobIdKey, jobId, name, data, opts, timestamp)
   rcall("HMSET", jobIdKey, "name", name, "data", data, "opts", jsonOpts,
         "timestamp", timestamp, "delay", delay, "priority", priority,
         "atm", 0, "ats", 0)
+
+  if parentKey ~= nil and parentKey ~= "" then
+    rcall("HSET", jobIdKey, "parentKey", parentKey)
+  end
+
+  if parentData ~= nil and parentData ~= "" then
+    rcall("HSET", jobIdKey, "parent", parentData)
+  end
 
   rcall("XADD", eventsKey, "*", "event", "added", "jobId", jobId, "name", name)
 

--- a/lua/includes/storeJob.lua
+++ b/lua/includes/storeJob.lua
@@ -1,0 +1,3 @@
+-- Placeholder: storeJob
+-- Will be ported from BullMQ Node.js
+return 0

--- a/lua/includes/storeJob.lua
+++ b/lua/includes/storeJob.lua
@@ -1,3 +1,17 @@
--- Placeholder: storeJob
--- Will be ported from BullMQ Node.js
-return 0
+--[[
+  Function to store a job's hash fields in Redis.
+
+  Ported from BullMQ (stripped: parent/dependency, dedup, debounce, repeat).
+]]
+local function storeJob(eventsKey, jobIdKey, jobId, name, data, opts, timestamp)
+  local jsonOpts = cjson.encode(opts)
+  local delay = opts['delay'] or 0
+  local priority = opts['priority'] or 0
+
+  rcall("HMSET", jobIdKey, "name", name, "data", data, "opts", jsonOpts,
+        "timestamp", timestamp, "delay", delay, "priority", priority)
+
+  rcall("XADD", eventsKey, "*", "event", "added", "jobId", jobId, "name", name)
+
+  return delay, priority
+end

--- a/lua/includes/updateParentDepsIfNeeded.lua
+++ b/lua/includes/updateParentDepsIfNeeded.lua
@@ -1,0 +1,15 @@
+--[[
+  Record the completed child return value and release the parent if it has
+  no pending dependencies left.
+]]
+local function updateParentDepsIfNeeded(parentKey, parentQueueKey, parentDependenciesKey,
+  parentId, jobIdKey, returnvalue, timestamp)
+  redis.call("HSET", parentKey .. ":processed", jobIdKey, returnvalue)
+  moveParentToWaitIfNoPendingDependencies(
+    parentQueueKey,
+    parentDependenciesKey,
+    parentKey,
+    parentId,
+    timestamp
+  )
+end

--- a/lua/moveStalledJobsToWait-8.lua
+++ b/lua/moveStalledJobsToWait-8.lua
@@ -1,0 +1,3 @@
+-- Placeholder: moveStalledJobsToWait-8
+-- Will be ported from BullMQ Node.js
+return 0

--- a/lua/moveStalledJobsToWait-8.lua
+++ b/lua/moveStalledJobsToWait-8.lua
@@ -1,3 +1,126 @@
--- Placeholder: moveStalledJobsToWait-8
--- Will be ported from BullMQ Node.js
-return 0
+--[[
+  Move stalled jobs back to wait (or mark them as failed).
+
+  KEYS[1] = wait list
+  KEYS[2] = active list
+  KEYS[3] = prioritized sorted set
+  KEYS[4] = stalled set
+  KEYS[5] = stalled-check key
+  KEYS[6] = meta hash
+  KEYS[7] = paused list
+  KEYS[8] = events stream
+
+  ARGV[1] = maxStalledCount (max times a job can stall before failing)
+  ARGV[2] = stalledInterval (ms, used as PX for the stalled-check lock)
+  ARGV[3] = timestamp
+  ARGV[4] = maxEvents
+  ARGV[5] = jobKeyPrefix (e.g. "bull:queueName:")
+  ARGV[6] = markerKey (e.g. "bull:queueName:marker")
+  ARGV[7] = priorityCounterKey (e.g. "bull:queueName:pc")
+
+  Returns: {stalledCount, failedCount}
+
+  Ported from BullMQ (stripped: parent/flow logic, groups).
+]]
+local rcall = redis.call
+
+--@include "addBaseMarkerIfNeeded"
+--@include "getPriorityScore"
+
+local waitKey = KEYS[1]
+local activeKey = KEYS[2]
+local prioritizedKey = KEYS[3]
+local stalledKey = KEYS[4]
+local stalledCheckKey = KEYS[5]
+local metaKey = KEYS[6]
+local pausedKey = KEYS[7]
+local eventsKey = KEYS[8]
+
+local maxStalledCount = tonumber(ARGV[1]) or 1
+local stalledInterval = tonumber(ARGV[2])
+local timestamp = ARGV[3]
+local maxEvents = tonumber(ARGV[4]) or 10000
+local jobKeyPrefix = ARGV[5]
+local markerKey = ARGV[6]
+local pcKey = ARGV[7]
+
+-- 1. Try to acquire the stalled-check lock (only one worker checks at a time)
+local acquired = rcall("SET", stalledCheckKey, timestamp, "NX", "PX", stalledInterval)
+if not acquired then
+  return {0, 0}
+end
+
+-- 2. Scan active jobs and detect stalled ones (no lock = stalled)
+local activeJobs = rcall("LRANGE", activeKey, 0, -1)
+for _, jobId in ipairs(activeJobs) do
+  local lockKey = jobKeyPrefix .. jobId .. ":lock"
+  if rcall("EXISTS", lockKey) == 0 then
+    rcall("SADD", stalledKey, jobId)
+  end
+end
+
+-- 3. Process stalled jobs
+local stalledJobs = rcall("SMEMBERS", stalledKey)
+local stalledCount = 0
+local failedCount = 0
+
+if #stalledJobs > 0 then
+  local isPaused = rcall("HEXISTS", metaKey, "paused") == 1
+
+  for _, jobId in ipairs(stalledJobs) do
+    local jobKey = jobKeyPrefix .. jobId
+
+    if rcall("EXISTS", jobKey) == 1 then
+      local stc = tonumber(rcall("HGET", jobKey, "stc")) or 0
+
+      if stc >= maxStalledCount then
+        -- Too many stalls: move to failed
+        failedCount = failedCount + 1
+
+        rcall("LREM", activeKey, 1, jobId)
+        rcall("SREM", stalledKey, jobId)
+
+        local failedReason = "job stalled more than allowable limit"
+        rcall("HSET", jobKey,
+              "failedReason", failedReason,
+              "finishedOn", timestamp,
+              "stc", stc + 1)
+
+        rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*",
+              "event", "failed", "jobId", jobId,
+              "failedReason", failedReason, "prev", "active")
+      else
+        -- Move back to wait
+        stalledCount = stalledCount + 1
+
+        rcall("LREM", activeKey, 1, jobId)
+        rcall("SREM", stalledKey, jobId)
+        rcall("HINCRBY", jobKey, "stc", 1)
+
+        local priority = tonumber(rcall("HGET", jobKey, "priority")) or 0
+
+        if priority > 0 then
+          local score = getPriorityScore(priority, pcKey)
+          rcall("ZADD", prioritizedKey, score, jobId)
+        else
+          local target = isPaused and pausedKey or waitKey
+          rcall("RPUSH", target, jobId)
+        end
+
+        rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*",
+              "event", "stalled", "jobId", jobId)
+      end
+    else
+      -- Job hash gone, just clean up stalled set
+      rcall("SREM", stalledKey, jobId)
+    end
+  end
+
+  -- Signal workers after processing
+  local isPaused = rcall("HEXISTS", metaKey, "paused") == 1
+  if not isPaused and stalledCount > 0 then
+    addBaseMarkerIfNeeded(markerKey)
+  end
+end
+
+return {stalledCount, failedCount}

--- a/lua/moveToActive-11.lua
+++ b/lua/moveToActive-11.lua
@@ -1,0 +1,3 @@
+-- Placeholder: moveToActive-11
+-- Will be ported from BullMQ Node.js
+return 0

--- a/lua/moveToActive-11.lua
+++ b/lua/moveToActive-11.lua
@@ -88,8 +88,8 @@ rcall("SET", lockKey, token, "PX", lockDuration)
 -- Add to stalled set (will be removed when lock is extended)
 rcall("SADD", stalledKey, jobId)
 
--- Update job state
-rcall("HSET", jobKey, "ats", timestamp)
+-- Increment attempts started counter
+rcall("HINCRBY", jobKey, "ats", 1)
 
 -- Emit active event
 rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*",

--- a/lua/moveToActive-11.lua
+++ b/lua/moveToActive-11.lua
@@ -1,3 +1,107 @@
--- Placeholder: moveToActive-11
--- Will be ported from BullMQ Node.js
-return 0
+--[[
+  Move the next job to the active state.
+
+  KEYS[1]  = wait list
+  KEYS[2]  = active list
+  KEYS[3]  = prioritized sorted set
+  KEYS[4]  = events stream
+  KEYS[5]  = stalled set
+  KEYS[6]  = limiter key (unused in this simplified port)
+  KEYS[7]  = delayed sorted set
+  KEYS[8]  = paused list
+  KEYS[9]  = meta hash
+  KEYS[10] = priority counter key
+  KEYS[11] = marker sorted set
+
+  ARGV[1] = token (worker lock token)
+  ARGV[2] = lockDuration (milliseconds)
+  ARGV[3] = timestamp (current time ms)
+  ARGV[4] = maxEvents
+  ARGV[5] = jobKeyPrefix (e.g. "bull:queueName:")
+
+  Returns:
+    Array with [jobId, jobData...] on success, or nil/0 if no jobs.
+
+  Ported from BullMQ (stripped: rate limiter, groups, parent/flow).
+]]
+local rcall = redis.call
+
+--@include "addBaseMarkerIfNeeded"
+--@include "getPriorityScore"
+--@include "getDelayedScore"
+--@include "addDelayMarkerIfNeeded"
+--@include "promoteDelayedJobs"
+
+local waitKey = KEYS[1]
+local activeKey = KEYS[2]
+local prioritizedKey = KEYS[3]
+local eventsKey = KEYS[4]
+local stalledKey = KEYS[5]
+-- local limiterKey = KEYS[6]
+local delayedKey = KEYS[7]
+local pausedKey = KEYS[8]
+local metaKey = KEYS[9]
+local pcKey = KEYS[10]
+local markerKey = KEYS[11]
+
+local token = ARGV[1]
+local lockDuration = tonumber(ARGV[2])
+local timestamp = tonumber(ARGV[3])
+local maxEvents = tonumber(ARGV[4]) or 10000
+local jobKeyPrefix = ARGV[5]
+
+-- 1. Promote any delayed jobs that are ready
+local isPaused = rcall("HEXISTS", metaKey, "paused") == 1
+promoteDelayedJobs(delayedKey, markerKey, waitKey, prioritizedKey,
+                   eventsKey, jobKeyPrefix, timestamp, pcKey, isPaused)
+
+if isPaused then
+  return nil
+end
+
+-- 2. Try to get a job from the wait list first (RPOPLPUSH = FIFO order)
+local jobId = rcall("RPOPLPUSH", waitKey, activeKey)
+
+-- 3. If no job in wait, try prioritized sorted set
+if not jobId then
+  local result = rcall("ZPOPMIN", prioritizedKey)
+  if #result > 0 then
+    jobId = result[1]
+    rcall("LPUSH", activeKey, jobId)
+  end
+end
+
+-- 4. If still no job, check if we should emit drained
+if not jobId then
+  -- Check if there are delayed jobs; if so, add delay marker
+  addDelayMarkerIfNeeded(markerKey, delayedKey)
+  return nil
+end
+
+-- 5. We have a job — acquire lock and set active state
+local jobKey = jobKeyPrefix .. jobId
+local lockKey = jobKey .. ":lock"
+
+-- Set lock with token and expiry
+rcall("SET", lockKey, token, "PX", lockDuration)
+
+-- Add to stalled set (will be removed when lock is extended)
+rcall("SADD", stalledKey, jobId)
+
+-- Update job state
+rcall("HSET", jobKey, "ats", timestamp)
+
+-- Emit active event
+rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*",
+      "event", "active", "jobId", jobId, "prev", "waiting")
+
+-- Remove marker since we consumed a job
+rcall("ZREM", markerKey, "0")
+
+-- Return job ID and all hash fields
+local jobData = rcall("HGETALL", jobKey)
+local result = {jobId}
+for i, v in ipairs(jobData) do
+  result[#result + 1] = v
+end
+return result

--- a/lua/moveToActive-11.lua
+++ b/lua/moveToActive-11.lua
@@ -98,6 +98,13 @@ rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*",
 -- Remove marker since we consumed a job
 rcall("ZREM", markerKey, "0")
 
+-- Re-add marker if there are still jobs waiting
+local waitLen = rcall("LLEN", waitKey)
+local priLen = rcall("ZCARD", prioritizedKey)
+if waitLen > 0 or priLen > 0 then
+  addBaseMarkerIfNeeded(markerKey, false)
+end
+
 -- Return job ID and all hash fields
 local jobData = rcall("HGETALL", jobKey)
 local result = {jobId}

--- a/lua/moveToDelayed-8.lua
+++ b/lua/moveToDelayed-8.lua
@@ -1,0 +1,3 @@
+-- Placeholder: moveToDelayed-8
+-- Will be ported from BullMQ Node.js
+return 0

--- a/lua/moveToDelayed-8.lua
+++ b/lua/moveToDelayed-8.lua
@@ -15,6 +15,7 @@
   ARGV[3] = jobId
   ARGV[4] = delayedTimestamp (target time ms)
   ARGV[5] = maxEvents
+  ARGV[6] = attemptsMade
 
   Returns:
     0  on success
@@ -44,6 +45,7 @@ local timestamp = ARGV[2]
 local jobId = ARGV[3]
 local delayedTimestamp = tonumber(ARGV[4])
 local maxEvents = tonumber(ARGV[5]) or 10000
+local attemptsMade = ARGV[6] or "0"
 
 -- 1. Check job exists
 if rcall("EXISTS", jobKey) ~= 1 then
@@ -60,12 +62,11 @@ end
 rcall("LREM", activeKey, 1, jobId)
 
 -- 4. Compute delayed score and add to delayed set
-local delay = tonumber(rcall("HGET", jobKey, "delay")) or 0
-local score = getDelayedScore(delayedKey, timestamp, delay)
+local score = getDelayedScore(delayedKey, delayedTimestamp, 0)
 rcall("ZADD", delayedKey, score, jobId)
 
 -- 5. Update job hash
-rcall("HSET", jobKey, "delay", delayedTimestamp - tonumber(timestamp))
+rcall("HSET", jobKey, "delay", delayedTimestamp - tonumber(timestamp), "atm", attemptsMade)
 
 -- 6. Emit delayed event
 rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*",

--- a/lua/moveToDelayed-8.lua
+++ b/lua/moveToDelayed-8.lua
@@ -1,3 +1,77 @@
--- Placeholder: moveToDelayed-8
--- Will be ported from BullMQ Node.js
+--[[
+  Move an active job to the delayed state.
+
+  KEYS[1] = active list
+  KEYS[2] = delayed sorted set
+  KEYS[3] = events stream
+  KEYS[4] = job hash key
+  KEYS[5] = job lock key (jobKey:lock)
+  KEYS[6] = meta hash
+  KEYS[7] = marker sorted set
+  KEYS[8] = stalled set
+
+  ARGV[1] = token
+  ARGV[2] = timestamp (current time ms)
+  ARGV[3] = jobId
+  ARGV[4] = delayedTimestamp (target time ms)
+  ARGV[5] = maxEvents
+
+  Returns:
+    0  on success
+    -1 if job not found
+    -2 if lock missing
+    -6 if token mismatch
+
+  Ported from BullMQ (stripped: parent/flow logic).
+]]
+local rcall = redis.call
+
+--@include "removeLock"
+--@include "getDelayedScore"
+--@include "addDelayMarkerIfNeeded"
+
+local activeKey = KEYS[1]
+local delayedKey = KEYS[2]
+local eventsKey = KEYS[3]
+local jobKey = KEYS[4]
+local lockKey = KEYS[5]
+local metaKey = KEYS[6]
+local markerKey = KEYS[7]
+local stalledKey = KEYS[8]
+
+local token = ARGV[1]
+local timestamp = ARGV[2]
+local jobId = ARGV[3]
+local delayedTimestamp = tonumber(ARGV[4])
+local maxEvents = tonumber(ARGV[5]) or 10000
+
+-- 1. Check job exists
+if rcall("EXISTS", jobKey) ~= 1 then
+  return -1
+end
+
+-- 2. Verify and remove lock
+local lockResult = removeLock(jobKey, stalledKey, token, jobId)
+if lockResult < 0 then
+  return lockResult
+end
+
+-- 3. Remove from active
+rcall("LREM", activeKey, 1, jobId)
+
+-- 4. Compute delayed score and add to delayed set
+local delay = tonumber(rcall("HGET", jobKey, "delay")) or 0
+local score = getDelayedScore(delayedKey, timestamp, delay)
+rcall("ZADD", delayedKey, score, jobId)
+
+-- 5. Update job hash
+rcall("HSET", jobKey, "delay", delayedTimestamp - tonumber(timestamp))
+
+-- 6. Emit delayed event
+rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*",
+      "event", "delayed", "jobId", jobId, "delay", delayedTimestamp)
+
+-- 7. Signal workers about delayed job
+addDelayMarkerIfNeeded(markerKey, delayedKey)
+
 return 0

--- a/lua/moveToFinished-14.lua
+++ b/lua/moveToFinished-14.lua
@@ -141,7 +141,7 @@ if fetchNext == 1 then
 
   rcall("SET", nextLockKey, token, "PX", lockDuration)
   rcall("SADD", stalledKey, nextJobId)
-  rcall("HSET", nextJobKey, "ats", timestamp)
+  rcall("HINCRBY", nextJobKey, "ats", 1)
 
   rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*",
         "event", "active", "jobId", nextJobId, "prev", "waiting")

--- a/lua/moveToFinished-14.lua
+++ b/lua/moveToFinished-14.lua
@@ -1,0 +1,3 @@
+-- Placeholder: moveToFinished-14
+-- Will be ported from BullMQ Node.js
+return 0

--- a/lua/moveToFinished-14.lua
+++ b/lua/moveToFinished-14.lua
@@ -148,6 +148,13 @@ if fetchNext == 1 then
 
   rcall("ZREM", markerKey, "0")
 
+  -- Re-add marker if there are still jobs waiting
+  local waitLen = rcall("LLEN", waitKey)
+  local priLen = rcall("ZCARD", prioritizedKey)
+  if waitLen > 0 or priLen > 0 then
+    addBaseMarkerIfNeeded(markerKey, false)
+  end
+
   local nextJobData = rcall("HGETALL", nextJobKey)
   local result = {nextJobId}
   for i, v in ipairs(nextJobData) do

--- a/lua/moveToFinished-14.lua
+++ b/lua/moveToFinished-14.lua
@@ -1,3 +1,159 @@
--- Placeholder: moveToFinished-14
--- Will be ported from BullMQ Node.js
+--[[
+  Move a job to the completed or failed state and optionally fetch the next job.
+
+  KEYS[1]  = wait list
+  KEYS[2]  = active list
+  KEYS[3]  = prioritized sorted set
+  KEYS[4]  = events stream
+  KEYS[5]  = stalled set
+  KEYS[6]  = limiter key (unused)
+  KEYS[7]  = delayed sorted set
+  KEYS[8]  = paused list
+  KEYS[9]  = finished set (completed or failed sorted set)
+  KEYS[10] = meta hash
+  KEYS[11] = priority counter key
+  KEYS[12] = marker sorted set
+  KEYS[13] = job hash key
+  KEYS[14] = job lock key (jobKey:lock)
+
+  ARGV[1]  = token
+  ARGV[2]  = timestamp
+  ARGV[3]  = returnvalue or failedReason (JSON string)
+  ARGV[4]  = target state name ("completed" or "failed")
+  ARGV[5]  = maxEvents
+  ARGV[6]  = fetchNext (0 or 1)
+  ARGV[7]  = lockDuration
+  ARGV[8]  = jobId
+  ARGV[9]  = attempts made
+  ARGV[10] = jobKeyPrefix (e.g. "bull:queueName:")
+
+  Returns:
+    On error: negative integer (-1 = missing job, -2 = missing lock, -6 = token mismatch)
+    On success without fetchNext: 0
+    On success with fetchNext: array [nextJobId, nextJobData...] or 0
+
+  Ported from BullMQ (stripped: parent/flow, rate limiter, groups, metrics).
+]]
+local rcall = redis.call
+
+--@include "removeLock"
+--@include "addBaseMarkerIfNeeded"
+--@include "getPriorityScore"
+--@include "getDelayedScore"
+--@include "addDelayMarkerIfNeeded"
+--@include "promoteDelayedJobs"
+
+local waitKey = KEYS[1]
+local activeKey = KEYS[2]
+local prioritizedKey = KEYS[3]
+local eventsKey = KEYS[4]
+local stalledKey = KEYS[5]
+-- local limiterKey = KEYS[6]
+local delayedKey = KEYS[7]
+local pausedKey = KEYS[8]
+local finishedKey = KEYS[9]
+local metaKey = KEYS[10]
+local pcKey = KEYS[11]
+local markerKey = KEYS[12]
+local jobKey = KEYS[13]
+local lockKey = KEYS[14]
+
+local token = ARGV[1]
+local timestamp = tonumber(ARGV[2])
+local returnvalue = ARGV[3]
+local targetState = ARGV[4]
+local maxEvents = tonumber(ARGV[5]) or 10000
+local fetchNext = tonumber(ARGV[6]) or 0
+local lockDuration = tonumber(ARGV[7])
+local jobId = ARGV[8]
+local attemptsMade = ARGV[9]
+local jobKeyPrefix = ARGV[10]
+
+-- 1. Check the job still exists
+if rcall("EXISTS", jobKey) ~= 1 then
+  return -1
+end
+
+-- 2. Verify and remove the lock
+local lockResult = removeLock(jobKey, stalledKey, token, jobId)
+if lockResult < 0 then
+  return lockResult
+end
+
+-- 3. Remove from active list
+rcall("LREM", activeKey, 1, jobId)
+
+-- 4. Add to finished set (scored by timestamp)
+rcall("ZADD", finishedKey, timestamp, jobId)
+
+-- 5. Update job hash
+if targetState == "completed" then
+  rcall("HSET", jobKey,
+        "finishedOn", timestamp,
+        "returnvalue", returnvalue,
+        "atm", attemptsMade)
+else
+  -- failed
+  rcall("HSET", jobKey,
+        "finishedOn", timestamp,
+        "failedReason", returnvalue,
+        "atm", attemptsMade)
+end
+
+-- 6. Emit finished event
+rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*",
+      "event", targetState, "jobId", jobId,
+      targetState == "completed" and "returnvalue" or "failedReason", returnvalue,
+      "prev", "active")
+
+-- 7. If fetchNext requested, try to get the next job (same logic as moveToActive)
+if fetchNext == 1 then
+  local isPaused = rcall("HEXISTS", metaKey, "paused") == 1
+
+  -- Promote delayed jobs
+  promoteDelayedJobs(delayedKey, markerKey, waitKey, prioritizedKey,
+                     eventsKey, jobKeyPrefix, timestamp, pcKey, isPaused)
+
+  if isPaused then
+    return 0
+  end
+
+  -- Try wait list
+  local nextJobId = rcall("RPOPLPUSH", waitKey, activeKey)
+
+  -- Try prioritized
+  if not nextJobId then
+    local result = rcall("ZPOPMIN", prioritizedKey)
+    if #result > 0 then
+      nextJobId = result[1]
+      rcall("LPUSH", activeKey, nextJobId)
+    end
+  end
+
+  if not nextJobId then
+    addDelayMarkerIfNeeded(markerKey, delayedKey)
+    return 0
+  end
+
+  -- Acquire lock on next job
+  local nextJobKey = jobKeyPrefix .. nextJobId
+  local nextLockKey = nextJobKey .. ":lock"
+
+  rcall("SET", nextLockKey, token, "PX", lockDuration)
+  rcall("SADD", stalledKey, nextJobId)
+  rcall("HSET", nextJobKey, "ats", timestamp)
+
+  rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*",
+        "event", "active", "jobId", nextJobId, "prev", "waiting")
+
+  rcall("ZREM", markerKey, "0")
+
+  local nextJobData = rcall("HGETALL", nextJobKey)
+  local result = {nextJobId}
+  for i, v in ipairs(nextJobData) do
+    result[#result + 1] = v
+  end
+  return result
+end
+
 return 0

--- a/lua/moveToFinished-14.lua
+++ b/lua/moveToFinished-14.lua
@@ -42,12 +42,12 @@ local rcall = redis.call
 --@include "addJobWithPriority"
 --@include "getTargetQueueList"
 --@include "getPriorityScore"
+--@include "getDelayedScore"
+--@include "addDelayMarkerIfNeeded"
 --@include "moveParentToWait"
 --@include "moveParentToWaitIfNeeded"
 --@include "moveParentToWaitIfNoPendingDependencies"
 --@include "updateParentDepsIfNeeded"
---@include "getDelayedScore"
---@include "addDelayMarkerIfNeeded"
 --@include "promoteDelayedJobs"
 
 local waitKey = KEYS[1]
@@ -119,16 +119,17 @@ if targetState == "completed" then
 
     if parentId and parentQueueKey then
       local parentDependenciesKey = parentKey .. ":dependencies"
-      rcall("SREM", parentDependenciesKey, jobKey)
-      updateParentDepsIfNeeded(
-        parentKey,
-        parentQueueKey,
-        parentDependenciesKey,
-        parentId,
-        jobKey,
-        returnvalue,
-        timestamp
-      )
+      if rcall("SREM", parentDependenciesKey, jobKey) == 1 then
+        updateParentDepsIfNeeded(
+          parentKey,
+          parentQueueKey,
+          parentDependenciesKey,
+          parentId,
+          jobKey,
+          returnvalue,
+          timestamp
+        )
+      end
     end
   end
 end

--- a/lua/moveToFinished-14.lua
+++ b/lua/moveToFinished-14.lua
@@ -32,13 +32,20 @@
     On success without fetchNext: 0
     On success with fetchNext: array [nextJobId, nextJobData...] or 0
 
-  Ported from BullMQ (stripped: parent/flow, rate limiter, groups, metrics).
+  Ported from BullMQ (stripped: rate limiter, groups, metrics).
 ]]
 local rcall = redis.call
 
 --@include "removeLock"
 --@include "addBaseMarkerIfNeeded"
+--@include "addJobInTargetList"
+--@include "addJobWithPriority"
+--@include "getTargetQueueList"
 --@include "getPriorityScore"
+--@include "moveParentToWait"
+--@include "moveParentToWaitIfNeeded"
+--@include "moveParentToWaitIfNoPendingDependencies"
+--@include "updateParentDepsIfNeeded"
 --@include "getDelayedScore"
 --@include "addDelayMarkerIfNeeded"
 --@include "promoteDelayedJobs"
@@ -98,6 +105,32 @@ else
         "finishedOn", timestamp,
         "failedReason", returnvalue,
         "atm", attemptsMade)
+end
+
+-- 6. Update parent dependencies for completed child jobs before fetching the next job
+if targetState == "completed" then
+  local parentKey = rcall("HGET", jobKey, "parentKey")
+  local parentData = rcall("HGET", jobKey, "parent")
+
+  if parentKey and parentData then
+    local parent = cjson.decode(parentData)
+    local parentId = parent["id"]
+    local parentQueueKey = parent["queue"]
+
+    if parentId and parentQueueKey then
+      local parentDependenciesKey = parentKey .. ":dependencies"
+      rcall("SREM", parentDependenciesKey, jobKey)
+      updateParentDepsIfNeeded(
+        parentKey,
+        parentQueueKey,
+        parentDependenciesKey,
+        parentId,
+        jobKey,
+        returnvalue,
+        timestamp
+      )
+    end
+  end
 end
 
 -- 6. Emit finished event

--- a/lua/pause-7.lua
+++ b/lua/pause-7.lua
@@ -1,0 +1,3 @@
+-- Placeholder: pause-7
+-- Will be ported from BullMQ Node.js
+return 0

--- a/lua/pause-7.lua
+++ b/lua/pause-7.lua
@@ -1,3 +1,68 @@
--- Placeholder: pause-7
--- Will be ported from BullMQ Node.js
-return 0
+--[[
+  Pause or resume a queue.
+
+  KEYS[1] = wait list
+  KEYS[2] = paused list
+  KEYS[3] = meta hash
+  KEYS[4] = events stream
+  KEYS[5] = delayed sorted set
+  KEYS[6] = prioritized sorted set
+  KEYS[7] = marker sorted set
+
+  ARGV[1] = action ("pause" or "resume")
+  ARGV[2] = maxEvents
+
+  Returns: nil
+
+  Ported from BullMQ.
+]]
+local rcall = redis.call
+
+--@include "addBaseMarkerIfNeeded"
+
+local waitKey = KEYS[1]
+local pausedKey = KEYS[2]
+local metaKey = KEYS[3]
+local eventsKey = KEYS[4]
+-- local delayedKey = KEYS[5]
+-- local prioritizedKey = KEYS[6]
+local markerKey = KEYS[7]
+
+local action = ARGV[1]
+local maxEvents = tonumber(ARGV[2]) or 10000
+
+if action == "pause" then
+  -- Set paused flag
+  rcall("HSET", metaKey, "paused", 1)
+
+  -- Move all jobs from wait to paused
+  while true do
+    local jobId = rcall("RPOPLPUSH", waitKey, pausedKey)
+    if not jobId then
+      break
+    end
+  end
+
+  -- Emit paused event
+  rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*",
+        "event", "paused")
+else
+  -- Resume
+  -- Remove paused flag
+  rcall("HDEL", metaKey, "paused")
+
+  -- Move all jobs from paused to wait
+  while true do
+    local jobId = rcall("RPOPLPUSH", pausedKey, waitKey)
+    if not jobId then
+      break
+    end
+  end
+
+  -- Emit resumed event
+  rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*",
+        "event", "resumed")
+
+  -- Signal workers
+  addBaseMarkerIfNeeded(markerKey)
+end

--- a/lua/promote-9.lua
+++ b/lua/promote-9.lua
@@ -1,0 +1,71 @@
+--[[
+  Promote a delayed job: move it from delayed to wait/prioritized.
+
+  Input:
+    KEYS[1] delayed
+    KEYS[2] wait
+    KEYS[3] paused
+    KEYS[4] meta
+    KEYS[5] prioritized
+    KEYS[6] active
+    KEYS[7] pc (priority counter)
+    KEYS[8] events
+    KEYS[9] marker
+
+    ARGV[1] jobId
+    ARGV[2] jobKey
+    ARGV[3] timestamp
+    ARGV[4] maxEvents
+
+  Output:
+    0  - OK
+    -1 - Job not in delayed set
+
+  Ported from BullMQ (stripped: flows, groups).
+]]
+local rcall = redis.call
+
+--@include "addBaseMarkerIfNeeded"
+--@include "getPriorityScore"
+--@include "moveJobToWait"
+
+local delayedKey = KEYS[1]
+local waitKey = KEYS[2]
+local pausedKey = KEYS[3]
+local metaKey = KEYS[4]
+local prioritizedKey = KEYS[5]
+local activeKey = KEYS[6]
+local pcKey = KEYS[7]
+local eventsKey = KEYS[8]
+local markerKey = KEYS[9]
+
+local jobId = ARGV[1]
+local jobKey = ARGV[2]
+local timestamp = ARGV[3]
+local maxEvents = tonumber(ARGV[4])
+
+-- Remove from delayed set
+if rcall("ZREM", delayedKey, jobId) == 0 then
+  return -1
+end
+
+-- Reset the delay field
+rcall("HSET", jobKey, "delay", 0)
+
+-- Read priority to determine target
+local priority = tonumber(rcall("HGET", jobKey, "priority")) or 0
+
+if priority > 0 then
+  local score = getPriorityScore(priority, pcKey)
+  rcall("ZADD", prioritizedKey, score, jobId)
+  addBaseMarkerIfNeeded(markerKey, false)
+else
+  local target, isPausedOrMaxed = getTargetQueueList(metaKey, activeKey, waitKey, pausedKey)
+  addJobInTargetList(target, markerKey, "RPUSH", isPausedOrMaxed, jobId)
+end
+
+-- Emit waiting event
+rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*",
+  "event", "waiting", "jobId", jobId, "prev", "delayed")
+
+return 0

--- a/lua/retryJob-11.lua
+++ b/lua/retryJob-11.lua
@@ -1,0 +1,3 @@
+-- Placeholder: retryJob-11
+-- Will be ported from BullMQ Node.js
+return 0

--- a/lua/retryJob-11.lua
+++ b/lua/retryJob-11.lua
@@ -88,8 +88,6 @@ rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*",
       "event", "waiting", "jobId", jobId, "prev", "failed")
 
 -- 8. Signal workers
-if not isPaused then
-  addBaseMarkerIfNeeded(markerKey)
-end
+addBaseMarkerIfNeeded(markerKey, isPaused)
 
 return 0

--- a/lua/retryJob-11.lua
+++ b/lua/retryJob-11.lua
@@ -1,3 +1,95 @@
--- Placeholder: retryJob-11
--- Will be ported from BullMQ Node.js
+--[[
+  Retry a failed/active job by moving it back to wait or prioritized.
+
+  KEYS[1]  = active list
+  KEYS[2]  = wait list
+  KEYS[3]  = stalled set
+  KEYS[4]  = paused list
+  KEYS[5]  = meta hash
+  KEYS[6]  = events stream
+  KEYS[7]  = delayed sorted set
+  KEYS[8]  = prioritized sorted set
+  KEYS[9]  = priority counter key
+  KEYS[10] = marker sorted set
+  KEYS[11] = job hash key
+
+  ARGV[1] = token
+  ARGV[2] = pushCmd ("LPUSH" or "RPUSH")
+  ARGV[3] = jobId
+  ARGV[4] = maxEvents
+  ARGV[5] = attemptsMade
+  ARGV[6] = priority
+
+  Returns:
+    0  on success
+    -1 if job not found
+    -2 if lock missing
+    -6 if token mismatch
+
+  Ported from BullMQ (stripped: parent/flow logic).
+]]
+local rcall = redis.call
+
+--@include "removeLock"
+--@include "addBaseMarkerIfNeeded"
+--@include "getPriorityScore"
+
+local activeKey = KEYS[1]
+local waitKey = KEYS[2]
+local stalledKey = KEYS[3]
+local pausedKey = KEYS[4]
+local metaKey = KEYS[5]
+local eventsKey = KEYS[6]
+local delayedKey = KEYS[7]
+local prioritizedKey = KEYS[8]
+local pcKey = KEYS[9]
+local markerKey = KEYS[10]
+local jobKey = KEYS[11]
+
+local token = ARGV[1]
+local pushCmd = ARGV[2]
+local jobId = ARGV[3]
+local maxEvents = tonumber(ARGV[4]) or 10000
+local attemptsMade = ARGV[5]
+local priority = tonumber(ARGV[6]) or 0
+
+-- 1. Check job exists
+if rcall("EXISTS", jobKey) ~= 1 then
+  return -1
+end
+
+-- 2. Verify and remove lock
+local lockResult = removeLock(jobKey, stalledKey, token, jobId)
+if lockResult < 0 then
+  return lockResult
+end
+
+-- 3. Remove from active
+rcall("LREM", activeKey, 1, jobId)
+
+-- 4. Update attempts
+rcall("HSET", jobKey, "atm", attemptsMade)
+
+-- 5. Check if paused
+local isPaused = rcall("HEXISTS", metaKey, "paused") == 1
+
+-- 6. Move to wait or prioritized
+if priority > 0 then
+  local score = getPriorityScore(priority, pcKey)
+  rcall("ZADD", prioritizedKey, score, jobId)
+else
+  local target = isPaused and pausedKey or waitKey
+  -- RPUSH puts retried jobs at the end (behind fresh jobs)
+  rcall(pushCmd, target, jobId)
+end
+
+-- 7. Emit waiting event
+rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*",
+      "event", "waiting", "jobId", jobId, "prev", "failed")
+
+-- 8. Signal workers
+if not isPaused then
+  addBaseMarkerIfNeeded(markerKey)
+end
+
 return 0

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -31,9 +31,18 @@ impl RedisConnection {
 
     /// Create a `ConnectionManager` for resilient Redis connections.
     pub(crate) async fn get_manager(&self) -> BullmqResult<ConnectionManager> {
+        self.get_manager_with_response_timeout(None).await
+    }
+
+    /// Create a `ConnectionManager` with an optional per-command response timeout.
+    pub(crate) async fn get_manager_with_response_timeout(
+        &self,
+        response_timeout: Option<Duration>,
+    ) -> BullmqResult<ConnectionManager> {
         let client = redis::Client::open(self.url.as_str())?;
-        let config =
-            ConnectionManagerConfig::new().set_max_delay(Duration::from_millis(5_000));
+        let config = ConnectionManagerConfig::new()
+            .set_max_delay(Duration::from_millis(5_000))
+            .set_response_timeout(response_timeout);
         let manager = ConnectionManager::new_with_config(client, config).await?;
         Ok(manager)
     }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use redis::aio::ConnectionManager;
 use redis::aio::ConnectionManagerConfig;
 
@@ -30,7 +32,8 @@ impl RedisConnection {
     /// Create a `ConnectionManager` for resilient Redis connections.
     pub(crate) async fn get_manager(&self) -> BullmqResult<ConnectionManager> {
         let client = redis::Client::open(self.url.as_str())?;
-        let config = ConnectionManagerConfig::new().set_max_delay(5_000);
+        let config =
+            ConnectionManagerConfig::new().set_max_delay(Duration::from_millis(5_000));
         let manager = ConnectionManager::new_with_config(client, config).await?;
         Ok(manager)
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,8 @@ pub enum BullmqError {
     ScriptError(String),
     /// Generic error.
     Other(String),
+    /// Feature not yet implemented.
+    NotImplemented(String),
 }
 
 impl fmt::Display for BullmqError {
@@ -34,6 +36,7 @@ impl fmt::Display for BullmqError {
             BullmqError::QueuePaused => write!(f, "Queue is paused"),
             BullmqError::ScriptError(msg) => write!(f, "Script error: {}", msg),
             BullmqError::Other(msg) => write!(f, "{}", msg),
+            BullmqError::NotImplemented(msg) => write!(f, "Not implemented: {}", msg),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,12 @@ pub enum BullmqError {
     JobNotFound(String),
     /// Worker has been shut down.
     WorkerClosed,
+    /// Lock token mismatch (job was stalled and recovered by another worker).
+    LockMismatch,
+    /// Queue is paused.
+    QueuePaused,
+    /// Lua script error.
+    ScriptError(String),
     /// Generic error.
     Other(String),
 }
@@ -22,6 +28,11 @@ impl fmt::Display for BullmqError {
             BullmqError::Serialization(e) => write!(f, "Serialization error: {}", e),
             BullmqError::JobNotFound(id) => write!(f, "Job not found: {}", id),
             BullmqError::WorkerClosed => write!(f, "Worker has been shut down"),
+            BullmqError::LockMismatch => {
+                write!(f, "Lock token mismatch: job was stalled and recovered")
+            }
+            BullmqError::QueuePaused => write!(f, "Queue is paused"),
+            BullmqError::ScriptError(msg) => write!(f, "Script error: {}", msg),
             BullmqError::Other(msg) => write!(f, "{}", msg),
         }
     }

--- a/src/flow_producer.rs
+++ b/src/flow_producer.rs
@@ -130,6 +130,7 @@ impl FlowProducer {
                 .await;
             return Err(err);
         }
+        maybe_watch_window_hook(&mut conn, &root_queue).await?;
 
         redis::cmd("MULTI").query_async::<redis::Value>(&mut conn).await?;
         let queue_result = queue_insert(&self.scripts, &mut conn, &prepared).await;
@@ -300,7 +301,10 @@ where
 async fn ensure_job_keys_do_not_exist<T>(
     conn: &mut redis::aio::ConnectionManager,
     node: &PreparedNode<T>,
-) -> BullmqResult<()> {
+) -> BullmqResult<()>
+where
+    T: Sync,
+{
     let exists: bool = redis::cmd("EXISTS")
         .arg(&node.job_key)
         .query_async(conn)
@@ -322,7 +326,10 @@ async fn ensure_job_keys_do_not_exist<T>(
 fn queue_insert_existing_check<'a, T>(
     conn: &'a mut redis::aio::ConnectionManager,
     node: &'a PreparedNode<T>,
-) -> std::pin::Pin<Box<dyn std::future::Future<Output = BullmqResult<()>> + 'a>> {
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = BullmqResult<()>> + Send + 'a>>
+where
+    T: Sync,
+{
     Box::pin(async move { ensure_job_keys_do_not_exist(conn, node).await })
 }
 
@@ -354,11 +361,63 @@ fn validate_exec_result(result: redis::Value) -> BullmqResult<()> {
     }
 }
 
+#[cfg(debug_assertions)]
+async fn maybe_watch_window_hook(
+    conn: &mut redis::aio::ConnectionManager,
+    queue_name: &str,
+) -> BullmqResult<()> {
+    let target_queue = match std::env::var("BULLMQ_RS_FLOW_ADD_WATCH_HOOK_QUEUE") {
+        Ok(value) => value,
+        Err(_) => return Ok(()),
+    };
+    if target_queue != queue_name {
+        return Ok(());
+    }
+
+    let open_key = match std::env::var("BULLMQ_RS_FLOW_ADD_WATCH_HOOK_OPEN_KEY") {
+        Ok(value) => value,
+        Err(_) => return Ok(()),
+    };
+    let release_key = std::env::var("BULLMQ_RS_FLOW_ADD_WATCH_HOOK_RELEASE_KEY")
+        .map_err(|_| BullmqError::Other("Missing BULLMQ_RS_FLOW_ADD_WATCH_HOOK_RELEASE_KEY".into()))?;
+
+    redis::cmd("SET")
+        .arg(&open_key)
+        .arg("1")
+        .query_async::<redis::Value>(conn)
+        .await?;
+
+    loop {
+        let released: bool = redis::cmd("EXISTS")
+            .arg(&release_key)
+            .query_async(conn)
+            .await?;
+        if released {
+            redis::cmd("DEL")
+                .arg(&open_key)
+                .arg(&release_key)
+                .query_async::<redis::Value>(conn)
+                .await?;
+            return Ok(());
+        }
+
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+}
+
+#[cfg(not(debug_assertions))]
+async fn maybe_watch_window_hook(
+    _conn: &mut redis::aio::ConnectionManager,
+    _queue_name: &str,
+) -> BullmqResult<()> {
+    Ok(())
+}
+
 fn queue_insert<'a, T>(
     scripts: &'a ScriptLoader,
     conn: &'a mut redis::aio::ConnectionManager,
     node: &'a PreparedNode<T>,
-) -> std::pin::Pin<Box<dyn std::future::Future<Output = BullmqResult<()>> + 'a>>
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = BullmqResult<()>> + Send + 'a>>
 where
     T: Serialize + DeserializeOwned + Send + Sync + 'static,
 {

--- a/src/flow_producer.rs
+++ b/src/flow_producer.rs
@@ -3,10 +3,16 @@ use std::sync::Arc;
 use crate::connection::RedisConnection;
 use crate::error::{BullmqError, BullmqResult};
 use crate::job::Job;
+use crate::scripts::commands::add_delayed_job::add_delayed_job_with_parent;
+use crate::scripts::commands::add_parent_job::add_parent_job;
+use crate::scripts::commands::add_prioritized_job::add_prioritized_job_with_parent;
+use crate::scripts::commands::add_standard_job::add_standard_job_with_parent;
+use crate::scripts::commands::key;
 use crate::scripts::ScriptLoader;
-use crate::types::JobOptions;
+use crate::types::{JobOptions, JobState, DEFAULT_MAX_EVENTS};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+use serde_json::json;
 
 /// Producer for BullMQ flows.
 pub struct FlowProducer {
@@ -73,13 +79,327 @@ impl FlowProducerBuilder {
 
 impl FlowProducer {
     /// Add a flow to Redis.
-    pub async fn add<T>(&self, _job: FlowJob<T>) -> BullmqResult<FlowNode<T>>
+    pub async fn add<T>(&self, job: FlowJob<T>) -> BullmqResult<FlowNode<T>>
     where
         T: Serialize + DeserializeOwned + Send + Sync + 'static,
     {
-        let _ = (&self.connection, &self.prefix, &self.scripts);
-        Err(BullmqError::NotImplemented(
-            "FlowProducer::add is not yet implemented".into(),
-        ))
+        let root_prefix = job.prefix.clone().unwrap_or_else(|| self.prefix.clone());
+        let root_queue = job.queue_name.clone();
+        validate_same_queue(&job, &root_prefix, &root_queue, &self.prefix)?;
+
+        let auto_id_count = count_auto_ids(&job);
+        let mut conn = self.connection.get_manager().await?;
+
+        self.scripts.load("addStandardJob", &mut conn).await?;
+        self.scripts.load("addPrioritizedJob", &mut conn).await?;
+        self.scripts.load("addDelayedJob", &mut conn).await?;
+        self.scripts.load("addParentJob", &mut conn).await?;
+
+        let mut next_auto_id = if auto_id_count == 0 {
+            0
+        } else {
+            let last_id: i64 = redis::cmd("INCRBY")
+                .arg(key(&root_prefix, &root_queue, "id"))
+                .arg(auto_id_count)
+                .query_async(&mut conn)
+                .await?;
+            last_id - auto_id_count as i64 + 1
+        };
+
+        let prepared = prepare_node(job, &root_prefix, &root_queue, &self.prefix, None, &mut next_auto_id)?;
+
+        redis::cmd("MULTI")
+            .query_async::<redis::Value>(&mut conn)
+            .await?;
+        queue_insert(&self.scripts, &mut conn, &prepared).await?;
+        let exec_result: redis::Value = redis::cmd("EXEC").query_async(&mut conn).await?;
+        if matches!(exec_result, redis::Value::Nil) {
+            return Err(BullmqError::Other(
+                "Redis transaction aborted while creating flow".into(),
+            ));
+        }
+
+        Ok(build_flow_node(prepared, self.scripts.clone()))
     }
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64
+}
+
+fn effective_prefix(explicit_prefix: &Option<String>, default_prefix: &str) -> String {
+    explicit_prefix
+        .clone()
+        .unwrap_or_else(|| default_prefix.to_string())
+}
+
+fn validate_same_queue<T>(
+    node: &FlowJob<T>,
+    root_prefix: &str,
+    root_queue: &str,
+    default_prefix: &str,
+) -> BullmqResult<()> {
+    let prefix = effective_prefix(&node.prefix, default_prefix);
+    if prefix != root_prefix || node.queue_name != root_queue {
+        return Err(BullmqError::NotImplemented(
+            "FlowProducer::add only supports same-queue flows for now".into(),
+        ));
+    }
+
+    for child in &node.children {
+        validate_same_queue(child, root_prefix, root_queue, default_prefix)?;
+    }
+
+    Ok(())
+}
+
+fn count_auto_ids<T>(node: &FlowJob<T>) -> usize {
+    let own = usize::from(
+        node.opts
+            .as_ref()
+            .and_then(|opts| opts.job_id.as_ref())
+            .is_none(),
+    );
+    own + node.children.iter().map(count_auto_ids).sum::<usize>()
+}
+
+struct PreparedNode<T> {
+    id: String,
+    name: String,
+    queue_name: String,
+    prefix: String,
+    data: T,
+    opts: JobOptions,
+    timestamp: u64,
+    job_key: String,
+    parent_key: Option<String>,
+    parent_data: Option<String>,
+    children: Vec<PreparedNode<T>>,
+}
+
+fn prepare_node<T>(
+    job: FlowJob<T>,
+    root_prefix: &str,
+    root_queue: &str,
+    default_prefix: &str,
+    parent: Option<(String, String)>,
+    next_auto_id: &mut i64,
+) -> BullmqResult<PreparedNode<T>>
+where
+    T: Serialize + DeserializeOwned + Send + Sync + 'static,
+{
+    let prefix = effective_prefix(&job.prefix, default_prefix);
+    if prefix != root_prefix || job.queue_name != root_queue {
+        return Err(BullmqError::NotImplemented(
+            "FlowProducer::add only supports same-queue flows for now".into(),
+        ));
+    }
+
+    let opts = job.opts.unwrap_or_default();
+    let id = match opts.job_id.clone() {
+        Some(job_id) => job_id,
+        None => {
+            let job_id = next_auto_id.to_string();
+            *next_auto_id += 1;
+            job_id
+        }
+    };
+    let timestamp = now_ms();
+    let job_key = key(&prefix, &job.queue_name, &id);
+    let parent_descriptor = serde_json::to_string(&json!({
+        "id": id,
+        "queue": format!("{}:{}", prefix, job.queue_name),
+    }))?;
+
+    let children = job
+        .children
+        .into_iter()
+        .map(|child| {
+            prepare_node(
+                child,
+                root_prefix,
+                root_queue,
+                default_prefix,
+                Some((job_key.clone(), parent_descriptor.clone())),
+                next_auto_id,
+            )
+        })
+        .collect::<BullmqResult<Vec<_>>>()?;
+
+    let (parent_key, parent_data) = match parent {
+        Some((parent_key, parent_data)) => (Some(parent_key), Some(parent_data)),
+        None => (None, None),
+    };
+
+    Ok(PreparedNode {
+        id,
+        name: job.name,
+        queue_name: job.queue_name,
+        prefix,
+        data: job.data,
+        opts,
+        timestamp,
+        job_key,
+        parent_key,
+        parent_data,
+        children,
+    })
+}
+
+fn queue_insert<'a, T>(
+    scripts: &'a ScriptLoader,
+    conn: &'a mut redis::aio::ConnectionManager,
+    node: &'a PreparedNode<T>,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = BullmqResult<()>> + 'a>>
+where
+    T: Serialize + DeserializeOwned + Send + Sync + 'static,
+{
+    Box::pin(async move {
+        let data_json = serde_json::to_string(&node.data)?;
+        let opts_json = serde_json::to_string(&node.opts)?;
+
+        if node.children.is_empty() {
+            let parent = node
+                .parent_key
+                .as_deref()
+                .zip(node.parent_data.as_deref());
+            let delay = node.opts.delay.map(|d| d.as_millis() as u64).unwrap_or(0);
+            let priority = node.opts.priority.unwrap_or(0);
+
+            if delay > 0 {
+                add_delayed_job_with_parent(
+                    scripts,
+                    conn,
+                    &node.prefix,
+                    &node.queue_name,
+                    &node.id,
+                    &node.name,
+                    &data_json,
+                    node.timestamp,
+                    &opts_json,
+                    DEFAULT_MAX_EVENTS,
+                    node.timestamp + delay,
+                    parent,
+                )
+                .await?;
+            } else if priority > 0 {
+                add_prioritized_job_with_parent(
+                    scripts,
+                    conn,
+                    &node.prefix,
+                    &node.queue_name,
+                    &node.id,
+                    &node.name,
+                    &data_json,
+                    node.timestamp,
+                    &opts_json,
+                    DEFAULT_MAX_EVENTS,
+                    parent,
+                )
+                .await?;
+            } else {
+                add_standard_job_with_parent(
+                    scripts,
+                    conn,
+                    &node.prefix,
+                    &node.queue_name,
+                    &node.id,
+                    &node.name,
+                    &data_json,
+                    node.timestamp,
+                    &opts_json,
+                    DEFAULT_MAX_EVENTS,
+                    parent,
+                )
+                .await?;
+            }
+
+            return Ok(());
+        }
+
+        let parent = node
+            .parent_key
+            .as_deref()
+            .zip(node.parent_data.as_deref())
+            .map(|(parent_key, parent_data)| {
+                (
+                    format!("{parent_key}:dependencies"),
+                    parent_key,
+                    parent_data,
+                )
+            });
+
+        let parent_ref = parent
+            .as_ref()
+            .map(|(dependencies_key, parent_key, parent_data)| {
+                (
+                    dependencies_key.as_str(),
+                    *parent_key,
+                    *parent_data,
+                )
+            });
+
+        add_parent_job(
+            scripts,
+            conn,
+            &node.prefix,
+            &node.queue_name,
+            &node.id,
+            &node.name,
+            &data_json,
+            node.timestamp,
+            &opts_json,
+            DEFAULT_MAX_EVENTS,
+            parent_ref,
+        )
+        .await?;
+
+        let dependencies_key = format!("{}:dependencies", node.job_key);
+        for child in &node.children {
+            redis::cmd("SADD")
+                .arg(&dependencies_key)
+                .arg(&child.job_key)
+                .query_async::<redis::Value>(conn)
+                .await?;
+        }
+
+        for child in &node.children {
+            queue_insert(scripts, conn, child).await?;
+        }
+
+        Ok(())
+    })
+}
+
+fn build_flow_node<T>(node: PreparedNode<T>, scripts: Arc<ScriptLoader>) -> FlowNode<T>
+where
+    T: Serialize + DeserializeOwned + Send + Sync + 'static,
+{
+    let mut job = Job::new(
+        node.id.clone(),
+        node.name,
+        node.data,
+        Some(node.opts),
+    );
+    job.timestamp = node.timestamp;
+    job.state = if !node.children.is_empty() {
+        JobState::WaitingChildren
+    } else if job.delay > 0 {
+        JobState::Delayed
+    } else if job.priority > 0 {
+        JobState::Prioritized
+    } else {
+        JobState::Wait
+    };
+
+    let children = node
+        .children
+        .into_iter()
+        .map(|child| build_flow_node(child, scripts.clone()))
+        .collect();
+
+    FlowNode { job, children }
 }

--- a/src/flow_producer.rs
+++ b/src/flow_producer.rs
@@ -116,7 +116,20 @@ impl FlowProducer {
             &mut next_auto_id,
             &mut seen_job_keys,
         )?;
-        ensure_job_keys_do_not_exist(&mut conn, &prepared).await?;
+        let planned_job_keys = collect_job_keys(&prepared);
+
+        let mut watch_cmd = redis::cmd("WATCH");
+        for job_key in &planned_job_keys {
+            watch_cmd.arg(job_key);
+        }
+        watch_cmd.query_async::<redis::Value>(&mut conn).await?;
+        let existence_result = ensure_job_keys_do_not_exist(&mut conn, &prepared).await;
+        if let Err(err) = existence_result {
+            let _ = redis::cmd("UNWATCH")
+                .query_async::<redis::Value>(&mut conn)
+                .await;
+            return Err(err);
+        }
 
         redis::cmd("MULTI").query_async::<redis::Value>(&mut conn).await?;
         let queue_result = queue_insert(&self.scripts, &mut conn, &prepared).await;
@@ -128,11 +141,7 @@ impl FlowProducer {
         }
 
         let exec_result: redis::Value = redis::cmd("EXEC").query_async(&mut conn).await?;
-        if matches!(exec_result, redis::Value::Nil) {
-            return Err(BullmqError::Other(
-                "Redis transaction aborted while creating flow".into(),
-            ));
-        }
+        validate_exec_result(exec_result)?;
 
         Ok(build_flow_node(
             prepared,
@@ -315,6 +324,34 @@ fn queue_insert_existing_check<'a, T>(
     node: &'a PreparedNode<T>,
 ) -> std::pin::Pin<Box<dyn std::future::Future<Output = BullmqResult<()>> + 'a>> {
     Box::pin(async move { ensure_job_keys_do_not_exist(conn, node).await })
+}
+
+fn collect_job_keys<T>(node: &PreparedNode<T>) -> Vec<String> {
+    let mut keys = vec![node.job_key.clone()];
+    for child in &node.children {
+        keys.extend(collect_job_keys(child));
+    }
+    keys
+}
+
+fn validate_exec_result(result: redis::Value) -> BullmqResult<()> {
+    match result {
+        redis::Value::Nil => Err(BullmqError::Other(
+            "Redis transaction aborted while creating flow".into(),
+        )),
+        redis::Value::Array(values) => {
+            for value in values {
+                if let redis::Value::ServerError(err) = value {
+                    return Err(BullmqError::from(redis::RedisError::from(err)));
+                }
+            }
+            Ok(())
+        }
+        other => Err(BullmqError::Other(format!(
+            "Unexpected EXEC response while creating flow: {:?}",
+            other
+        ))),
+    }
 }
 
 fn queue_insert<'a, T>(

--- a/src/flow_producer.rs
+++ b/src/flow_producer.rs
@@ -1,0 +1,83 @@
+use std::sync::Arc;
+
+use crate::connection::RedisConnection;
+use crate::error::{BullmqError, BullmqResult};
+use crate::job::Job;
+use crate::scripts::ScriptLoader;
+use crate::types::JobOptions;
+
+/// Producer for BullMQ flows.
+pub struct FlowProducer {
+    connection: RedisConnection,
+    prefix: String,
+    scripts: Arc<ScriptLoader>,
+}
+
+/// Builder for creating a [`FlowProducer`].
+pub struct FlowProducerBuilder {
+    connection: Option<RedisConnection>,
+    prefix: String,
+}
+
+/// A flow job definition.
+#[derive(Debug, Clone)]
+pub struct FlowJob<T = serde_json::Value> {
+    pub name: String,
+    pub queue_name: String,
+    pub data: T,
+    pub prefix: Option<String>,
+    pub opts: Option<JobOptions>,
+    pub children: Vec<FlowJob<T>>,
+}
+
+/// A node in a flow tree.
+#[derive(Debug, Clone)]
+pub struct FlowNode<T = serde_json::Value> {
+    pub job: Job<T>,
+    pub children: Vec<FlowNode<T>>,
+}
+
+impl FlowProducerBuilder {
+    /// Create a new flow producer builder.
+    pub fn new() -> Self {
+        Self {
+            connection: None,
+            prefix: "bull".to_string(),
+        }
+    }
+
+    /// Set the Redis connection configuration.
+    pub fn connection(mut self, conn: RedisConnection) -> Self {
+        self.connection = Some(conn);
+        self
+    }
+
+    /// Set a custom key prefix (default: "bull").
+    pub fn prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.prefix = prefix.into();
+        self
+    }
+
+    /// Build the flow producer.
+    pub async fn build(self) -> BullmqResult<FlowProducer> {
+        let connection = self.connection.ok_or_else(|| {
+            BullmqError::Other("FlowProducerBuilder requires a Redis connection".into())
+        })?;
+
+        Ok(FlowProducer {
+            connection,
+            prefix: self.prefix,
+            scripts: Arc::new(ScriptLoader::new()),
+        })
+    }
+}
+
+impl FlowProducer {
+    /// Add a flow to Redis.
+    pub async fn add<T>(&self, _job: FlowJob<T>) -> BullmqResult<FlowNode<T>> {
+        let _ = (&self.connection, &self.prefix, &self.scripts);
+        Err(BullmqError::NotImplemented(
+            "FlowProducer::add is not yet implemented".into(),
+        ))
+    }
+}

--- a/src/flow_producer.rs
+++ b/src/flow_producer.rs
@@ -15,7 +15,7 @@ pub struct FlowProducer {
 
 /// Builder for creating a [`FlowProducer`].
 pub struct FlowProducerBuilder {
-    connection: Option<RedisConnection>,
+    connection: RedisConnection,
     prefix: String,
 }
 
@@ -41,14 +41,14 @@ impl FlowProducerBuilder {
     /// Create a new flow producer builder.
     pub fn new() -> Self {
         Self {
-            connection: None,
+            connection: RedisConnection::default(),
             prefix: "bull".to_string(),
         }
     }
 
     /// Set the Redis connection configuration.
     pub fn connection(mut self, conn: RedisConnection) -> Self {
-        self.connection = Some(conn);
+        self.connection = conn;
         self
     }
 
@@ -60,12 +60,8 @@ impl FlowProducerBuilder {
 
     /// Build the flow producer.
     pub async fn build(self) -> BullmqResult<FlowProducer> {
-        let connection = self.connection.ok_or_else(|| {
-            BullmqError::Other("FlowProducerBuilder requires a Redis connection".into())
-        })?;
-
         Ok(FlowProducer {
-            connection,
+            connection: self.connection,
             prefix: self.prefix,
             scripts: Arc::new(ScriptLoader::new()),
         })

--- a/src/flow_producer.rs
+++ b/src/flow_producer.rs
@@ -143,7 +143,6 @@ impl FlowProducer {
 
         let exec_result: redis::Value = redis::cmd("EXEC").query_async(&mut conn).await?;
         validate_exec_result(exec_result)?;
-
         Ok(build_flow_node(
             prepared,
             conn.clone(),
@@ -412,7 +411,6 @@ async fn maybe_watch_window_hook(
 ) -> BullmqResult<()> {
     Ok(())
 }
-
 fn queue_insert<'a, T>(
     scripts: &'a ScriptLoader,
     conn: &'a mut redis::aio::ConnectionManager,

--- a/src/flow_producer.rs
+++ b/src/flow_producer.rs
@@ -5,6 +5,8 @@ use crate::error::{BullmqError, BullmqResult};
 use crate::job::Job;
 use crate::scripts::ScriptLoader;
 use crate::types::JobOptions;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 
 /// Producer for BullMQ flows.
 pub struct FlowProducer {
@@ -60,6 +62,7 @@ impl FlowProducerBuilder {
 
     /// Build the flow producer.
     pub async fn build(self) -> BullmqResult<FlowProducer> {
+        let _conn = self.connection.get_manager().await?;
         Ok(FlowProducer {
             connection: self.connection,
             prefix: self.prefix,
@@ -70,7 +73,10 @@ impl FlowProducerBuilder {
 
 impl FlowProducer {
     /// Add a flow to Redis.
-    pub async fn add<T>(&self, _job: FlowJob<T>) -> BullmqResult<FlowNode<T>> {
+    pub async fn add<T>(&self, _job: FlowJob<T>) -> BullmqResult<FlowNode<T>>
+    where
+        T: Serialize + DeserializeOwned + Send + Sync + 'static,
+    {
         let _ = (&self.connection, &self.prefix, &self.scripts);
         Err(BullmqError::NotImplemented(
             "FlowProducer::add is not yet implemented".into(),

--- a/src/flow_producer.rs
+++ b/src/flow_producer.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::connection::RedisConnection;
 use crate::error::{BullmqError, BullmqResult};
-use crate::job::Job;
+use crate::job::{Job, JobContext};
 use crate::scripts::commands::add_delayed_job::add_delayed_job_with_parent;
 use crate::scripts::commands::add_parent_job::add_parent_job;
 use crate::scripts::commands::add_prioritized_job::add_prioritized_job_with_parent;
@@ -106,12 +106,27 @@ impl FlowProducer {
             last_id - auto_id_count as i64 + 1
         };
 
-        let prepared = prepare_node(job, &root_prefix, &root_queue, &self.prefix, None, &mut next_auto_id)?;
+        let mut seen_job_keys = std::collections::HashSet::new();
+        let prepared = prepare_node(
+            job,
+            &root_prefix,
+            &root_queue,
+            &self.prefix,
+            None,
+            &mut next_auto_id,
+            &mut seen_job_keys,
+        )?;
+        ensure_job_keys_do_not_exist(&mut conn, &prepared).await?;
 
-        redis::cmd("MULTI")
-            .query_async::<redis::Value>(&mut conn)
-            .await?;
-        queue_insert(&self.scripts, &mut conn, &prepared).await?;
+        redis::cmd("MULTI").query_async::<redis::Value>(&mut conn).await?;
+        let queue_result = queue_insert(&self.scripts, &mut conn, &prepared).await;
+        if let Err(err) = queue_result {
+            let _ = redis::cmd("DISCARD")
+                .query_async::<redis::Value>(&mut conn)
+                .await;
+            return Err(err);
+        }
+
         let exec_result: redis::Value = redis::cmd("EXEC").query_async(&mut conn).await?;
         if matches!(exec_result, redis::Value::Nil) {
             return Err(BullmqError::Other(
@@ -119,7 +134,11 @@ impl FlowProducer {
             ));
         }
 
-        Ok(build_flow_node(prepared, self.scripts.clone()))
+        Ok(build_flow_node(
+            prepared,
+            conn.clone(),
+            self.scripts.clone(),
+        ))
     }
 }
 
@@ -172,11 +191,15 @@ struct PreparedNode<T> {
     queue_name: String,
     prefix: String,
     data: T,
+    data_json: String,
     opts: JobOptions,
+    opts_json: String,
     timestamp: u64,
     job_key: String,
     parent_key: Option<String>,
     parent_data: Option<String>,
+    delay_ms: u64,
+    priority: u32,
     children: Vec<PreparedNode<T>>,
 }
 
@@ -187,6 +210,7 @@ fn prepare_node<T>(
     default_prefix: &str,
     parent: Option<(String, String)>,
     next_auto_id: &mut i64,
+    seen_job_keys: &mut std::collections::HashSet<String>,
 ) -> BullmqResult<PreparedNode<T>>
 where
     T: Serialize + DeserializeOwned + Send + Sync + 'static,
@@ -209,10 +233,20 @@ where
     };
     let timestamp = now_ms();
     let job_key = key(&prefix, &job.queue_name, &id);
+    if !seen_job_keys.insert(job_key.clone()) {
+        return Err(BullmqError::Other(format!(
+            "Job key '{}' is duplicated within the flow",
+            job_key
+        )));
+    }
     let parent_descriptor = serde_json::to_string(&json!({
         "id": id,
         "queue": format!("{}:{}", prefix, job.queue_name),
     }))?;
+    let data_json = serde_json::to_string(&job.data)?;
+    let opts_json = serde_json::to_string(&opts)?;
+    let delay_ms = opts.delay.map(|d| d.as_millis() as u64).unwrap_or(0);
+    let priority = opts.priority.unwrap_or(0);
 
     let children = job
         .children
@@ -225,6 +259,7 @@ where
                 default_prefix,
                 Some((job_key.clone(), parent_descriptor.clone())),
                 next_auto_id,
+                seen_job_keys,
             )
         })
         .collect::<BullmqResult<Vec<_>>>()?;
@@ -240,13 +275,46 @@ where
         queue_name: job.queue_name,
         prefix,
         data: job.data,
+        data_json,
         opts,
+        opts_json,
         timestamp,
         job_key,
         parent_key,
         parent_data,
+        delay_ms,
+        priority,
         children,
     })
+}
+
+async fn ensure_job_keys_do_not_exist<T>(
+    conn: &mut redis::aio::ConnectionManager,
+    node: &PreparedNode<T>,
+) -> BullmqResult<()> {
+    let exists: bool = redis::cmd("EXISTS")
+        .arg(&node.job_key)
+        .query_async(conn)
+        .await?;
+    if exists {
+        return Err(BullmqError::Other(format!(
+            "Job '{}' already exists",
+            node.job_key
+        )));
+    }
+
+    for child in &node.children {
+        queue_insert_existing_check(conn, child).await?;
+    }
+
+    Ok(())
+}
+
+fn queue_insert_existing_check<'a, T>(
+    conn: &'a mut redis::aio::ConnectionManager,
+    node: &'a PreparedNode<T>,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = BullmqResult<()>> + 'a>> {
+    Box::pin(async move { ensure_job_keys_do_not_exist(conn, node).await })
 }
 
 fn queue_insert<'a, T>(
@@ -258,18 +326,13 @@ where
     T: Serialize + DeserializeOwned + Send + Sync + 'static,
 {
     Box::pin(async move {
-        let data_json = serde_json::to_string(&node.data)?;
-        let opts_json = serde_json::to_string(&node.opts)?;
-
         if node.children.is_empty() {
             let parent = node
                 .parent_key
                 .as_deref()
                 .zip(node.parent_data.as_deref());
-            let delay = node.opts.delay.map(|d| d.as_millis() as u64).unwrap_or(0);
-            let priority = node.opts.priority.unwrap_or(0);
 
-            if delay > 0 {
+            if node.delay_ms > 0 {
                 add_delayed_job_with_parent(
                     scripts,
                     conn,
@@ -277,15 +340,15 @@ where
                     &node.queue_name,
                     &node.id,
                     &node.name,
-                    &data_json,
+                    &node.data_json,
                     node.timestamp,
-                    &opts_json,
+                    &node.opts_json,
                     DEFAULT_MAX_EVENTS,
-                    node.timestamp + delay,
+                    node.timestamp + node.delay_ms,
                     parent,
                 )
                 .await?;
-            } else if priority > 0 {
+            } else if node.priority > 0 {
                 add_prioritized_job_with_parent(
                     scripts,
                     conn,
@@ -293,9 +356,9 @@ where
                     &node.queue_name,
                     &node.id,
                     &node.name,
-                    &data_json,
+                    &node.data_json,
                     node.timestamp,
-                    &opts_json,
+                    &node.opts_json,
                     DEFAULT_MAX_EVENTS,
                     parent,
                 )
@@ -308,9 +371,9 @@ where
                     &node.queue_name,
                     &node.id,
                     &node.name,
-                    &data_json,
+                    &node.data_json,
                     node.timestamp,
-                    &opts_json,
+                    &node.opts_json,
                     DEFAULT_MAX_EVENTS,
                     parent,
                 )
@@ -349,9 +412,9 @@ where
             &node.queue_name,
             &node.id,
             &node.name,
-            &data_json,
+            &node.data_json,
             node.timestamp,
-            &opts_json,
+            &node.opts_json,
             DEFAULT_MAX_EVENTS,
             parent_ref,
         )
@@ -374,7 +437,11 @@ where
     })
 }
 
-fn build_flow_node<T>(node: PreparedNode<T>, scripts: Arc<ScriptLoader>) -> FlowNode<T>
+fn build_flow_node<T>(
+    node: PreparedNode<T>,
+    conn: redis::aio::ConnectionManager,
+    scripts: Arc<ScriptLoader>,
+) -> FlowNode<T>
 where
     T: Serialize + DeserializeOwned + Send + Sync + 'static,
 {
@@ -394,11 +461,17 @@ where
     } else {
         JobState::Wait
     };
+    job.ctx = Some(Arc::new(JobContext {
+        conn: conn.clone(),
+        scripts: scripts.clone(),
+        prefix: node.prefix.clone(),
+        queue_name: node.queue_name.clone(),
+    }));
 
     let children = node
         .children
         .into_iter()
-        .map(|child| build_flow_node(child, scripts.clone()))
+        .map(|child| build_flow_node(child, conn.clone(), scripts.clone()))
         .collect();
 
     FlowNode { job, children }

--- a/src/flow_producer.rs
+++ b/src/flow_producer.rs
@@ -45,6 +45,12 @@ pub struct FlowNode<T = serde_json::Value> {
     pub children: Vec<FlowNode<T>>,
 }
 
+impl Default for FlowProducerBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl FlowProducerBuilder {
     /// Create a new flow producer builder.
     pub fn new() -> Self {
@@ -127,7 +133,9 @@ impl FlowProducer {
         }
         maybe_watch_window_hook(&mut conn, &root_queue).await?;
 
-        redis::cmd("MULTI").query_async::<redis::Value>(&mut conn).await?;
+        redis::cmd("MULTI")
+            .query_async::<redis::Value>(&mut conn)
+            .await?;
         let queue_result = queue_insert(&self.scripts, &mut conn, &prepared).await;
         if let Err(err) = queue_result {
             let _ = redis::cmd("DISCARD")
@@ -359,8 +367,9 @@ async fn maybe_watch_window_hook(
         Ok(value) => value,
         Err(_) => return Ok(()),
     };
-    let release_key = std::env::var("BULLMQ_RS_FLOW_ADD_WATCH_HOOK_RELEASE_KEY")
-        .map_err(|_| BullmqError::Other("Missing BULLMQ_RS_FLOW_ADD_WATCH_HOOK_RELEASE_KEY".into()))?;
+    let release_key = std::env::var("BULLMQ_RS_FLOW_ADD_WATCH_HOOK_RELEASE_KEY").map_err(|_| {
+        BullmqError::Other("Missing BULLMQ_RS_FLOW_ADD_WATCH_HOOK_RELEASE_KEY".into())
+    })?;
 
     redis::cmd("SET")
         .arg(&open_key)
@@ -403,10 +412,7 @@ where
 {
     Box::pin(async move {
         if node.children.is_empty() {
-            let parent = node
-                .parent_key
-                .as_deref()
-                .zip(node.parent_data.as_deref());
+            let parent = node.parent_key.as_deref().zip(node.parent_data.as_deref());
 
             if node.delay_ms > 0 {
                 add_delayed_job_with_parent(
@@ -474,11 +480,7 @@ where
         let parent_ref = parent
             .as_ref()
             .map(|(dependencies_key, parent_key, parent_data)| {
-                (
-                    dependencies_key.as_str(),
-                    *parent_key,
-                    *parent_data,
-                )
+                (dependencies_key.as_str(), *parent_key, *parent_data)
             });
 
         add_parent_job(
@@ -521,12 +523,7 @@ fn build_flow_node<T>(
 where
     T: Serialize + DeserializeOwned + Send + Sync + 'static,
 {
-    let mut job = Job::new(
-        node.id.clone(),
-        node.name,
-        node.data,
-        Some(node.opts),
-    );
+    let mut job = Job::new(node.id.clone(), node.name, node.data, Some(node.opts));
     job.timestamp = node.timestamp;
     job.state = if !node.children.is_empty() {
         JobState::WaitingChildren

--- a/src/flow_producer.rs
+++ b/src/flow_producer.rs
@@ -83,11 +83,9 @@ impl FlowProducer {
     where
         T: Serialize + DeserializeOwned + Send + Sync + 'static,
     {
-        let root_prefix = job.prefix.clone().unwrap_or_else(|| self.prefix.clone());
         let root_queue = job.queue_name.clone();
-        validate_same_queue(&job, &root_prefix, &root_queue, &self.prefix)?;
-
-        let auto_id_count = count_auto_ids(&job);
+        let mut auto_id_counts = std::collections::HashMap::new();
+        count_auto_ids(&job, &self.prefix, &mut auto_id_counts);
         let mut conn = self.connection.get_manager().await?;
 
         self.scripts.load("addStandardJob", &mut conn).await?;
@@ -95,25 +93,22 @@ impl FlowProducer {
         self.scripts.load("addDelayedJob", &mut conn).await?;
         self.scripts.load("addParentJob", &mut conn).await?;
 
-        let mut next_auto_id = if auto_id_count == 0 {
-            0
-        } else {
+        let mut next_auto_ids = std::collections::HashMap::new();
+        for ((prefix, queue_name), auto_id_count) in auto_id_counts {
             let last_id: i64 = redis::cmd("INCRBY")
-                .arg(key(&root_prefix, &root_queue, "id"))
+                .arg(key(&prefix, &queue_name, "id"))
                 .arg(auto_id_count)
                 .query_async(&mut conn)
                 .await?;
-            last_id - auto_id_count as i64 + 1
-        };
+            next_auto_ids.insert((prefix, queue_name), last_id - auto_id_count as i64 + 1);
+        }
 
         let mut seen_job_keys = std::collections::HashSet::new();
         let prepared = prepare_node(
             job,
-            &root_prefix,
-            &root_queue,
             &self.prefix,
             None,
-            &mut next_auto_id,
+            &mut next_auto_ids,
             &mut seen_job_keys,
         )?;
         let planned_job_keys = collect_job_keys(&prepared);
@@ -164,34 +159,24 @@ fn effective_prefix(explicit_prefix: &Option<String>, default_prefix: &str) -> S
         .unwrap_or_else(|| default_prefix.to_string())
 }
 
-fn validate_same_queue<T>(
+fn count_auto_ids<T>(
     node: &FlowJob<T>,
-    root_prefix: &str,
-    root_queue: &str,
     default_prefix: &str,
-) -> BullmqResult<()> {
-    let prefix = effective_prefix(&node.prefix, default_prefix);
-    if prefix != root_prefix || node.queue_name != root_queue {
-        return Err(BullmqError::NotImplemented(
-            "FlowProducer::add only supports same-queue flows for now".into(),
-        ));
+    counts: &mut std::collections::HashMap<(String, String), usize>,
+) {
+    if node
+        .opts
+        .as_ref()
+        .and_then(|opts| opts.job_id.as_ref())
+        .is_none()
+    {
+        let prefix = effective_prefix(&node.prefix, default_prefix);
+        *counts.entry((prefix, node.queue_name.clone())).or_insert(0) += 1;
     }
 
     for child in &node.children {
-        validate_same_queue(child, root_prefix, root_queue, default_prefix)?;
+        count_auto_ids(child, default_prefix, counts);
     }
-
-    Ok(())
-}
-
-fn count_auto_ids<T>(node: &FlowJob<T>) -> usize {
-    let own = usize::from(
-        node.opts
-            .as_ref()
-            .and_then(|opts| opts.job_id.as_ref())
-            .is_none(),
-    );
-    own + node.children.iter().map(count_auto_ids).sum::<usize>()
 }
 
 struct PreparedNode<T> {
@@ -214,27 +199,26 @@ struct PreparedNode<T> {
 
 fn prepare_node<T>(
     job: FlowJob<T>,
-    root_prefix: &str,
-    root_queue: &str,
     default_prefix: &str,
     parent: Option<(String, String)>,
-    next_auto_id: &mut i64,
+    next_auto_ids: &mut std::collections::HashMap<(String, String), i64>,
     seen_job_keys: &mut std::collections::HashSet<String>,
 ) -> BullmqResult<PreparedNode<T>>
 where
     T: Serialize + DeserializeOwned + Send + Sync + 'static,
 {
     let prefix = effective_prefix(&job.prefix, default_prefix);
-    if prefix != root_prefix || job.queue_name != root_queue {
-        return Err(BullmqError::NotImplemented(
-            "FlowProducer::add only supports same-queue flows for now".into(),
-        ));
-    }
-
     let opts = job.opts.unwrap_or_default();
     let id = match opts.job_id.clone() {
         Some(job_id) => job_id,
         None => {
+            let queue_key = (prefix.clone(), job.queue_name.clone());
+            let next_auto_id = next_auto_ids.get_mut(&queue_key).ok_or_else(|| {
+                BullmqError::Other(format!(
+                    "Missing auto-id range for queue '{}:{}'",
+                    prefix, job.queue_name
+                ))
+            })?;
             let job_id = next_auto_id.to_string();
             *next_auto_id += 1;
             job_id
@@ -263,11 +247,9 @@ where
         .map(|child| {
             prepare_node(
                 child,
-                root_prefix,
-                root_queue,
                 default_prefix,
                 Some((job_key.clone(), parent_descriptor.clone())),
-                next_auto_id,
+                next_auto_ids,
                 seen_job_keys,
             )
         })

--- a/src/job.rs
+++ b/src/job.rs
@@ -566,6 +566,54 @@ impl<T: Serialize + DeserializeOwned> Job<T> {
         Ok(())
     }
 
+    /// Change the priority of this job.
+    ///
+    /// If priority > 0, moves job to the prioritized sorted set.
+    /// If priority == 0, moves job back to the wait list.
+    pub async fn change_priority(&mut self, priority: u32) -> BullmqResult<()> {
+        let ctx = self.ctx()?;
+        let mut conn = ctx.conn.clone();
+        let timestamp = now_ms();
+
+        crate::scripts::commands::change_priority::change_priority(
+            &ctx.scripts,
+            &mut conn,
+            &ctx.prefix,
+            &ctx.queue_name,
+            &self.id,
+            priority,
+            10_000,
+            timestamp,
+        )
+        .await?;
+
+        self.priority = priority;
+        self.opts.priority = if priority > 0 { Some(priority) } else { None };
+        Ok(())
+    }
+
+    /// Promote this job from delayed to wait (or prioritized if priority > 0).
+    pub async fn promote(&mut self) -> BullmqResult<()> {
+        let ctx = self.ctx()?;
+        let mut conn = ctx.conn.clone();
+        let timestamp = now_ms();
+
+        crate::scripts::commands::promote::promote(
+            &ctx.scripts,
+            &mut conn,
+            &ctx.prefix,
+            &ctx.queue_name,
+            &self.id,
+            10_000,
+            timestamp,
+        )
+        .await?;
+
+        self.state = JobState::Wait;
+        self.delay = 0;
+        Ok(())
+    }
+
     /// Retry this active job by moving it back to wait or prioritized.
     ///
     /// Only works on active jobs with a lock token (inside a worker handler).

--- a/src/job.rs
+++ b/src/job.rs
@@ -1,17 +1,27 @@
 use std::collections::HashMap;
 
-use chrono::{DateTime, Utc};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
 use crate::error::{BullmqError, BullmqResult};
-use crate::types::{BackoffStrategy, JobOptions, JobState};
+use crate::types::{JobOptions, JobState};
+
+/// Returns the current time as milliseconds since the Unix epoch.
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64
+}
 
 /// A job with a typed data payload.
 ///
 /// Jobs are created by [`Queue::add`](crate::Queue::add) and processed by
 /// [`Worker::start`](crate::Worker::start). The `data` field contains your
 /// custom payload, which must implement `Serialize` and `DeserializeOwned`.
+///
+/// Field names in the Redis hash match BullMQ Node.js v5.x exactly for
+/// wire compatibility (camelCase, abbreviations, etc.).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Job<T> {
     /// Unique job identifier.
@@ -22,100 +32,117 @@ pub struct Job<T> {
     pub data: T,
     /// Current lifecycle state.
     pub state: JobState,
-    /// When the job was created.
-    pub timestamp: DateTime<Utc>,
+    /// Original creation options, serialized as JSON in the Redis hash.
+    pub opts: JobOptions,
+    /// When the job was created (ms since Unix epoch).
+    pub timestamp: u64,
     /// Priority (lower = higher priority).
-    pub priority: i32,
+    pub priority: u32,
     /// Delay in milliseconds before the job becomes available.
     pub delay: u64,
-    /// Number of attempts made so far.
+    /// Number of attempts made so far. Maps to "atm" in the Redis hash.
     pub attempts_made: u32,
-    /// Maximum number of attempts allowed.
-    pub max_attempts: u32,
-    /// Backoff strategy for retries.
-    pub backoff: Option<BackoffStrategy>,
-    /// Time-to-live in milliseconds.
-    pub ttl: Option<u64>,
-    /// Job progress (0-100).
-    pub progress: Option<u32>,
-    /// When the job started being processed.
-    pub processed_on: Option<DateTime<Utc>>,
-    /// When the job finished (completed or failed).
-    pub finished_on: Option<DateTime<Utc>>,
+    /// Number of attempts started. Maps to "ats" in the Redis hash.
+    pub attempts_started: u32,
+    /// Job progress (flexible JSON value).
+    pub progress: Option<serde_json::Value>,
+    /// When the job started being processed (ms since Unix epoch).
+    pub processed_on: Option<u64>,
+    /// When the job finished — completed or failed (ms since Unix epoch).
+    pub finished_on: Option<u64>,
     /// Reason for failure, if the job failed.
     pub failed_reason: Option<String>,
+    /// Stack trace entries from failed processing attempts.
+    pub stacktrace: Vec<String>,
     /// Return value from the handler (serialized as JSON).
     pub return_value: Option<serde_json::Value>,
+    /// Identifier of the worker that processed this job. Maps to "pb" in the Redis hash.
+    pub processed_by: Option<String>,
 }
 
 impl<T: Serialize + DeserializeOwned> Job<T> {
     /// Create a new job with the given name, data, and options.
+    ///
+    /// The job is always created in `JobState::Wait` — Lua scripts handle
+    /// actual placement into the correct Redis data structure.
     pub fn new(id: String, name: String, data: T, opts: Option<JobOptions>) -> Self {
         let opts = opts.unwrap_or_default();
+        let priority = opts.priority.unwrap_or(0);
+        let delay = opts.delay.map(|d| d.as_millis() as u64).unwrap_or(0);
+
         Job {
             id,
             name,
             data,
-            state: if opts.delay.is_some() {
-                JobState::Delayed
-            } else {
-                JobState::Waiting
-            },
-            timestamp: Utc::now(),
-            priority: opts.priority.unwrap_or(0),
-            delay: opts.delay.map(|d| d.as_millis() as u64).unwrap_or(0),
+            state: JobState::Wait,
+            opts,
+            timestamp: now_ms(),
+            priority,
+            delay,
             attempts_made: 0,
-            max_attempts: opts.attempts.unwrap_or(1),
-            backoff: opts.backoff,
-            ttl: opts.ttl.map(|d| d.as_millis() as u64),
+            attempts_started: 0,
             progress: None,
             processed_on: None,
             finished_on: None,
             failed_reason: None,
+            stacktrace: Vec::new(),
             return_value: None,
+            processed_by: None,
         }
     }
 
-    /// Serialize the job into a list of (field, value) pairs for Redis HSET.
+    /// Serialize the job into a list of (field, value) pairs for Redis `HSET`.
+    ///
+    /// The field names match BullMQ Node.js v5.x exactly:
+    /// - `atm` for attempts_made
+    /// - `ats` for attempts_started
+    /// - `processedOn`, `finishedOn`, `failedReason` (camelCase)
+    /// - `returnvalue` (all lowercase)
+    /// - `pb` for processed_by
     pub fn to_redis_hash(&self) -> BullmqResult<Vec<(String, String)>> {
         let data_json = serde_json::to_string(&self.data)?;
+        let opts_json = serde_json::to_string(&self.opts)?;
+
         let mut fields = vec![
-            ("name".to_string(), self.name.clone()),
-            ("data".to_string(), data_json),
-            ("state".to_string(), self.state.to_string()),
-            ("timestamp".to_string(), self.timestamp.timestamp_millis().to_string()),
-            ("priority".to_string(), self.priority.to_string()),
-            ("delay".to_string(), self.delay.to_string()),
-            ("attempts_made".to_string(), self.attempts_made.to_string()),
-            ("max_attempts".to_string(), self.max_attempts.to_string()),
+            ("name".into(), self.name.clone()),
+            ("data".into(), data_json),
+            ("opts".into(), opts_json),
+            ("timestamp".into(), self.timestamp.to_string()),
+            ("delay".into(), self.delay.to_string()),
+            ("priority".into(), self.priority.to_string()),
+            ("atm".into(), self.attempts_made.to_string()),
+            ("ats".into(), self.attempts_started.to_string()),
         ];
 
-        if let Some(ref backoff) = self.backoff {
-            fields.push(("backoff".to_string(), serde_json::to_string(backoff)?));
+        if let Some(ref progress) = self.progress {
+            fields.push(("progress".into(), serde_json::to_string(progress)?));
         }
-        if let Some(ttl) = self.ttl {
-            fields.push(("ttl".to_string(), ttl.to_string()));
+        if let Some(processed_on) = self.processed_on {
+            fields.push(("processedOn".into(), processed_on.to_string()));
         }
-        if let Some(progress) = self.progress {
-            fields.push(("progress".to_string(), progress.to_string()));
-        }
-        if let Some(ref ts) = self.processed_on {
-            fields.push(("processed_on".to_string(), ts.timestamp_millis().to_string()));
-        }
-        if let Some(ref ts) = self.finished_on {
-            fields.push(("finished_on".to_string(), ts.timestamp_millis().to_string()));
+        if let Some(finished_on) = self.finished_on {
+            fields.push(("finishedOn".into(), finished_on.to_string()));
         }
         if let Some(ref reason) = self.failed_reason {
-            fields.push(("failed_reason".to_string(), reason.clone()));
+            fields.push(("failedReason".into(), serde_json::to_string(reason)?));
         }
         if let Some(ref val) = self.return_value {
-            fields.push(("return_value".to_string(), serde_json::to_string(val)?));
+            fields.push(("returnvalue".into(), serde_json::to_string(val)?));
+        }
+        if !self.stacktrace.is_empty() {
+            fields.push(("stacktrace".into(), serde_json::to_string(&self.stacktrace)?));
+        }
+        if let Some(ref pb) = self.processed_by {
+            fields.push(("pb".into(), pb.clone()));
         }
 
         Ok(fields)
     }
 
     /// Deserialize a job from a Redis hash (field-value map).
+    ///
+    /// Reads BullMQ Node.js field names and tolerates unknown fields
+    /// (e.g., `stc` for stalled counter, managed by Lua scripts).
     pub fn from_redis_hash(id: &str, map: &HashMap<String, String>) -> BullmqResult<Self> {
         let get = |key: &str| -> BullmqResult<&String> {
             map.get(key).ok_or_else(|| {
@@ -124,73 +151,93 @@ impl<T: Serialize + DeserializeOwned> Job<T> {
         };
 
         let data: T = serde_json::from_str(get("data")?)?;
-        let state: JobState = get("state")?
-            .parse()
-            .map_err(|e: String| BullmqError::Other(e))?;
-        let timestamp_ms: i64 = get("timestamp")?
-            .parse()
-            .map_err(|_| BullmqError::Other("Invalid timestamp".to_string()))?;
-        let timestamp = DateTime::from_timestamp_millis(timestamp_ms)
-            .unwrap_or_else(Utc::now);
 
-        let priority: i32 = get("priority")?
-            .parse()
-            .map_err(|_| BullmqError::Other("Invalid priority".to_string()))?;
-        let delay: u64 = get("delay")?
-            .parse()
-            .map_err(|_| BullmqError::Other("Invalid delay".to_string()))?;
-        let attempts_made: u32 = get("attempts_made")?
-            .parse()
-            .map_err(|_| BullmqError::Other("Invalid attempts_made".to_string()))?;
-        let max_attempts: u32 = get("max_attempts")?
-            .parse()
-            .map_err(|_| BullmqError::Other("Invalid max_attempts".to_string()))?;
+        let opts: JobOptions = match map.get("opts") {
+            Some(s) => serde_json::from_str(s)?,
+            None => JobOptions::default(),
+        };
 
-        let backoff = map
-            .get("backoff")
-            .map(|s| serde_json::from_str(s))
-            .transpose()?;
-        let ttl = map
-            .get("ttl")
-            .map(|s| s.parse::<u64>())
+        let timestamp: u64 = get("timestamp")?
+            .parse()
+            .map_err(|_| BullmqError::Other("Invalid timestamp".into()))?;
+        let priority: u32 = map
+            .get("priority")
+            .map(|s| s.parse())
             .transpose()
-            .map_err(|_| BullmqError::Other("Invalid ttl".to_string()))?;
+            .map_err(|_| BullmqError::Other("Invalid priority".into()))?
+            .unwrap_or(0);
+        let delay: u64 = map
+            .get("delay")
+            .map(|s| s.parse())
+            .transpose()
+            .map_err(|_| BullmqError::Other("Invalid delay".into()))?
+            .unwrap_or(0);
+        let attempts_made: u32 = map
+            .get("atm")
+            .map(|s| s.parse())
+            .transpose()
+            .map_err(|_| BullmqError::Other("Invalid atm".into()))?
+            .unwrap_or(0);
+        let attempts_started: u32 = map
+            .get("ats")
+            .map(|s| s.parse())
+            .transpose()
+            .map_err(|_| BullmqError::Other("Invalid ats".into()))?
+            .unwrap_or(0);
+
         let progress = map
             .get("progress")
-            .map(|s| s.parse::<u32>())
-            .transpose()
-            .map_err(|_| BullmqError::Other("Invalid progress".to_string()))?;
-        let processed_on = map
-            .get("processed_on")
-            .and_then(|s| s.parse::<i64>().ok())
-            .and_then(DateTime::from_timestamp_millis);
-        let finished_on = map
-            .get("finished_on")
-            .and_then(|s| s.parse::<i64>().ok())
-            .and_then(DateTime::from_timestamp_millis);
-        let failed_reason = map.get("failed_reason").cloned();
-        let return_value = map
-            .get("return_value")
             .map(|s| serde_json::from_str(s))
             .transpose()?;
+        let processed_on = map
+            .get("processedOn")
+            .map(|s| s.parse::<u64>())
+            .transpose()
+            .map_err(|_| BullmqError::Other("Invalid processedOn".into()))?;
+        let finished_on = map
+            .get("finishedOn")
+            .map(|s| s.parse::<u64>())
+            .transpose()
+            .map_err(|_| BullmqError::Other("Invalid finishedOn".into()))?;
+        let failed_reason = map
+            .get("failedReason")
+            .map(|s| serde_json::from_str(s))
+            .transpose()?;
+        let return_value = map
+            .get("returnvalue")
+            .map(|s| serde_json::from_str(s))
+            .transpose()?;
+        let stacktrace: Vec<String> = map
+            .get("stacktrace")
+            .map(|s| serde_json::from_str(s))
+            .transpose()?
+            .unwrap_or_default();
+        let processed_by = map.get("pb").cloned();
+
+        // Determine state: prefer explicit "state" field, otherwise infer Wait.
+        let state: JobState = match map.get("state") {
+            Some(s) => s.parse().map_err(|e: String| BullmqError::Other(e))?,
+            None => JobState::Wait,
+        };
 
         Ok(Job {
             id: id.to_string(),
             name: get("name")?.clone(),
             data,
             state,
+            opts,
             timestamp,
             priority,
             delay,
             attempts_made,
-            max_attempts,
-            backoff,
-            ttl,
+            attempts_started,
             progress,
             processed_on,
             finished_on,
             failed_reason,
+            stacktrace,
             return_value,
+            processed_by,
         })
     }
 }

--- a/src/job.rs
+++ b/src/job.rs
@@ -501,41 +501,7 @@ impl<T: Serialize + DeserializeOwned> Job<T> {
     pub async fn remove(&self) -> BullmqResult<()> {
         let ctx = self.ctx()?;
         let mut conn = ctx.conn.clone();
-        let job_id = &self.id;
-
-        // Remove from lists (LREM)
-        for suffix in &["wait", "active", "paused"] {
-            let key = build_key(&ctx.prefix, &ctx.queue_name, suffix);
-            redis::cmd("LREM")
-                .arg(&key)
-                .arg(0i64)
-                .arg(job_id)
-                .query_async::<i64>(&mut conn)
-                .await?;
-        }
-
-        // Remove from sorted sets (ZREM)
-        for suffix in &["prioritized", "delayed", "completed", "failed"] {
-            let key = build_key(&ctx.prefix, &ctx.queue_name, suffix);
-            redis::cmd("ZREM")
-                .arg(&key)
-                .arg(job_id)
-                .query_async::<i64>(&mut conn)
-                .await?;
-        }
-
-        // Delete the job hash, lock key, and logs key
-        let job_key = self.queue_key(job_id)?;
-        let lock_key = format!("{}:lock", job_key);
-        let logs_key = format!("{}:logs", job_key);
-        redis::cmd("DEL")
-            .arg(&job_key)
-            .arg(&lock_key)
-            .arg(&logs_key)
-            .query_async::<i64>(&mut conn)
-            .await?;
-
-        Ok(())
+        cleanup_job(&mut conn, &ctx.prefix, &ctx.queue_name, &self.id).await
     }
 
     /// Move this active job back to delayed with a new delay.
@@ -800,4 +766,71 @@ impl<T: Serialize + DeserializeOwned> Job<T> {
             "getChildrenValues requires Flows (not yet implemented)".into(),
         ))
     }
+}
+
+pub(crate) async fn cleanup_job(
+    conn: &mut ConnectionManager,
+    prefix: &str,
+    queue_name: &str,
+    job_id: &str,
+) -> BullmqResult<()> {
+    let job_key = build_key(prefix, queue_name, job_id);
+    let parent_key: Option<String> = redis::cmd("HGET")
+        .arg(&job_key)
+        .arg("parentKey")
+        .query_async(conn)
+        .await?;
+
+    for suffix in &["wait", "active", "paused"] {
+        let key = build_key(prefix, queue_name, suffix);
+        redis::cmd("LREM")
+            .arg(&key)
+            .arg(0i64)
+            .arg(job_id)
+            .query_async::<i64>(conn)
+            .await?;
+    }
+
+    for suffix in &[
+        "prioritized",
+        "delayed",
+        "completed",
+        "failed",
+        "waiting-children",
+    ] {
+        let key = build_key(prefix, queue_name, suffix);
+        redis::cmd("ZREM")
+            .arg(&key)
+            .arg(job_id)
+            .query_async::<i64>(conn)
+            .await?;
+    }
+
+    if let Some(parent_key) = parent_key {
+        redis::cmd("SREM")
+            .arg(format!("{parent_key}:dependencies"))
+            .arg(&job_key)
+            .query_async::<i64>(conn)
+            .await?;
+        redis::cmd("HDEL")
+            .arg(format!("{parent_key}:processed"))
+            .arg(&job_key)
+            .query_async::<i64>(conn)
+            .await?;
+    }
+
+    let lock_key = format!("{}:lock", job_key);
+    let logs_key = format!("{}:logs", job_key);
+    let dependencies_key = format!("{}:dependencies", job_key);
+    let processed_key = format!("{}:processed", job_key);
+    redis::cmd("DEL")
+        .arg(&job_key)
+        .arg(&lock_key)
+        .arg(&logs_key)
+        .arg(&dependencies_key)
+        .arg(&processed_key)
+        .query_async::<i64>(conn)
+        .await?;
+
+    Ok(())
 }

--- a/src/job.rs
+++ b/src/job.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use redis::aio::ConnectionManager;
 use serde::de::DeserializeOwned;
@@ -640,5 +641,35 @@ impl<T: Serialize + DeserializeOwned> Job<T> {
             self.priority,
         )
         .await
+    }
+
+    /// Wait until this job is finished (completed or failed).
+    ///
+    /// **Not yet implemented.** Requires QueueEvents subsystem.
+    pub async fn wait_until_finished(
+        &self,
+        _ttl: Option<Duration>,
+    ) -> BullmqResult<serde_json::Value> {
+        Err(BullmqError::NotImplemented(
+            "waitUntilFinished requires QueueEvents (not yet implemented)".into(),
+        ))
+    }
+
+    /// Get this job's dependencies.
+    ///
+    /// **Not yet implemented.** Requires Flows subsystem.
+    pub async fn get_dependencies(&self) -> BullmqResult<serde_json::Value> {
+        Err(BullmqError::NotImplemented(
+            "getDependencies requires Flows (not yet implemented)".into(),
+        ))
+    }
+
+    /// Get the return values of this job's children.
+    ///
+    /// **Not yet implemented.** Requires Flows subsystem.
+    pub async fn get_children_values(&self) -> BullmqResult<serde_json::Value> {
+        Err(BullmqError::NotImplemented(
+            "getChildrenValues requires Flows (not yet implemented)".into(),
+        ))
     }
 }

--- a/src/job.rs
+++ b/src/job.rs
@@ -8,8 +8,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::{BullmqError, BullmqResult};
 use crate::queue_events::{QueueEvent, QueueEvents};
-use crate::scripts::ScriptLoader;
 use crate::scripts::commands::key as build_key;
+use crate::scripts::ScriptLoader;
 use crate::types::{JobOptions, JobState};
 
 /// Returns the current time as milliseconds since the Unix epoch.
@@ -162,7 +162,10 @@ impl<T: Serialize + DeserializeOwned> Job<T> {
             fields.push(("returnvalue".into(), serde_json::to_string(val)?));
         }
         if !self.stacktrace.is_empty() {
-            fields.push(("stacktrace".into(), serde_json::to_string(&self.stacktrace)?));
+            fields.push((
+                "stacktrace".into(),
+                serde_json::to_string(&self.stacktrace)?,
+            ));
         }
         if let Some(ref pb) = self.processed_by {
             fields.push(("pb".into(), pb.clone()));
@@ -177,9 +180,8 @@ impl<T: Serialize + DeserializeOwned> Job<T> {
     /// (e.g., `stc` for stalled counter, managed by Lua scripts).
     pub fn from_redis_hash(id: &str, map: &HashMap<String, String>) -> BullmqResult<Self> {
         let get = |key: &str| -> BullmqResult<&String> {
-            map.get(key).ok_or_else(|| {
-                BullmqError::Other(format!("Missing field '{}' in job hash", key))
-            })
+            map.get(key)
+                .ok_or_else(|| BullmqError::Other(format!("Missing field '{}' in job hash", key)))
         };
 
         let data: T = serde_json::from_str(get("data")?)?;
@@ -231,10 +233,9 @@ impl<T: Serialize + DeserializeOwned> Job<T> {
             .map(|s| s.parse::<u64>())
             .transpose()
             .map_err(|_| BullmqError::Other("Invalid finishedOn".into()))?;
-        let failed_reason = map
-            .get("failedReason")
-            .map(|s| serde_json::from_str(s))
-            .transpose()?;
+        let failed_reason = map.get("failedReason").map(|s| {
+            serde_json::from_str(s).unwrap_or_else(|_| s.clone())
+        });
         let return_value = map
             .get("returnvalue")
             .map(|s| serde_json::from_str(s))
@@ -600,7 +601,11 @@ impl<T: Serialize + DeserializeOwned> Job<T> {
 
         self.priority = priority;
         self.opts.priority = if priority > 0 { Some(priority) } else { None };
-        self.state = if priority > 0 { JobState::Prioritized } else { JobState::Wait };
+        self.state = if priority > 0 {
+            JobState::Prioritized
+        } else {
+            JobState::Wait
+        };
         Ok(())
     }
 
@@ -673,7 +678,10 @@ impl<T: Serialize + DeserializeOwned> Job<T> {
         let mut rx = queue_events.subscribe();
 
         // 2. Race condition guard: check if already finished.
-        if let Some(result) = self.check_finished(&mut conn, &ctx.prefix, &ctx.queue_name, &job_id).await? {
+        if let Some(result) = self
+            .check_finished(&mut conn, &ctx.prefix, &ctx.queue_name, &job_id)
+            .await?
+        {
             return result;
         }
 
@@ -681,16 +689,31 @@ impl<T: Serialize + DeserializeOwned> Job<T> {
         let wait_fut = async {
             loop {
                 match rx.recv().await {
-                    Ok((QueueEvent::Completed { job_id: eid, return_value }, _)) if eid == job_id => {
+                    Ok((
+                        QueueEvent::Completed {
+                            job_id: eid,
+                            return_value,
+                        },
+                        _,
+                    )) if eid == job_id => {
                         return Ok(return_value);
                     }
-                    Ok((QueueEvent::Failed { job_id: eid, reason }, _)) if eid == job_id => {
+                    Ok((
+                        QueueEvent::Failed {
+                            job_id: eid,
+                            reason,
+                        },
+                        _,
+                    )) if eid == job_id => {
                         return Err(BullmqError::Other(reason));
                     }
                     Ok(_) => continue,
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
                         // Missed events — fall back to Redis check.
-                        if let Some(result) = self.check_finished(&mut conn, &ctx.prefix, &ctx.queue_name, &job_id).await? {
+                        if let Some(result) = self
+                            .check_finished(&mut conn, &ctx.prefix, &ctx.queue_name, &job_id)
+                            .await?
+                        {
                             return result;
                         }
                         continue;
@@ -703,11 +726,9 @@ impl<T: Serialize + DeserializeOwned> Job<T> {
         };
 
         match ttl {
-            Some(duration) => {
-                tokio::time::timeout(duration, wait_fut)
-                    .await
-                    .unwrap_or(Err(BullmqError::Other("Job wait timed out".into())))
-            }
+            Some(duration) => tokio::time::timeout(duration, wait_fut)
+                .await
+                .unwrap_or(Err(BullmqError::Other("Job wait timed out".into()))),
             None => wait_fut.await,
         }
     }

--- a/src/job.rs
+++ b/src/job.rs
@@ -481,4 +481,116 @@ impl<T: Serialize + DeserializeOwned> Job<T> {
     pub async fn is_prioritized(&mut self) -> BullmqResult<bool> {
         Ok(self.get_state().await? == JobState::Prioritized)
     }
+
+    /// Remove this job from the queue.
+    ///
+    /// Removes the job ID from all state lists/sets and deletes the job hash,
+    /// lock key, and logs key. Not atomic (multiple Redis commands).
+    pub async fn remove(&self) -> BullmqResult<()> {
+        let ctx = self.ctx()?;
+        let mut conn = ctx.conn.clone();
+        let job_id = &self.id;
+
+        // Remove from lists (LREM)
+        for suffix in &["wait", "active", "paused"] {
+            let key = build_key(&ctx.prefix, &ctx.queue_name, suffix);
+            redis::cmd("LREM")
+                .arg(&key)
+                .arg(0i64)
+                .arg(job_id)
+                .query_async::<i64>(&mut conn)
+                .await?;
+        }
+
+        // Remove from sorted sets (ZREM)
+        for suffix in &["prioritized", "delayed", "completed", "failed"] {
+            let key = build_key(&ctx.prefix, &ctx.queue_name, suffix);
+            redis::cmd("ZREM")
+                .arg(&key)
+                .arg(job_id)
+                .query_async::<i64>(&mut conn)
+                .await?;
+        }
+
+        // Delete the job hash, lock key, and logs key
+        let job_key = self.queue_key(job_id)?;
+        let lock_key = format!("{}:lock", job_key);
+        let logs_key = format!("{}:logs", job_key);
+        redis::cmd("DEL")
+            .arg(&job_key)
+            .arg(&lock_key)
+            .arg(&logs_key)
+            .query_async::<i64>(&mut conn)
+            .await?;
+
+        Ok(())
+    }
+
+    /// Move this active job back to delayed with a new delay.
+    ///
+    /// Only valid when the job is active and has a lock token (inside a worker handler).
+    pub async fn change_delay(&mut self, delay_ms: u64) -> BullmqResult<()> {
+        if self.state != JobState::Active {
+            return Err(BullmqError::Other(format!(
+                "change_delay requires job to be active, but job {} is in state {}",
+                self.id, self.state
+            )));
+        }
+
+        let token = self.lock_token.as_deref().ok_or_else(|| {
+            BullmqError::Other(
+                "change_delay requires a lock token (only available in worker handler)".into(),
+            )
+        })?;
+
+        let ctx = self.ctx()?;
+        let mut conn = ctx.conn.clone();
+        let timestamp = now_ms();
+        let delayed_timestamp = timestamp + delay_ms;
+
+        crate::scripts::commands::move_to_delayed::move_to_delayed(
+            &ctx.scripts,
+            &mut conn,
+            &ctx.prefix,
+            &ctx.queue_name,
+            &self.id,
+            token,
+            timestamp,
+            delayed_timestamp,
+            10_000,
+            self.attempts_made,
+        )
+        .await?;
+
+        self.delay = delay_ms;
+        Ok(())
+    }
+
+    /// Retry this active job by moving it back to wait or prioritized.
+    ///
+    /// Only works on active jobs with a lock token (inside a worker handler).
+    pub async fn retry(&self) -> BullmqResult<()> {
+        let token = self.lock_token.as_deref().ok_or_else(|| {
+            BullmqError::Other(
+                "retry requires a lock token (only available in worker handler)".into(),
+            )
+        })?;
+
+        let ctx = self.ctx()?;
+        let mut conn = ctx.conn.clone();
+
+        crate::scripts::commands::retry_job::retry_job(
+            &ctx.scripts,
+            &mut conn,
+            &ctx.prefix,
+            &ctx.queue_name,
+            &self.id,
+            token,
+            "RPUSH",
+            10_000,
+            self.attempts_made,
+            self.priority,
+        )
+        .await
+    }
 }

--- a/src/job.rs
+++ b/src/job.rs
@@ -7,6 +7,7 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
 use crate::error::{BullmqError, BullmqResult};
+use crate::queue_events::{QueueEvent, QueueEvents};
 use crate::scripts::ScriptLoader;
 use crate::scripts::commands::key as build_key;
 use crate::types::{JobOptions, JobState};
@@ -655,14 +656,110 @@ impl<T: Serialize + DeserializeOwned> Job<T> {
 
     /// Wait until this job is finished (completed or failed).
     ///
-    /// **Not yet implemented.** Requires QueueEvents subsystem.
+    /// Subscribes to the QueueEvents broadcast channel and filters for
+    /// matching Completed/Failed events. Also checks Redis immediately
+    /// for the race condition where the job already finished before
+    /// subscribing.
     pub async fn wait_until_finished(
         &self,
-        _ttl: Option<Duration>,
+        queue_events: &QueueEvents,
+        ttl: Option<Duration>,
     ) -> BullmqResult<serde_json::Value> {
-        Err(BullmqError::NotImplemented(
-            "waitUntilFinished requires QueueEvents (not yet implemented)".into(),
-        ))
+        let ctx = self.ctx()?;
+        let mut conn = ctx.conn.clone();
+        let job_id = self.id.clone();
+
+        // 1. Subscribe first (before checking Redis) to avoid missing events.
+        let mut rx = queue_events.subscribe();
+
+        // 2. Race condition guard: check if already finished.
+        if let Some(result) = self.check_finished(&mut conn, &ctx.prefix, &ctx.queue_name, &job_id).await? {
+            return result;
+        }
+
+        // 3. Wait for matching event with optional timeout.
+        let wait_fut = async {
+            loop {
+                match rx.recv().await {
+                    Ok((QueueEvent::Completed { job_id: eid, return_value }, _)) if eid == job_id => {
+                        return Ok(return_value);
+                    }
+                    Ok((QueueEvent::Failed { job_id: eid, reason }, _)) if eid == job_id => {
+                        return Err(BullmqError::Other(reason));
+                    }
+                    Ok(_) => continue,
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
+                        // Missed events — fall back to Redis check.
+                        if let Some(result) = self.check_finished(&mut conn, &ctx.prefix, &ctx.queue_name, &job_id).await? {
+                            return result;
+                        }
+                        continue;
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        return Err(BullmqError::Other("QueueEvents closed".into()));
+                    }
+                }
+            }
+        };
+
+        match ttl {
+            Some(duration) => {
+                tokio::time::timeout(duration, wait_fut)
+                    .await
+                    .unwrap_or(Err(BullmqError::Other("Job wait timed out".into())))
+            }
+            None => wait_fut.await,
+        }
+    }
+
+    /// Check Redis to see if this job is already in completed or failed state.
+    async fn check_finished(
+        &self,
+        conn: &mut ConnectionManager,
+        prefix: &str,
+        queue_name: &str,
+        job_id: &str,
+    ) -> BullmqResult<Option<BullmqResult<serde_json::Value>>> {
+        let completed_key = build_key(prefix, queue_name, "completed");
+        let failed_key = build_key(prefix, queue_name, "failed");
+        let job_key = build_key(prefix, queue_name, job_id);
+
+        // Check completed
+        let score: Option<f64> = redis::cmd("ZSCORE")
+            .arg(&completed_key)
+            .arg(job_id)
+            .query_async(conn)
+            .await?;
+        if score.is_some() {
+            let rv: Option<String> = redis::cmd("HGET")
+                .arg(&job_key)
+                .arg("returnvalue")
+                .query_async(conn)
+                .await?;
+            let value = rv
+                .and_then(|s| serde_json::from_str(&s).ok())
+                .unwrap_or(serde_json::Value::Null);
+            return Ok(Some(Ok(value)));
+        }
+
+        // Check failed
+        let score: Option<f64> = redis::cmd("ZSCORE")
+            .arg(&failed_key)
+            .arg(job_id)
+            .query_async(conn)
+            .await?;
+        if score.is_some() {
+            let reason: Option<String> = redis::cmd("HGET")
+                .arg(&job_key)
+                .arg("failedReason")
+                .query_async(conn)
+                .await?;
+            // failedReason is stored as a plain string in Redis, not JSON-encoded.
+            let reason = reason.unwrap_or_else(|| "Unknown failure".to_string());
+            return Ok(Some(Err(BullmqError::Other(reason))));
+        }
+
+        Ok(None)
     }
 
     /// Get this job's dependencies.

--- a/src/job.rs
+++ b/src/job.rs
@@ -287,4 +287,91 @@ impl<T: Serialize + DeserializeOwned> Job<T> {
         let ctx = self.ctx()?;
         Ok(build_key(&ctx.prefix, &ctx.queue_name, suffix))
     }
+
+    /// Update the job's progress in Redis and locally.
+    pub async fn update_progress(&mut self, progress: serde_json::Value) -> BullmqResult<()> {
+        let ctx = self.ctx()?;
+        let mut conn = ctx.conn.clone();
+        let job_key = self.queue_key(&self.id)?;
+        let events_key = self.queue_key("events")?;
+
+        let progress_json = serde_json::to_string(&progress)?;
+
+        redis::cmd("HSET")
+            .arg(&job_key)
+            .arg("progress")
+            .arg(&progress_json)
+            .query_async::<i64>(&mut conn)
+            .await?;
+
+        redis::cmd("XADD")
+            .arg(&events_key)
+            .arg("MAXLEN")
+            .arg("~")
+            .arg(10_000u64)
+            .arg("*")
+            .arg("event")
+            .arg("progress")
+            .arg("jobId")
+            .arg(&self.id)
+            .arg("data")
+            .arg(&progress_json)
+            .query_async::<String>(&mut conn)
+            .await?;
+
+        self.progress = Some(progress);
+        Ok(())
+    }
+
+    /// Append a log line to this job's log list in Redis.
+    ///
+    /// Returns the total log count after insertion.
+    pub async fn log(&self, row: &str) -> BullmqResult<u64> {
+        let ctx = self.ctx()?;
+        let mut conn = ctx.conn.clone();
+        crate::scripts::commands::add_log::add_log(
+            &ctx.scripts,
+            &mut conn,
+            &ctx.prefix,
+            &ctx.queue_name,
+            &self.id,
+            row,
+            0,
+        )
+        .await
+    }
+
+    /// Update the job's data payload in Redis and locally.
+    pub async fn update_data(&mut self, data: T) -> BullmqResult<()> {
+        let ctx = self.ctx()?;
+        let mut conn = ctx.conn.clone();
+        let job_key = self.queue_key(&self.id)?;
+
+        let data_json = serde_json::to_string(&data)?;
+
+        redis::cmd("HSET")
+            .arg(&job_key)
+            .arg("data")
+            .arg(&data_json)
+            .query_async::<i64>(&mut conn)
+            .await?;
+
+        self.data = data;
+        Ok(())
+    }
+
+    /// Delete all log entries for this job from Redis.
+    pub async fn clear_logs(&self) -> BullmqResult<()> {
+        let ctx = self.ctx()?;
+        let mut conn = ctx.conn.clone();
+        let job_key = self.queue_key(&self.id)?;
+        let logs_key = format!("{}:logs", job_key);
+
+        redis::cmd("DEL")
+            .arg(&logs_key)
+            .query_async::<i64>(&mut conn)
+            .await?;
+
+        Ok(())
+    }
 }

--- a/src/job.rs
+++ b/src/job.rs
@@ -1,9 +1,13 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
+use redis::aio::ConnectionManager;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
 use crate::error::{BullmqError, BullmqResult};
+use crate::scripts::ScriptLoader;
+use crate::scripts::commands::key as build_key;
 use crate::types::{JobOptions, JobState};
 
 /// Returns the current time as milliseconds since the Unix epoch.
@@ -12,6 +16,24 @@ fn now_ms() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
         .as_millis() as u64
+}
+
+/// Connection context injected by Queue/Worker. Enables active-handle methods
+/// on Job instances (update_progress, log, change_delay, etc.).
+pub(crate) struct JobContext {
+    pub conn: ConnectionManager,
+    pub scripts: Arc<ScriptLoader>,
+    pub prefix: String,
+    pub queue_name: String,
+}
+
+impl std::fmt::Debug for JobContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("JobContext")
+            .field("prefix", &self.prefix)
+            .field("queue_name", &self.queue_name)
+            .finish_non_exhaustive()
+    }
 }
 
 /// A job with a typed data payload.
@@ -58,6 +80,12 @@ pub struct Job<T> {
     pub return_value: Option<serde_json::Value>,
     /// Identifier of the worker that processed this job. Maps to "pb" in the Redis hash.
     pub processed_by: Option<String>,
+    /// Connection context injected by Queue/Worker. None for manually-created jobs.
+    #[serde(skip)]
+    pub(crate) ctx: Option<Arc<JobContext>>,
+    /// Lock token assigned by the worker. Used by active-handle methods.
+    #[serde(skip)]
+    pub(crate) lock_token: Option<String>,
 }
 
 impl<T: Serialize + DeserializeOwned> Job<T> {
@@ -88,6 +116,8 @@ impl<T: Serialize + DeserializeOwned> Job<T> {
             stacktrace: Vec::new(),
             return_value: None,
             processed_by: None,
+            ctx: None,
+            lock_token: None,
         }
     }
 
@@ -238,6 +268,23 @@ impl<T: Serialize + DeserializeOwned> Job<T> {
             stacktrace,
             return_value,
             processed_by,
+            ctx: None,
+            lock_token: None,
         })
+    }
+
+    /// Get the connection context, or error if this job was created without one.
+    fn ctx(&self) -> BullmqResult<&JobContext> {
+        self.ctx.as_ref().map(|arc| arc.as_ref()).ok_or_else(|| {
+            BullmqError::Other(
+                "Job has no connection context (created outside a Queue/Worker)".into(),
+            )
+        })
+    }
+
+    /// Build a Redis key for this job's queue.
+    fn queue_key(&self, suffix: &str) -> BullmqResult<String> {
+        let ctx = self.ctx()?;
+        Ok(build_key(&ctx.prefix, &ctx.queue_name, suffix))
     }
 }

--- a/src/job.rs
+++ b/src/job.rs
@@ -233,9 +233,9 @@ impl<T: Serialize + DeserializeOwned> Job<T> {
             .map(|s| s.parse::<u64>())
             .transpose()
             .map_err(|_| BullmqError::Other("Invalid finishedOn".into()))?;
-        let failed_reason = map.get("failedReason").map(|s| {
-            serde_json::from_str(s).unwrap_or_else(|_| s.clone())
-        });
+        let failed_reason = map
+            .get("failedReason")
+            .map(|s| serde_json::from_str(s).unwrap_or_else(|_| s.clone()));
         let return_value = map
             .get("returnvalue")
             .map(|s| serde_json::from_str(s))
@@ -767,8 +767,7 @@ impl<T: Serialize + DeserializeOwned> Job<T> {
         let processed = processed_raw
             .into_iter()
             .map(|(job_key, value)| {
-                let parsed =
-                    serde_json::from_str(&value).unwrap_or(serde_json::Value::Null);
+                let parsed = serde_json::from_str(&value).unwrap_or(serde_json::Value::Null);
                 (job_key, parsed)
             })
             .collect();
@@ -780,9 +779,7 @@ impl<T: Serialize + DeserializeOwned> Job<T> {
     }
 
     /// Get the return values of this job's children.
-    pub async fn get_children_values(
-        &self,
-    ) -> BullmqResult<HashMap<String, serde_json::Value>> {
+    pub async fn get_children_values(&self) -> BullmqResult<HashMap<String, serde_json::Value>> {
         Ok(self.get_dependencies().await?.processed)
     }
 }

--- a/src/job.rs
+++ b/src/job.rs
@@ -10,7 +10,7 @@ use crate::error::{BullmqError, BullmqResult};
 use crate::queue_events::{QueueEvent, QueueEvents};
 use crate::scripts::commands::key as build_key;
 use crate::scripts::ScriptLoader;
-use crate::types::{JobOptions, JobState};
+use crate::types::{JobDependencies, JobOptions, JobState};
 
 /// Returns the current time as milliseconds since the Unix epoch.
 fn now_ms() -> u64 {
@@ -749,22 +749,41 @@ impl<T: Serialize + DeserializeOwned> Job<T> {
         Ok(None)
     }
 
-    /// Get this job's dependencies.
-    ///
-    /// **Not yet implemented.** Requires Flows subsystem.
-    pub async fn get_dependencies(&self) -> BullmqResult<serde_json::Value> {
-        Err(BullmqError::NotImplemented(
-            "getDependencies requires Flows (not yet implemented)".into(),
-        ))
+    /// Get this job's dependencies, split into processed and unprocessed sets.
+    pub async fn get_dependencies(&self) -> BullmqResult<JobDependencies> {
+        let ctx = self.ctx()?;
+        let mut conn = ctx.conn.clone();
+        let job_key = self.queue_key(&self.id)?;
+
+        let processed_raw: HashMap<String, String> = redis::cmd("HGETALL")
+            .arg(format!("{job_key}:processed"))
+            .query_async(&mut conn)
+            .await?;
+        let unprocessed: Vec<String> = redis::cmd("SMEMBERS")
+            .arg(format!("{job_key}:dependencies"))
+            .query_async(&mut conn)
+            .await?;
+
+        let processed = processed_raw
+            .into_iter()
+            .map(|(job_key, value)| {
+                let parsed =
+                    serde_json::from_str(&value).unwrap_or(serde_json::Value::Null);
+                (job_key, parsed)
+            })
+            .collect();
+
+        Ok(JobDependencies {
+            processed,
+            unprocessed,
+        })
     }
 
     /// Get the return values of this job's children.
-    ///
-    /// **Not yet implemented.** Requires Flows subsystem.
-    pub async fn get_children_values(&self) -> BullmqResult<serde_json::Value> {
-        Err(BullmqError::NotImplemented(
-            "getChildrenValues requires Flows (not yet implemented)".into(),
-        ))
+    pub async fn get_children_values(
+        &self,
+    ) -> BullmqResult<HashMap<String, serde_json::Value>> {
+        Ok(self.get_dependencies().await?.processed)
     }
 }
 

--- a/src/job.rs
+++ b/src/job.rs
@@ -374,4 +374,111 @@ impl<T: Serialize + DeserializeOwned> Job<T> {
 
         Ok(())
     }
+
+    /// Query Redis to determine the current state of this job.
+    ///
+    /// Checks key membership in BullMQ order: completed, failed, delayed,
+    /// active, wait, paused, prioritized, waiting-children.
+    /// Lists use LPOS (O(N), Redis 6.0.6+), sorted sets use ZSCORE (O(log N)).
+    pub async fn get_state(&mut self) -> BullmqResult<JobState> {
+        let ctx = self.ctx()?;
+        let mut conn = ctx.conn.clone();
+        let job_id = self.id.clone();
+
+        // Sorted sets: use ZSCORE
+        let checks_zset: &[(JobState, &str)] = &[
+            (JobState::Completed, "completed"),
+            (JobState::Failed, "failed"),
+            (JobState::Delayed, "delayed"),
+        ];
+        for (state, suffix) in checks_zset {
+            let key = build_key(&ctx.prefix, &ctx.queue_name, suffix);
+            let score: Option<f64> = redis::cmd("ZSCORE")
+                .arg(&key)
+                .arg(&job_id)
+                .query_async(&mut conn)
+                .await?;
+            if score.is_some() {
+                self.state = *state;
+                return Ok(*state);
+            }
+        }
+
+        // Lists: use LPOS (Redis 6.0.6+)
+        let checks_list: &[(JobState, &str)] = &[
+            (JobState::Active, "active"),
+            (JobState::Wait, "wait"),
+            (JobState::Paused, "paused"),
+        ];
+        for (state, suffix) in checks_list {
+            let key = build_key(&ctx.prefix, &ctx.queue_name, suffix);
+            let pos: redis::Value = redis::cmd("LPOS")
+                .arg(&key)
+                .arg(&job_id)
+                .query_async(&mut conn)
+                .await?;
+            if !matches!(pos, redis::Value::Nil) {
+                self.state = *state;
+                return Ok(*state);
+            }
+        }
+
+        // Sorted set: prioritized
+        {
+            let key = build_key(&ctx.prefix, &ctx.queue_name, "prioritized");
+            let score: Option<f64> = redis::cmd("ZSCORE")
+                .arg(&key)
+                .arg(&job_id)
+                .query_async(&mut conn)
+                .await?;
+            if score.is_some() {
+                self.state = JobState::Prioritized;
+                return Ok(JobState::Prioritized);
+            }
+        }
+
+        // Sorted set: waiting-children
+        {
+            let key = build_key(&ctx.prefix, &ctx.queue_name, "waiting-children");
+            let score: Option<f64> = redis::cmd("ZSCORE")
+                .arg(&key)
+                .arg(&job_id)
+                .query_async(&mut conn)
+                .await?;
+            if score.is_some() {
+                self.state = JobState::WaitingChildren;
+                return Ok(JobState::WaitingChildren);
+            }
+        }
+
+        Err(BullmqError::JobNotFound(self.id.clone()))
+    }
+
+    pub async fn is_completed(&mut self) -> BullmqResult<bool> {
+        Ok(self.get_state().await? == JobState::Completed)
+    }
+
+    pub async fn is_failed(&mut self) -> BullmqResult<bool> {
+        Ok(self.get_state().await? == JobState::Failed)
+    }
+
+    pub async fn is_delayed(&mut self) -> BullmqResult<bool> {
+        Ok(self.get_state().await? == JobState::Delayed)
+    }
+
+    pub async fn is_active(&mut self) -> BullmqResult<bool> {
+        Ok(self.get_state().await? == JobState::Active)
+    }
+
+    pub async fn is_waiting(&mut self) -> BullmqResult<bool> {
+        Ok(self.get_state().await? == JobState::Wait)
+    }
+
+    pub async fn is_paused(&mut self) -> BullmqResult<bool> {
+        Ok(self.get_state().await? == JobState::Paused)
+    }
+
+    pub async fn is_prioritized(&mut self) -> BullmqResult<bool> {
+        Ok(self.get_state().await? == JobState::Prioritized)
+    }
 }

--- a/src/job.rs
+++ b/src/job.rs
@@ -296,6 +296,15 @@ impl<T: Serialize + DeserializeOwned> Job<T> {
         let job_key = self.queue_key(&self.id)?;
         let events_key = self.queue_key("events")?;
 
+        // Check job still exists to avoid creating orphan hashes
+        let exists: bool = redis::cmd("EXISTS")
+            .arg(&job_key)
+            .query_async(&mut conn)
+            .await?;
+        if !exists {
+            return Err(BullmqError::JobNotFound(self.id.clone()));
+        }
+
         let progress_json = serde_json::to_string(&progress)?;
 
         redis::cmd("HSET")
@@ -590,6 +599,7 @@ impl<T: Serialize + DeserializeOwned> Job<T> {
 
         self.priority = priority;
         self.opts.priority = if priority > 0 { Some(priority) } else { None };
+        self.state = if priority > 0 { JobState::Prioritized } else { JobState::Wait };
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,14 +33,14 @@ pub mod types;
 pub mod job;
 pub(crate) mod scripts;
 
-// These modules are temporarily disabled during the v2 rewrite.
-// They depend on old type signatures that are being replaced.
-#[cfg(any())]
 pub mod queue;
+
+// Worker module is temporarily disabled during the v2 rewrite.
 #[cfg(any())]
 pub mod worker;
 
 pub use connection::RedisConnection;
 pub use error::{BullmqError, BullmqResult};
 pub use job::Job;
+pub use queue::{Queue, QueueBuilder};
 pub use types::{BackoffStrategy, JobOptions, JobState, WorkerOptions};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub mod error;
 pub mod types;
 
 pub mod job;
+pub(crate) mod scripts;
 
 // These modules are temporarily disabled during the v2 rewrite.
 // They depend on old type signatures that are being replaced.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,10 +30,10 @@ pub mod connection;
 pub mod error;
 pub mod types;
 
-// These modules are temporarily disabled during the v2 rewrite.
-// They depend on chrono and old type signatures that are being replaced.
-#[cfg(any())]
 pub mod job;
+
+// These modules are temporarily disabled during the v2 rewrite.
+// They depend on old type signatures that are being replaced.
 #[cfg(any())]
 pub mod queue;
 #[cfg(any())]
@@ -41,4 +41,5 @@ pub mod worker;
 
 pub use connection::RedisConnection;
 pub use error::{BullmqError, BullmqResult};
+pub use job::Job;
 pub use types::{BackoffStrategy, JobOptions, JobState, WorkerOptions};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,6 @@ pub use connection::RedisConnection;
 pub use error::{BullmqError, BullmqResult};
 pub use job::Job;
 pub use queue::{Queue, QueueBuilder};
-pub use queue_events::QueueEvent;
+pub use queue_events::{QueueEvent, QueueEvents, QueueEventsBuilder};
 pub use types::{BackoffStrategy, JobOptions, JobState, WorkerOptions};
 pub use worker::{Worker, WorkerBuilder, WorkerHandle};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@
 
 pub mod connection;
 pub mod error;
+pub mod flow_producer;
 pub mod types;
 
 pub mod job;
@@ -71,9 +72,10 @@ pub mod worker;
 
 pub use connection::RedisConnection;
 pub use error::{BullmqError, BullmqResult};
+pub use flow_producer::{FlowJob, FlowNode, FlowProducer, FlowProducerBuilder};
 pub use job::Job;
 pub use queue::{Queue, QueueBuilder};
 pub use queue_events::{QueueEvent, QueueEvents, QueueEventsBuilder};
 pub use queue_events_producer::{QueueEventsProducer, QueueEventsProducerBuilder};
-pub use types::{BackoffStrategy, JobOptions, JobState, WorkerOptions};
+pub use types::{BackoffStrategy, JobDependencies, JobOptions, JobState, WorkerOptions};
 pub use worker::{Worker, WorkerBuilder, WorkerHandle};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,8 +35,6 @@ pub(crate) mod scripts;
 
 pub mod queue;
 
-// Worker module is temporarily disabled during the v2 rewrite.
-#[cfg(any())]
 pub mod worker;
 
 pub use connection::RedisConnection;
@@ -44,3 +42,4 @@ pub use error::{BullmqError, BullmqResult};
 pub use job::Job;
 pub use queue::{Queue, QueueBuilder};
 pub use types::{BackoffStrategy, JobOptions, JobState, WorkerOptions};
+pub use worker::{Worker, WorkerBuilder, WorkerHandle};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@ pub mod job;
 pub(crate) mod scripts;
 
 pub mod queue;
+pub mod queue_events;
 
 pub mod worker;
 
@@ -71,5 +72,6 @@ pub use connection::RedisConnection;
 pub use error::{BullmqError, BullmqResult};
 pub use job::Job;
 pub use queue::{Queue, QueueBuilder};
+pub use queue_events::QueueEvent;
 pub use types::{BackoffStrategy, JobOptions, JobState, WorkerOptions};
 pub use worker::{Worker, WorkerBuilder, WorkerHandle};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //! ## Quick Start
 //!
 //! ```rust,no_run
-//! use bullmq_rs::{Queue, QueueBuilder, Worker, WorkerBuilder, RedisConnection, JobOptions};
+//! use bullmq_rs::{RedisConnection, JobOptions};
 //! use serde::{Serialize, Deserialize};
 //! use std::time::Duration;
 //!
@@ -21,49 +21,24 @@
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     let conn = RedisConnection::new("redis://127.0.0.1:6379");
-//!
-//!     // Create a typed queue
-//!     let queue: Queue<Email> = QueueBuilder::new("emails")
-//!         .connection(conn.clone())
-//!         .build()
-//!         .await?;
-//!
-//!     // Add a job
-//!     queue.add("welcome", Email {
-//!         to: "user@example.com".into(),
-//!         subject: "Welcome!".into(),
-//!         body: "Hello and welcome.".into(),
-//!     }, None).await?;
-//!
-//!     // Create a worker to process jobs
-//!     let worker: Worker<Email> = WorkerBuilder::new("emails")
-//!         .connection(conn)
-//!         .concurrency(3)
-//!         .build()
-//!         .await?;
-//!
-//!     let handle = worker.start(|job| async move {
-//!         println!("Sending email to {}", job.data.to);
-//!         Ok(())
-//!     }).await?;
-//!
-//!     // Graceful shutdown
-//!     handle.shutdown();
-//!     handle.wait().await?;
+//!     // Queue, Worker, and Job APIs are being rewritten for v2 wire compatibility.
 //!     Ok(())
 //! }
 //! ```
 
 pub mod connection;
 pub mod error;
-pub mod job;
-pub mod queue;
 pub mod types;
+
+// These modules are temporarily disabled during the v2 rewrite.
+// They depend on chrono and old type signatures that are being replaced.
+#[cfg(any())]
+pub mod job;
+#[cfg(any())]
+pub mod queue;
+#[cfg(any())]
 pub mod worker;
 
 pub use connection::RedisConnection;
 pub use error::{BullmqError, BullmqResult};
-pub use job::Job;
-pub use queue::{Queue, QueueBuilder};
 pub use types::{BackoffStrategy, JobOptions, JobState, WorkerOptions};
-pub use worker::{Worker, WorkerBuilder, WorkerHandle};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,10 +4,13 @@
 //! distributed job queue with support for priorities, delays, retries with
 //! backoff, concurrency control, and typed job payloads.
 //!
+//! Wire-compatible with BullMQ Node.js v5.x — jobs created by this crate
+//! can be consumed by Node.js workers and vice versa.
+//!
 //! ## Quick Start
 //!
 //! ```rust,no_run
-//! use bullmq_rs::{RedisConnection, JobOptions};
+//! use bullmq_rs::{RedisConnection, QueueBuilder, WorkerBuilder, JobOptions};
 //! use serde::{Serialize, Deserialize};
 //! use std::time::Duration;
 //!
@@ -21,7 +24,34 @@
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     let conn = RedisConnection::new("redis://127.0.0.1:6379");
-//!     // Queue, Worker, and Job APIs are being rewritten for v2 wire compatibility.
+//!
+//!     // Create a queue
+//!     let queue = QueueBuilder::new("emails")
+//!         .connection(conn.clone())
+//!         .build::<Email>()
+//!         .await?;
+//!
+//!     // Add a job
+//!     queue.add("welcome", Email {
+//!         to: "user@example.com".into(),
+//!         subject: "Welcome!".into(),
+//!         body: "Thanks for signing up.".into(),
+//!     }, None).await?;
+//!
+//!     // Create and start a worker
+//!     let worker = WorkerBuilder::new("emails")
+//!         .connection(conn)
+//!         .concurrency(5)
+//!         .build::<Email>();
+//!
+//!     let handle = worker.start(|job| async move {
+//!         println!("Sending email to {}", job.data.to);
+//!         Ok(())
+//!     }).await?;
+//!
+//!     // Graceful shutdown
+//!     handle.shutdown();
+//!     handle.wait().await?;
 //!     Ok(())
 //! }
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@ pub(crate) mod scripts;
 
 pub mod queue;
 pub mod queue_events;
+pub mod queue_events_producer;
 
 pub mod worker;
 
@@ -73,5 +74,6 @@ pub use error::{BullmqError, BullmqResult};
 pub use job::Job;
 pub use queue::{Queue, QueueBuilder};
 pub use queue_events::{QueueEvent, QueueEvents, QueueEventsBuilder};
+pub use queue_events_producer::{QueueEventsProducer, QueueEventsProducerBuilder};
 pub use types::{BackoffStrategy, JobOptions, JobState, WorkerOptions};
 pub use worker::{Worker, WorkerBuilder, WorkerHandle};

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::marker::PhantomData;
 use std::sync::Arc;
 
@@ -55,6 +55,91 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + 'static> Queue<T> {
             prefix: self.prefix.clone(),
             queue_name: self.name.clone(),
         })
+    }
+
+    fn normalize_job_states(states: &[JobState]) -> Vec<JobState> {
+        let requested = if states.is_empty() {
+            vec![
+                JobState::Wait,
+                JobState::Active,
+                JobState::Delayed,
+                JobState::Prioritized,
+                JobState::Completed,
+                JobState::Failed,
+                JobState::WaitingChildren,
+            ]
+        } else {
+            states.to_vec()
+        };
+
+        let mut normalized = Vec::new();
+        let mut seen = HashSet::new();
+
+        for state in requested {
+            if seen.insert(state) {
+                normalized.push(state);
+            }
+
+            if state == JobState::Wait && seen.insert(JobState::Paused) {
+                normalized.push(JobState::Paused);
+            }
+        }
+
+        normalized
+    }
+
+    async fn get_job_ids(
+        &self,
+        state: JobState,
+        start: i64,
+        end: i64,
+        asc: bool,
+    ) -> BullmqResult<Vec<String>> {
+        let mut conn = self.conn.clone();
+
+        match state {
+            JobState::Wait | JobState::Active | JobState::Paused => {
+                let mut ids: Vec<String> = if asc {
+                    let modified_start = if start == -1 { 0 } else { -(start + 1) };
+                    let modified_end = if end == -1 { 0 } else { -(end + 1) };
+
+                    redis::cmd("LRANGE")
+                        .arg(self.key(&state.to_string()))
+                        .arg(modified_end)
+                        .arg(modified_start)
+                        .query_async(&mut conn)
+                        .await?
+                } else {
+                    redis::cmd("LRANGE")
+                        .arg(self.key(&state.to_string()))
+                        .arg(start)
+                        .arg(end)
+                        .query_async(&mut conn)
+                        .await?
+                };
+
+                if asc {
+                    ids.reverse();
+                }
+
+                Ok(ids)
+            }
+            JobState::Prioritized
+            | JobState::WaitingChildren
+            | JobState::Delayed
+            | JobState::Completed
+            | JobState::Failed => {
+                let command = if asc { "ZRANGE" } else { "ZREVRANGE" };
+                let ids: Vec<String> = redis::cmd(command)
+                    .arg(self.key(&state.to_string()))
+                    .arg(start)
+                    .arg(end)
+                    .query_async(&mut conn)
+                    .await?;
+
+                Ok(ids)
+            }
+        }
     }
 
     /// Add a job to the queue.
@@ -216,6 +301,139 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + 'static> Queue<T> {
         counts.insert(JobState::WaitingChildren, waiting_children);
 
         Ok(counts)
+    }
+
+    /// Total jobs waiting to be processed.
+    ///
+    /// Matches BullMQ Node.js `Queue.count()` by including wait, paused,
+    /// delayed, prioritized, and waiting-children.
+    pub async fn count(&self) -> BullmqResult<u64> {
+        let counts = self.get_job_counts().await?;
+
+        Ok(counts.get(&JobState::Wait).copied().unwrap_or(0)
+            + counts.get(&JobState::Paused).copied().unwrap_or(0)
+            + counts.get(&JobState::Delayed).copied().unwrap_or(0)
+            + counts.get(&JobState::Prioritized).copied().unwrap_or(0)
+            + counts.get(&JobState::WaitingChildren).copied().unwrap_or(0))
+    }
+
+    /// Number of jobs in the waiting state, including paused jobs.
+    pub async fn get_waiting_count(&self) -> BullmqResult<u64> {
+        let counts = self.get_job_counts().await?;
+
+        Ok(counts.get(&JobState::Wait).copied().unwrap_or(0)
+            + counts.get(&JobState::Paused).copied().unwrap_or(0))
+    }
+
+    /// Number of jobs in the active state.
+    pub async fn get_active_count(&self) -> BullmqResult<u64> {
+        let counts = self.get_job_counts().await?;
+        Ok(counts.get(&JobState::Active).copied().unwrap_or(0))
+    }
+
+    /// Number of jobs in the delayed state.
+    pub async fn get_delayed_count(&self) -> BullmqResult<u64> {
+        let counts = self.get_job_counts().await?;
+        Ok(counts.get(&JobState::Delayed).copied().unwrap_or(0))
+    }
+
+    /// Number of jobs in the completed state.
+    pub async fn get_completed_count(&self) -> BullmqResult<u64> {
+        let counts = self.get_job_counts().await?;
+        Ok(counts.get(&JobState::Completed).copied().unwrap_or(0))
+    }
+
+    /// Number of jobs in the failed state.
+    pub async fn get_failed_count(&self) -> BullmqResult<u64> {
+        let counts = self.get_job_counts().await?;
+        Ok(counts.get(&JobState::Failed).copied().unwrap_or(0))
+    }
+
+    /// Number of jobs in the prioritized state.
+    pub async fn get_prioritized_count(&self) -> BullmqResult<u64> {
+        let counts = self.get_job_counts().await?;
+        Ok(counts.get(&JobState::Prioritized).copied().unwrap_or(0))
+    }
+
+    /// Number of jobs in the waiting-children state.
+    pub async fn get_waiting_children_count(&self) -> BullmqResult<u64> {
+        let counts = self.get_job_counts().await?;
+        Ok(counts.get(&JobState::WaitingChildren).copied().unwrap_or(0))
+    }
+
+    /// Get jobs from one or more states with BullMQ-compatible ordering.
+    pub async fn get_jobs(
+        &self,
+        states: &[JobState],
+        start: i64,
+        end: i64,
+        asc: bool,
+    ) -> BullmqResult<Vec<Job<T>>> {
+        let query_states = Self::normalize_job_states(states);
+        let mut conn = self.conn.clone();
+        let ctx = self.job_context();
+        let mut seen = HashSet::new();
+        let mut jobs = Vec::new();
+
+        for state in query_states {
+            let job_ids = self.get_job_ids(state, start, end, asc).await?;
+
+            for job_id in job_ids {
+                if !seen.insert(job_id.clone()) {
+                    continue;
+                }
+
+                let map: HashMap<String, String> = conn.hgetall(self.key(&job_id)).await?;
+                if map.is_empty() {
+                    continue;
+                }
+
+                let mut job = Job::from_redis_hash(&job_id, &map)?;
+                job.state = state;
+                job.ctx = Some(ctx.clone());
+                jobs.push(job);
+            }
+        }
+
+        Ok(jobs)
+    }
+
+    /// Get waiting jobs, including paused jobs, oldest first.
+    pub async fn get_waiting(&self, start: i64, end: i64) -> BullmqResult<Vec<Job<T>>> {
+        self.get_jobs(&[JobState::Wait], start, end, true).await
+    }
+
+    /// Get active jobs, oldest first.
+    pub async fn get_active(&self, start: i64, end: i64) -> BullmqResult<Vec<Job<T>>> {
+        self.get_jobs(&[JobState::Active], start, end, true).await
+    }
+
+    /// Get delayed jobs, earliest scheduled first.
+    pub async fn get_delayed(&self, start: i64, end: i64) -> BullmqResult<Vec<Job<T>>> {
+        self.get_jobs(&[JobState::Delayed], start, end, true).await
+    }
+
+    /// Get prioritized jobs, highest priority first.
+    pub async fn get_prioritized(&self, start: i64, end: i64) -> BullmqResult<Vec<Job<T>>> {
+        self.get_jobs(&[JobState::Prioritized], start, end, true)
+            .await
+    }
+
+    /// Get completed jobs, newest first.
+    pub async fn get_completed(&self, start: i64, end: i64) -> BullmqResult<Vec<Job<T>>> {
+        self.get_jobs(&[JobState::Completed], start, end, false)
+            .await
+    }
+
+    /// Get failed jobs, newest first.
+    pub async fn get_failed(&self, start: i64, end: i64) -> BullmqResult<Vec<Job<T>>> {
+        self.get_jobs(&[JobState::Failed], start, end, false).await
+    }
+
+    /// Get waiting-children jobs, lowest score first.
+    pub async fn get_waiting_children(&self, start: i64, end: i64) -> BullmqResult<Vec<Job<T>>> {
+        self.get_jobs(&[JobState::WaitingChildren], start, end, true)
+            .await
     }
 
     /// Remove a job by its ID from all state lists/sets and delete its hash,

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::marker::PhantomData;
+use std::sync::Arc;
 
 use redis::aio::ConnectionManager;
 use redis::AsyncCommands;
@@ -9,7 +10,14 @@ use serde::Serialize;
 use crate::connection::RedisConnection;
 use crate::error::{BullmqError, BullmqResult};
 use crate::job::Job;
+use crate::scripts::commands::{
+    add_delayed_job, add_log, add_prioritized_job, add_standard_job, pause,
+};
+use crate::scripts::ScriptLoader;
 use crate::types::{JobOptions, JobState};
+
+/// Default maximum number of events to keep in the events stream.
+const DEFAULT_MAX_EVENTS: u64 = 10_000;
 
 /// A typed job queue backed by Redis.
 ///
@@ -37,11 +45,17 @@ pub struct Queue<T> {
     pub(crate) name: String,
     pub(crate) prefix: String,
     pub(crate) conn: ConnectionManager,
+    pub(crate) scripts: Arc<ScriptLoader>,
     _phantom: PhantomData<T>,
 }
 
 impl<T: Serialize + DeserializeOwned + Send + Sync + 'static> Queue<T> {
     /// Add a job to the queue.
+    ///
+    /// Dispatches to the appropriate Lua script based on job options:
+    /// - `delay > 0` uses `addDelayedJob`
+    /// - `priority > 0` uses `addPrioritizedJob`
+    /// - otherwise uses `addStandardJob`
     ///
     /// Returns the created job with its assigned ID.
     pub async fn add(
@@ -52,7 +66,7 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + 'static> Queue<T> {
     ) -> BullmqResult<Job<T>> {
         let mut conn = self.conn.clone();
 
-        // Generate job ID
+        // Generate job ID: custom if provided, otherwise INCR the id counter.
         let job_id: String = match opts.as_ref().and_then(|o| o.job_id.clone()) {
             Some(custom_id) => custom_id,
             None => {
@@ -66,46 +80,57 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + 'static> Queue<T> {
 
         let job = Job::new(job_id.clone(), name.to_string(), data, opts);
 
-        // Store job hash
-        let fields = job.to_redis_hash()?;
-        let job_key = self.key(&format!("{}", job_id));
-        redis::cmd("HSET")
-            .arg(&job_key)
-            .arg(&fields)
-            .query_async::<()>(&mut conn)
+        let data_json = serde_json::to_string(&job.data)?;
+        let opts_json = serde_json::to_string(&job.opts)?;
+        let timestamp = job.timestamp;
+
+        if job.delay > 0 {
+            // Delayed job: compute the delayed timestamp.
+            let delayed_timestamp = timestamp + job.delay;
+            add_delayed_job::add_delayed_job(
+                &self.scripts,
+                &mut conn,
+                &self.prefix,
+                &self.name,
+                &job_id,
+                name,
+                &data_json,
+                timestamp,
+                &opts_json,
+                DEFAULT_MAX_EVENTS,
+                delayed_timestamp,
+            )
             .await?;
-
-        // Add to appropriate sorted set
-        match job.state {
-            JobState::Delayed => {
-                let process_at = job.timestamp.timestamp_millis() + job.delay as i64;
-                redis::cmd("ZADD")
-                    .arg(self.key("delayed"))
-                    .arg(process_at)
-                    .arg(&job_id)
-                    .query_async::<()>(&mut conn)
-                    .await?;
-            }
-            _ => {
-                // Score: negate priority so lower priority values get processed first
-                let score = -(job.priority as f64);
-                redis::cmd("ZADD")
-                    .arg(self.key("waiting"))
-                    .arg(score)
-                    .arg(&job_id)
-                    .query_async::<()>(&mut conn)
-                    .await?;
-            }
-        }
-
-        // Set TTL on the job key if specified
-        if let Some(ttl) = job.ttl {
-            let ttl_secs = (ttl / 1000).max(1);
-            redis::cmd("EXPIRE")
-                .arg(&job_key)
-                .arg(ttl_secs)
-                .query_async::<()>(&mut conn)
-                .await?;
+        } else if job.priority > 0 {
+            // Prioritized job.
+            add_prioritized_job::add_prioritized_job(
+                &self.scripts,
+                &mut conn,
+                &self.prefix,
+                &self.name,
+                &job_id,
+                name,
+                &data_json,
+                timestamp,
+                &opts_json,
+                DEFAULT_MAX_EVENTS,
+            )
+            .await?;
+        } else {
+            // Standard job.
+            add_standard_job::add_standard_job(
+                &self.scripts,
+                &mut conn,
+                &self.prefix,
+                &self.name,
+                &job_id,
+                name,
+                &data_json,
+                timestamp,
+                &opts_json,
+                DEFAULT_MAX_EVENTS,
+            )
+            .await?;
         }
 
         Ok(job)
@@ -126,20 +151,35 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + 'static> Queue<T> {
     }
 
     /// Get the number of jobs in each state.
+    ///
+    /// Uses the correct Redis data structure for each BullMQ v5.x key:
+    /// - `wait` and `paused` and `active` are Lists (LLEN)
+    /// - `prioritized`, `delayed`, `completed`, `failed` are Sorted Sets (ZCARD)
     pub async fn get_job_counts(&self) -> BullmqResult<HashMap<JobState, u64>> {
         let mut conn = self.conn.clone();
         let mut counts = HashMap::new();
 
-        let waiting: u64 = redis::cmd("ZCARD")
-            .arg(self.key("waiting"))
+        // Lists: LLEN
+        let wait: u64 = redis::cmd("LLEN")
+            .arg(self.key("wait"))
+            .query_async(&mut conn)
+            .await?;
+        let paused: u64 = redis::cmd("LLEN")
+            .arg(self.key("paused"))
+            .query_async(&mut conn)
+            .await?;
+        let active: u64 = redis::cmd("LLEN")
+            .arg(self.key("active"))
+            .query_async(&mut conn)
+            .await?;
+
+        // Sorted sets: ZCARD
+        let prioritized: u64 = redis::cmd("ZCARD")
+            .arg(self.key("prioritized"))
             .query_async(&mut conn)
             .await?;
         let delayed: u64 = redis::cmd("ZCARD")
             .arg(self.key("delayed"))
-            .query_async(&mut conn)
-            .await?;
-        let active: u64 = redis::cmd("SCARD")
-            .arg(self.key("active"))
             .query_async(&mut conn)
             .await?;
         let completed: u64 = redis::cmd("ZCARD")
@@ -151,63 +191,108 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + 'static> Queue<T> {
             .query_async(&mut conn)
             .await?;
 
-        counts.insert(JobState::Waiting, waiting);
-        counts.insert(JobState::Delayed, delayed);
+        counts.insert(JobState::Wait, wait);
+        counts.insert(JobState::Paused, paused);
         counts.insert(JobState::Active, active);
+        counts.insert(JobState::Prioritized, prioritized);
+        counts.insert(JobState::Delayed, delayed);
         counts.insert(JobState::Completed, completed);
         counts.insert(JobState::Failed, failed);
 
         Ok(counts)
     }
 
-    /// Remove a job by its ID from all state sets and delete its hash.
+    /// Remove a job by its ID from all state lists/sets and delete its hash,
+    /// lock key, and logs key.
     pub async fn remove(&self, job_id: &str) -> BullmqResult<()> {
         let mut conn = self.conn.clone();
-        let job_key = self.key(job_id);
 
-        // Remove from all state sets
-        redis::cmd("ZREM")
-            .arg(self.key("waiting"))
+        // Remove from lists (LREM)
+        redis::cmd("LREM")
+            .arg(self.key("wait"))
+            .arg(0i64)
             .arg(job_id)
-            .query_async::<()>(&mut conn)
+            .query_async::<i64>(&mut conn)
+            .await?;
+        redis::cmd("LREM")
+            .arg(self.key("active"))
+            .arg(0i64)
+            .arg(job_id)
+            .query_async::<i64>(&mut conn)
+            .await?;
+        redis::cmd("LREM")
+            .arg(self.key("paused"))
+            .arg(0i64)
+            .arg(job_id)
+            .query_async::<i64>(&mut conn)
+            .await?;
+
+        // Remove from sorted sets (ZREM)
+        redis::cmd("ZREM")
+            .arg(self.key("prioritized"))
+            .arg(job_id)
+            .query_async::<i64>(&mut conn)
             .await?;
         redis::cmd("ZREM")
             .arg(self.key("delayed"))
             .arg(job_id)
-            .query_async::<()>(&mut conn)
-            .await?;
-        redis::cmd("SREM")
-            .arg(self.key("active"))
-            .arg(job_id)
-            .query_async::<()>(&mut conn)
+            .query_async::<i64>(&mut conn)
             .await?;
         redis::cmd("ZREM")
             .arg(self.key("completed"))
             .arg(job_id)
-            .query_async::<()>(&mut conn)
+            .query_async::<i64>(&mut conn)
             .await?;
         redis::cmd("ZREM")
             .arg(self.key("failed"))
             .arg(job_id)
-            .query_async::<()>(&mut conn)
+            .query_async::<i64>(&mut conn)
             .await?;
 
-        // Delete the job hash
+        // Delete the job hash, lock key, and logs key
+        let job_key = self.key(job_id);
+        let lock_key = format!("{}:lock", job_key);
+        let logs_key = format!("{}:logs", job_key);
         redis::cmd("DEL")
             .arg(&job_key)
-            .query_async::<()>(&mut conn)
+            .arg(&lock_key)
+            .arg(&logs_key)
+            .query_async::<i64>(&mut conn)
             .await?;
 
         Ok(())
     }
 
     /// Remove all jobs from the queue (drain).
+    ///
+    /// Gets all job IDs from all state lists and sorted sets, deletes all
+    /// job hashes + lock keys + log keys, then deletes all state keys.
     pub async fn drain(&self) -> BullmqResult<()> {
         let mut conn = self.conn.clone();
 
-        // Get all job IDs from all sets
-        let waiting: Vec<String> = redis::cmd("ZRANGE")
-            .arg(self.key("waiting"))
+        // Get all job IDs from lists (LRANGE)
+        let wait: Vec<String> = redis::cmd("LRANGE")
+            .arg(self.key("wait"))
+            .arg(0i64)
+            .arg(-1i64)
+            .query_async(&mut conn)
+            .await?;
+        let paused: Vec<String> = redis::cmd("LRANGE")
+            .arg(self.key("paused"))
+            .arg(0i64)
+            .arg(-1i64)
+            .query_async(&mut conn)
+            .await?;
+        let active: Vec<String> = redis::cmd("LRANGE")
+            .arg(self.key("active"))
+            .arg(0i64)
+            .arg(-1i64)
+            .query_async(&mut conn)
+            .await?;
+
+        // Get all job IDs from sorted sets (ZRANGE)
+        let prioritized: Vec<String> = redis::cmd("ZRANGE")
+            .arg(self.key("prioritized"))
             .arg(0i64)
             .arg(-1i64)
             .query_async(&mut conn)
@@ -230,43 +315,56 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + 'static> Queue<T> {
             .arg(-1i64)
             .query_async(&mut conn)
             .await?;
-        let active: Vec<String> = redis::cmd("SMEMBERS")
-            .arg(self.key("active"))
-            .query_async(&mut conn)
-            .await?;
 
-        // Delete all job hashes
-        let all_ids: Vec<&String> = waiting
+        // Collect all unique IDs
+        let all_ids: Vec<&String> = wait
             .iter()
+            .chain(paused.iter())
+            .chain(active.iter())
+            .chain(prioritized.iter())
             .chain(delayed.iter())
             .chain(completed.iter())
             .chain(failed.iter())
-            .chain(active.iter())
             .collect();
 
+        // Delete all job hashes, lock keys, and log keys
         for id in &all_ids {
+            let job_key = self.key(id);
+            let lock_key = format!("{}:lock", job_key);
+            let logs_key = format!("{}:logs", job_key);
             redis::cmd("DEL")
-                .arg(self.key(id))
-                .query_async::<()>(&mut conn)
+                .arg(&job_key)
+                .arg(&lock_key)
+                .arg(&logs_key)
+                .query_async::<i64>(&mut conn)
                 .await?;
         }
 
-        // Delete all state sets and the ID counter
+        // Delete all state keys and the ID counter
         redis::cmd("DEL")
-            .arg(self.key("waiting"))
-            .arg(self.key("delayed"))
+            .arg(self.key("wait"))
+            .arg(self.key("paused"))
             .arg(self.key("active"))
+            .arg(self.key("prioritized"))
+            .arg(self.key("delayed"))
             .arg(self.key("completed"))
             .arg(self.key("failed"))
             .arg(self.key("id"))
-            .query_async::<()>(&mut conn)
+            .query_async::<i64>(&mut conn)
             .await?;
 
         Ok(())
     }
 
-    /// Update the progress of a job (0-100).
-    pub async fn update_progress(&self, job_id: &str, progress: u32) -> BullmqResult<()> {
+    /// Update the progress of a job.
+    ///
+    /// Accepts a flexible JSON value and also publishes a progress event
+    /// to the queue's events stream via XADD.
+    pub async fn update_progress(
+        &self,
+        job_id: &str,
+        progress: serde_json::Value,
+    ) -> BullmqResult<()> {
         let mut conn = self.conn.clone();
         let job_key = self.key(job_id);
 
@@ -278,14 +376,126 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + 'static> Queue<T> {
             return Err(BullmqError::JobNotFound(job_id.to_string()));
         }
 
+        let progress_json = serde_json::to_string(&progress)?;
+
+        // Update the progress field in the job hash
         redis::cmd("HSET")
             .arg(&job_key)
             .arg("progress")
-            .arg(progress.min(100))
-            .query_async::<()>(&mut conn)
+            .arg(&progress_json)
+            .query_async::<i64>(&mut conn)
+            .await?;
+
+        // Publish progress event to the events stream
+        redis::cmd("XADD")
+            .arg(self.key("events"))
+            .arg("MAXLEN")
+            .arg("~")
+            .arg(DEFAULT_MAX_EVENTS)
+            .arg("*")
+            .arg("event")
+            .arg("progress")
+            .arg("jobId")
+            .arg(job_id)
+            .arg("data")
+            .arg(&progress_json)
+            .query_async::<String>(&mut conn)
             .await?;
 
         Ok(())
+    }
+
+    /// Pause the queue.
+    ///
+    /// Moves jobs from the wait list to paused and marks the queue as paused
+    /// in the meta hash.
+    pub async fn pause(&self) -> BullmqResult<()> {
+        let mut conn = self.conn.clone();
+        pause::pause_queue(
+            &self.scripts,
+            &mut conn,
+            &self.prefix,
+            &self.name,
+            true,
+            DEFAULT_MAX_EVENTS,
+        )
+        .await
+    }
+
+    /// Resume the queue.
+    ///
+    /// Moves jobs from paused back to wait and removes the paused marker
+    /// from the meta hash.
+    pub async fn resume(&self) -> BullmqResult<()> {
+        let mut conn = self.conn.clone();
+        pause::pause_queue(
+            &self.scripts,
+            &mut conn,
+            &self.prefix,
+            &self.name,
+            false,
+            DEFAULT_MAX_EVENTS,
+        )
+        .await
+    }
+
+    /// Check if the queue is currently paused.
+    ///
+    /// Returns `true` if the `paused` field exists in the queue's meta hash.
+    pub async fn is_paused(&self) -> BullmqResult<bool> {
+        let mut conn = self.conn.clone();
+        let paused: bool = redis::cmd("HEXISTS")
+            .arg(self.key("meta"))
+            .arg("paused")
+            .query_async(&mut conn)
+            .await?;
+        Ok(paused)
+    }
+
+    /// Add a log entry to a job's log list.
+    ///
+    /// Returns the current log count after insertion.
+    pub async fn add_log(
+        &self,
+        job_id: &str,
+        log_line: &str,
+    ) -> BullmqResult<u64> {
+        let mut conn = self.conn.clone();
+        add_log::add_log(
+            &self.scripts,
+            &mut conn,
+            &self.prefix,
+            &self.name,
+            job_id,
+            log_line,
+            // No limit by default; use u64::MAX as "unlimited".
+            u64::MAX,
+        )
+        .await
+    }
+
+    /// Get log entries for a job.
+    ///
+    /// Returns log lines from `start` to `end` (inclusive, 0-based).
+    /// Use `start=0, end=-1` to get all logs.
+    pub async fn get_logs(
+        &self,
+        job_id: &str,
+        start: i64,
+        end: i64,
+    ) -> BullmqResult<Vec<String>> {
+        let mut conn = self.conn.clone();
+        let job_key = self.key(job_id);
+        let logs_key = format!("{}:logs", job_key);
+
+        let logs: Vec<String> = redis::cmd("LRANGE")
+            .arg(&logs_key)
+            .arg(start)
+            .arg(end)
+            .query_async(&mut conn)
+            .await?;
+
+        Ok(logs)
     }
 
     /// Get the queue name.
@@ -328,15 +538,17 @@ impl QueueBuilder {
         self
     }
 
-    /// Build the queue, establishing the Redis connection.
+    /// Build the queue, establishing the Redis connection and loading Lua scripts.
     pub async fn build<T: Serialize + DeserializeOwned + Send + Sync + 'static>(
         self,
     ) -> BullmqResult<Queue<T>> {
         let conn = self.connection.get_manager().await?;
+        let scripts = Arc::new(ScriptLoader::new());
         Ok(Queue {
             name: self.name,
             prefix: self.prefix,
             conn,
+            scripts,
             _phantom: PhantomData,
         })
     }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -468,8 +468,8 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + 'static> Queue<T> {
             &self.name,
             job_id,
             log_line,
-            // No limit by default; use u64::MAX as "unlimited".
-            u64::MAX,
+            // 0 means unlimited (Lua script checks > 0 before LTRIM).
+            0,
         )
         .await
     }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 
 use crate::connection::RedisConnection;
 use crate::error::{BullmqError, BullmqResult};
-use crate::job::{Job, JobContext};
+use crate::job::{cleanup_job, Job, JobContext};
 use crate::scripts::commands::{
     add_delayed_job, add_log, add_prioritized_job, add_standard_job, pause,
 };
@@ -440,61 +440,7 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + 'static> Queue<T> {
     /// lock key, and logs key.
     pub async fn remove(&self, job_id: &str) -> BullmqResult<()> {
         let mut conn = self.conn.clone();
-
-        // Remove from lists (LREM)
-        redis::cmd("LREM")
-            .arg(self.key("wait"))
-            .arg(0i64)
-            .arg(job_id)
-            .query_async::<i64>(&mut conn)
-            .await?;
-        redis::cmd("LREM")
-            .arg(self.key("active"))
-            .arg(0i64)
-            .arg(job_id)
-            .query_async::<i64>(&mut conn)
-            .await?;
-        redis::cmd("LREM")
-            .arg(self.key("paused"))
-            .arg(0i64)
-            .arg(job_id)
-            .query_async::<i64>(&mut conn)
-            .await?;
-
-        // Remove from sorted sets (ZREM)
-        redis::cmd("ZREM")
-            .arg(self.key("prioritized"))
-            .arg(job_id)
-            .query_async::<i64>(&mut conn)
-            .await?;
-        redis::cmd("ZREM")
-            .arg(self.key("delayed"))
-            .arg(job_id)
-            .query_async::<i64>(&mut conn)
-            .await?;
-        redis::cmd("ZREM")
-            .arg(self.key("completed"))
-            .arg(job_id)
-            .query_async::<i64>(&mut conn)
-            .await?;
-        redis::cmd("ZREM")
-            .arg(self.key("failed"))
-            .arg(job_id)
-            .query_async::<i64>(&mut conn)
-            .await?;
-
-        // Delete the job hash, lock key, and logs key
-        let job_key = self.key(job_id);
-        let lock_key = format!("{}:lock", job_key);
-        let logs_key = format!("{}:logs", job_key);
-        redis::cmd("DEL")
-            .arg(&job_key)
-            .arg(&lock_key)
-            .arg(&logs_key)
-            .query_async::<i64>(&mut conn)
-            .await?;
-
-        Ok(())
+        cleanup_job(&mut conn, &self.prefix, &self.name, job_id).await
     }
 
     /// Remove all jobs from the queue (drain).
@@ -549,9 +495,15 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + 'static> Queue<T> {
             .arg(-1i64)
             .query_async(&mut conn)
             .await?;
+        let waiting_children: Vec<String> = redis::cmd("ZRANGE")
+            .arg(self.key("waiting-children"))
+            .arg(0i64)
+            .arg(-1i64)
+            .query_async(&mut conn)
+            .await?;
 
         // Collect all unique IDs
-        let all_ids: Vec<&String> = wait
+        let all_ids: std::collections::HashSet<String> = wait
             .iter()
             .chain(paused.iter())
             .chain(active.iter())
@@ -559,19 +511,12 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + 'static> Queue<T> {
             .chain(delayed.iter())
             .chain(completed.iter())
             .chain(failed.iter())
+            .chain(waiting_children.iter())
+            .cloned()
             .collect();
 
-        // Delete all job hashes, lock keys, and log keys
-        for id in &all_ids {
-            let job_key = self.key(id);
-            let lock_key = format!("{}:lock", job_key);
-            let logs_key = format!("{}:logs", job_key);
-            redis::cmd("DEL")
-                .arg(&job_key)
-                .arg(&lock_key)
-                .arg(&logs_key)
-                .query_async::<i64>(&mut conn)
-                .await?;
+        for id in all_ids {
+            cleanup_job(&mut conn, &self.prefix, &self.name, &id).await?;
         }
 
         // Delete all state keys and the ID counter
@@ -583,6 +528,7 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + 'static> Queue<T> {
             .arg(self.key("delayed"))
             .arg(self.key("completed"))
             .arg(self.key("failed"))
+            .arg(self.key("waiting-children"))
             .arg(self.key("id"))
             .query_async::<i64>(&mut conn)
             .await?;

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -14,10 +14,7 @@ use crate::scripts::commands::{
     add_delayed_job, add_log, add_prioritized_job, add_standard_job, pause,
 };
 use crate::scripts::ScriptLoader;
-use crate::types::{JobOptions, JobState};
-
-/// Default maximum number of events to keep in the events stream.
-const DEFAULT_MAX_EVENTS: u64 = 10_000;
+use crate::types::{JobOptions, JobState, DEFAULT_MAX_EVENTS};
 
 /// A typed job queue backed by Redis.
 ///

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -150,12 +150,7 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + 'static> Queue<T> {
     /// - otherwise uses `addStandardJob`
     ///
     /// Returns the created job with its assigned ID.
-    pub async fn add(
-        &self,
-        name: &str,
-        data: T,
-        opts: Option<JobOptions>,
-    ) -> BullmqResult<Job<T>> {
+    pub async fn add(&self, name: &str, data: T, opts: Option<JobOptions>) -> BullmqResult<Job<T>> {
         let mut conn = self.conn.clone();
 
         // Generate job ID: custom if provided, otherwise INCR the id counter.
@@ -635,11 +630,7 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + 'static> Queue<T> {
     /// Add a log entry to a job's log list.
     ///
     /// Returns the current log count after insertion.
-    pub async fn add_log(
-        &self,
-        job_id: &str,
-        log_line: &str,
-    ) -> BullmqResult<u64> {
+    pub async fn add_log(&self, job_id: &str, log_line: &str) -> BullmqResult<u64> {
         let mut conn = self.conn.clone();
         add_log::add_log(
             &self.scripts,
@@ -658,12 +649,7 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + 'static> Queue<T> {
     ///
     /// Returns log lines from `start` to `end` (inclusive, 0-based).
     /// Use `start=0, end=-1` to get all logs.
-    pub async fn get_logs(
-        &self,
-        job_id: &str,
-        start: i64,
-        end: i64,
-    ) -> BullmqResult<Vec<String>> {
+    pub async fn get_logs(&self, job_id: &str, start: i64, end: i64) -> BullmqResult<Vec<String>> {
         let mut conn = self.conn.clone();
         let job_key = self.key(job_id);
         let logs_key = format!("{}:logs", job_key);

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 
 use crate::connection::RedisConnection;
 use crate::error::{BullmqError, BullmqResult};
-use crate::job::Job;
+use crate::job::{Job, JobContext};
 use crate::scripts::commands::{
     add_delayed_job, add_log, add_prioritized_job, add_standard_job, pause,
 };
@@ -50,6 +50,16 @@ pub struct Queue<T> {
 }
 
 impl<T: Serialize + DeserializeOwned + Send + Sync + 'static> Queue<T> {
+    /// Build a JobContext from this queue's connection info.
+    fn job_context(&self) -> Arc<JobContext> {
+        Arc::new(JobContext {
+            conn: self.conn.clone(),
+            scripts: self.scripts.clone(),
+            prefix: self.prefix.clone(),
+            queue_name: self.name.clone(),
+        })
+    }
+
     /// Add a job to the queue.
     ///
     /// Dispatches to the appropriate Lua script based on job options:
@@ -133,6 +143,9 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + 'static> Queue<T> {
             .await?;
         }
 
+        let mut job = job;
+        job.ctx = Some(self.job_context());
+
         Ok(job)
     }
 
@@ -146,7 +159,8 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + 'static> Queue<T> {
             return Ok(None);
         }
 
-        let job = Job::from_redis_hash(job_id, &map)?;
+        let mut job = Job::from_redis_hash(job_id, &map)?;
+        job.ctx = Some(self.job_context());
         Ok(Some(job))
     }
 

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -201,6 +201,10 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + 'static> Queue<T> {
             .arg(self.key("failed"))
             .query_async(&mut conn)
             .await?;
+        let waiting_children: u64 = redis::cmd("ZCARD")
+            .arg(self.key("waiting-children"))
+            .query_async(&mut conn)
+            .await?;
 
         counts.insert(JobState::Wait, wait);
         counts.insert(JobState::Paused, paused);
@@ -209,6 +213,7 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + 'static> Queue<T> {
         counts.insert(JobState::Delayed, delayed);
         counts.insert(JobState::Completed, completed);
         counts.insert(JobState::Failed, failed);
+        counts.insert(JobState::WaitingChildren, waiting_children);
 
         Ok(counts)
     }

--- a/src/queue_events.rs
+++ b/src/queue_events.rs
@@ -13,24 +13,58 @@ use crate::error::{BullmqError, BullmqResult};
 /// The stream key is `{prefix}:{queue}:events`.
 #[derive(Debug, Clone, PartialEq)]
 pub enum QueueEvent {
-    Added { job_id: String, name: String },
-    Waiting { job_id: String, prev: Option<String> },
-    Active { job_id: String, prev: Option<String> },
-    Completed { job_id: String, return_value: serde_json::Value },
-    Failed { job_id: String, reason: String },
+    Added {
+        job_id: String,
+        name: String,
+    },
+    Waiting {
+        job_id: String,
+        prev: Option<String>,
+    },
+    Active {
+        job_id: String,
+        prev: Option<String>,
+    },
+    Completed {
+        job_id: String,
+        return_value: serde_json::Value,
+    },
+    Failed {
+        job_id: String,
+        reason: String,
+    },
     /// The `delay` field is an absolute Unix timestamp in milliseconds
     /// (not a relative duration). This matches what the Lua scripts emit.
-    Delayed { job_id: String, delay: u64 },
-    Progress { job_id: String, data: serde_json::Value },
-    Stalled { job_id: String },
-    Priority { job_id: String, priority: u32 },
-    Removed { job_id: String, prev: Option<String> },
-    WaitingChildren { job_id: String },
+    Delayed {
+        job_id: String,
+        delay: u64,
+    },
+    Progress {
+        job_id: String,
+        data: serde_json::Value,
+    },
+    Stalled {
+        job_id: String,
+    },
+    Priority {
+        job_id: String,
+        priority: u32,
+    },
+    Removed {
+        job_id: String,
+        prev: Option<String>,
+    },
+    WaitingChildren {
+        job_id: String,
+    },
     Paused,
     Resumed,
     Drained,
     /// Custom or unrecognized events (e.g. from QueueEventsProducer).
-    Unknown { event: String, fields: HashMap<String, String> },
+    Unknown {
+        event: String,
+        fields: HashMap<String, String>,
+    },
 }
 
 impl QueueEvent {
@@ -39,9 +73,9 @@ impl QueueEvent {
         let event_type = fields.get("event").map(|s| s.as_str()).unwrap_or("");
         let job_id = || fields.get("jobId").cloned().unwrap_or_default();
         let prev = || {
-            fields.get("prev").and_then(|s| {
-                if s.is_empty() { None } else { Some(s.clone()) }
-            })
+            fields
+                .get("prev")
+                .and_then(|s| if s.is_empty() { None } else { Some(s.clone()) })
         };
 
         match event_type {
@@ -49,11 +83,18 @@ impl QueueEvent {
                 job_id: job_id(),
                 name: fields.get("name").cloned().unwrap_or_default(),
             },
-            "waiting" => QueueEvent::Waiting { job_id: job_id(), prev: prev() },
-            "active" => QueueEvent::Active { job_id: job_id(), prev: prev() },
+            "waiting" => QueueEvent::Waiting {
+                job_id: job_id(),
+                prev: prev(),
+            },
+            "active" => QueueEvent::Active {
+                job_id: job_id(),
+                prev: prev(),
+            },
             "completed" => QueueEvent::Completed {
                 job_id: job_id(),
-                return_value: fields.get("returnvalue")
+                return_value: fields
+                    .get("returnvalue")
                     .and_then(|s| serde_json::from_str(s).ok())
                     .unwrap_or(serde_json::Value::Null),
             },
@@ -63,20 +104,30 @@ impl QueueEvent {
             },
             "delayed" => QueueEvent::Delayed {
                 job_id: job_id(),
-                delay: fields.get("delay").and_then(|s| s.parse().ok()).unwrap_or(0),
+                delay: fields
+                    .get("delay")
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(0),
             },
             "progress" => QueueEvent::Progress {
                 job_id: job_id(),
-                data: fields.get("data")
+                data: fields
+                    .get("data")
                     .and_then(|s| serde_json::from_str(s).ok())
                     .unwrap_or(serde_json::Value::Null),
             },
             "stalled" => QueueEvent::Stalled { job_id: job_id() },
             "priority" => QueueEvent::Priority {
                 job_id: job_id(),
-                priority: fields.get("priority").and_then(|s| s.parse().ok()).unwrap_or(0),
+                priority: fields
+                    .get("priority")
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(0),
             },
-            "removed" => QueueEvent::Removed { job_id: job_id(), prev: prev() },
+            "removed" => QueueEvent::Removed {
+                job_id: job_id(),
+                prev: prev(),
+            },
             "waiting-children" => QueueEvent::WaitingChildren { job_id: job_id() },
             "paused" => QueueEvent::Paused,
             "resumed" => QueueEvent::Resumed,
@@ -132,7 +183,10 @@ fn parse_xread_response(value: &redis::Value) -> Vec<(String, HashMap<String, St
                 let k = match &field_values[i] {
                     redis::Value::BulkString(b) => String::from_utf8_lossy(b).to_string(),
                     redis::Value::SimpleString(s) => s.clone(),
-                    _ => { i += 2; continue; }
+                    _ => {
+                        i += 2;
+                        continue;
+                    }
                 };
                 let v = match &field_values[i + 1] {
                     redis::Value::BulkString(b) => String::from_utf8_lossy(b).to_string(),
@@ -180,7 +234,8 @@ impl QueueEvents {
     /// Wait for the background task to exit.
     pub async fn wait(&mut self) -> BullmqResult<()> {
         if let Some(handle) = self.join_handle.take() {
-            handle.await
+            handle
+                .await
                 .map_err(|e| BullmqError::Other(format!("QueueEvents task panicked: {}", e)))?;
         }
         Ok(())

--- a/src/queue_events.rs
+++ b/src/queue_events.rs
@@ -1,4 +1,11 @@
 use std::collections::HashMap;
+use std::time::Duration;
+
+use redis::aio::ConnectionManager;
+use tokio::sync::{broadcast, watch};
+
+use crate::connection::RedisConnection;
+use crate::error::{BullmqError, BullmqResult};
 
 /// A typed event from a BullMQ queue's event stream.
 ///
@@ -79,5 +86,230 @@ impl QueueEvent {
                 fields: fields.clone(),
             },
         }
+    }
+}
+
+/// Parse the nested redis::Value from XREAD into (entry_id, fields) pairs.
+fn parse_xread_response(value: &redis::Value) -> Vec<(String, HashMap<String, String>)> {
+    let mut results = Vec::new();
+
+    let streams = match value {
+        redis::Value::Array(streams) => streams,
+        _ => return results,
+    };
+
+    for stream in streams {
+        let stream_parts = match stream {
+            redis::Value::Array(parts) if parts.len() >= 2 => parts,
+            _ => continue,
+        };
+
+        let entries = match &stream_parts[1] {
+            redis::Value::Array(entries) => entries,
+            _ => continue,
+        };
+
+        for entry in entries {
+            let entry_parts = match entry {
+                redis::Value::Array(parts) if parts.len() >= 2 => parts,
+                _ => continue,
+            };
+
+            let entry_id = match &entry_parts[0] {
+                redis::Value::BulkString(b) => String::from_utf8_lossy(b).to_string(),
+                redis::Value::SimpleString(s) => s.clone(),
+                _ => continue,
+            };
+
+            let field_values = match &entry_parts[1] {
+                redis::Value::Array(fv) => fv,
+                _ => continue,
+            };
+
+            let mut fields = HashMap::new();
+            let mut i = 0;
+            while i + 1 < field_values.len() {
+                let k = match &field_values[i] {
+                    redis::Value::BulkString(b) => String::from_utf8_lossy(b).to_string(),
+                    redis::Value::SimpleString(s) => s.clone(),
+                    _ => { i += 2; continue; }
+                };
+                let v = match &field_values[i + 1] {
+                    redis::Value::BulkString(b) => String::from_utf8_lossy(b).to_string(),
+                    redis::Value::SimpleString(s) => s.clone(),
+                    _ => String::new(),
+                };
+                fields.insert(k, v);
+                i += 2;
+            }
+
+            results.push((entry_id, fields));
+        }
+    }
+
+    results
+}
+
+/// Consumes events from a BullMQ queue's Redis event stream.
+///
+/// Uses `XREAD BLOCK` in a background task and delivers events
+/// through a `tokio::broadcast` channel.
+///
+/// Not `Clone` — wrap in `Arc<QueueEvents>` to share across tasks.
+pub struct QueueEvents {
+    #[allow(dead_code)]
+    name: String,
+    #[allow(dead_code)]
+    prefix: String,
+    tx: broadcast::Sender<(QueueEvent, String)>,
+    shutdown_tx: watch::Sender<bool>,
+    join_handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl QueueEvents {
+    /// Create a new subscriber for events.
+    pub fn subscribe(&self) -> broadcast::Receiver<(QueueEvent, String)> {
+        self.tx.subscribe()
+    }
+
+    /// Signal the background XREAD loop to stop.
+    pub fn shutdown(&self) {
+        let _ = self.shutdown_tx.send(true);
+    }
+
+    /// Wait for the background task to exit.
+    pub async fn wait(&mut self) -> BullmqResult<()> {
+        if let Some(handle) = self.join_handle.take() {
+            handle.await
+                .map_err(|e| BullmqError::Other(format!("QueueEvents task panicked: {}", e)))?;
+        }
+        Ok(())
+    }
+
+    /// Signal shutdown and wait for the background task to exit.
+    pub async fn close(&mut self) -> BullmqResult<()> {
+        self.shutdown();
+        self.wait().await
+    }
+}
+
+/// Builder for creating a [`QueueEvents`].
+pub struct QueueEventsBuilder {
+    name: String,
+    connection: RedisConnection,
+    prefix: String,
+    last_event_id: String,
+    blocking_timeout: u64,
+    capacity: usize,
+}
+
+impl QueueEventsBuilder {
+    /// Create a new builder for the given queue name.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            connection: RedisConnection::default(),
+            prefix: "bull".to_string(),
+            last_event_id: "$".to_string(),
+            blocking_timeout: 10_000,
+            capacity: 256,
+        }
+    }
+
+    /// Set the Redis connection configuration.
+    pub fn connection(mut self, conn: RedisConnection) -> Self {
+        self.connection = conn;
+        self
+    }
+
+    /// Set a custom key prefix (default: "bull").
+    pub fn prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.prefix = prefix.into();
+        self
+    }
+
+    /// Resume from a specific stream ID instead of "$" (latest).
+    pub fn last_event_id(mut self, id: impl Into<String>) -> Self {
+        self.last_event_id = id.into();
+        self
+    }
+
+    /// Set the XREAD BLOCK timeout in milliseconds (default: 10000).
+    pub fn blocking_timeout(mut self, ms: u64) -> Self {
+        self.blocking_timeout = ms;
+        self
+    }
+
+    /// Set the broadcast channel capacity (default: 256).
+    pub fn capacity(mut self, cap: usize) -> Self {
+        self.capacity = cap;
+        self
+    }
+
+    /// Build the QueueEvents, establishing a dedicated Redis connection
+    /// and starting the background XREAD loop.
+    pub async fn build(self) -> BullmqResult<QueueEvents> {
+        let mut conn: ConnectionManager = self.connection.get_manager().await?;
+        let events_key = format!("{}:{}:events", self.prefix, self.name);
+        let (tx, _) = broadcast::channel(self.capacity);
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+        let tx_clone = tx.clone();
+        let blocking_timeout = self.blocking_timeout;
+        let mut last_id = self.last_event_id;
+
+        let join_handle = tokio::spawn(async move {
+            let mut shutdown_rx = shutdown_rx;
+
+            loop {
+                if *shutdown_rx.borrow() {
+                    break;
+                }
+
+                let result: redis::RedisResult<redis::Value> = redis::cmd("XREAD")
+                    .arg("BLOCK")
+                    .arg(blocking_timeout)
+                    .arg("STREAMS")
+                    .arg(&events_key)
+                    .arg(&last_id)
+                    .query_async(&mut conn)
+                    .await;
+
+                match result {
+                    Ok(redis::Value::Nil) => {
+                        // Timeout — no new entries.
+                        continue;
+                    }
+                    Ok(value) => {
+                        let entries = parse_xread_response(&value);
+                        for (entry_id, fields) in entries {
+                            last_id = entry_id.clone();
+                            let event = QueueEvent::parse(&fields);
+                            let _ = tx_clone.send((event, entry_id));
+                        }
+                    }
+                    Err(e) => {
+                        let msg = e.to_string();
+                        if msg.contains("response was nil") || msg.contains("not compatible") {
+                            continue;
+                        }
+                        tracing::warn!("QueueEvents XREAD error: {}", e);
+                        tokio::select! {
+                            _ = tokio::time::sleep(Duration::from_secs(1)) => {},
+                            _ = shutdown_rx.changed() => break,
+                        }
+                    }
+                }
+            }
+            tracing::debug!("QueueEvents loop stopped");
+        });
+
+        Ok(QueueEvents {
+            name: self.name,
+            prefix: self.prefix,
+            tx,
+            shutdown_tx,
+            join_handle: Some(join_handle),
+        })
     }
 }

--- a/src/queue_events.rs
+++ b/src/queue_events.rs
@@ -1,0 +1,83 @@
+use std::collections::HashMap;
+
+/// A typed event from a BullMQ queue's event stream.
+///
+/// Parsed from Redis stream entries emitted by Lua scripts via XADD.
+/// The stream key is `{prefix}:{queue}:events`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum QueueEvent {
+    Added { job_id: String, name: String },
+    Waiting { job_id: String, prev: Option<String> },
+    Active { job_id: String, prev: Option<String> },
+    Completed { job_id: String, return_value: serde_json::Value },
+    Failed { job_id: String, reason: String },
+    /// The `delay` field is an absolute Unix timestamp in milliseconds
+    /// (not a relative duration). This matches what the Lua scripts emit.
+    Delayed { job_id: String, delay: u64 },
+    Progress { job_id: String, data: serde_json::Value },
+    Stalled { job_id: String },
+    Priority { job_id: String, priority: u32 },
+    Removed { job_id: String, prev: Option<String> },
+    WaitingChildren { job_id: String },
+    Paused,
+    Resumed,
+    Drained,
+    /// Custom or unrecognized events (e.g. from QueueEventsProducer).
+    Unknown { event: String, fields: HashMap<String, String> },
+}
+
+impl QueueEvent {
+    /// Parse a stream entry's field-value map into a QueueEvent.
+    pub fn parse(fields: &HashMap<String, String>) -> Self {
+        let event_type = fields.get("event").map(|s| s.as_str()).unwrap_or("");
+        let job_id = || fields.get("jobId").cloned().unwrap_or_default();
+        let prev = || {
+            fields.get("prev").and_then(|s| {
+                if s.is_empty() { None } else { Some(s.clone()) }
+            })
+        };
+
+        match event_type {
+            "added" => QueueEvent::Added {
+                job_id: job_id(),
+                name: fields.get("name").cloned().unwrap_or_default(),
+            },
+            "waiting" => QueueEvent::Waiting { job_id: job_id(), prev: prev() },
+            "active" => QueueEvent::Active { job_id: job_id(), prev: prev() },
+            "completed" => QueueEvent::Completed {
+                job_id: job_id(),
+                return_value: fields.get("returnvalue")
+                    .and_then(|s| serde_json::from_str(s).ok())
+                    .unwrap_or(serde_json::Value::Null),
+            },
+            "failed" => QueueEvent::Failed {
+                job_id: job_id(),
+                reason: fields.get("failedReason").cloned().unwrap_or_default(),
+            },
+            "delayed" => QueueEvent::Delayed {
+                job_id: job_id(),
+                delay: fields.get("delay").and_then(|s| s.parse().ok()).unwrap_or(0),
+            },
+            "progress" => QueueEvent::Progress {
+                job_id: job_id(),
+                data: fields.get("data")
+                    .and_then(|s| serde_json::from_str(s).ok())
+                    .unwrap_or(serde_json::Value::Null),
+            },
+            "stalled" => QueueEvent::Stalled { job_id: job_id() },
+            "priority" => QueueEvent::Priority {
+                job_id: job_id(),
+                priority: fields.get("priority").and_then(|s| s.parse().ok()).unwrap_or(0),
+            },
+            "removed" => QueueEvent::Removed { job_id: job_id(), prev: prev() },
+            "waiting-children" => QueueEvent::WaitingChildren { job_id: job_id() },
+            "paused" => QueueEvent::Paused,
+            "resumed" => QueueEvent::Resumed,
+            "drained" => QueueEvent::Drained,
+            _ => QueueEvent::Unknown {
+                event: event_type.to_string(),
+                fields: fields.clone(),
+            },
+        }
+    }
+}

--- a/src/queue_events_producer.rs
+++ b/src/queue_events_producer.rs
@@ -58,12 +58,9 @@ impl QueueEventsProducer {
     /// Publish a custom event to the queue's event stream.
     ///
     /// Uses the default max stream length (10,000).
-    pub async fn publish(
-        &self,
-        event_name: &str,
-        fields: &[(&str, &str)],
-    ) -> BullmqResult<()> {
-        self.publish_with_max_len(event_name, fields, DEFAULT_MAX_EVENTS).await
+    pub async fn publish(&self, event_name: &str, fields: &[(&str, &str)]) -> BullmqResult<()> {
+        self.publish_with_max_len(event_name, fields, DEFAULT_MAX_EVENTS)
+            .await
     }
 
     /// Publish a custom event with a specific max stream length.

--- a/src/queue_events_producer.rs
+++ b/src/queue_events_producer.rs
@@ -1,0 +1,95 @@
+use redis::aio::ConnectionManager;
+
+use crate::connection::RedisConnection;
+use crate::error::BullmqResult;
+use crate::types::DEFAULT_MAX_EVENTS;
+
+/// Publishes custom events to a BullMQ queue's event stream.
+///
+/// Events are published via XADD and appear as `QueueEvent::Unknown`
+/// on the consumer side (unless they use a built-in event name).
+pub struct QueueEventsProducer {
+    name: String,
+    prefix: String,
+    conn: ConnectionManager,
+}
+
+/// Builder for creating a [`QueueEventsProducer`].
+pub struct QueueEventsProducerBuilder {
+    name: String,
+    connection: RedisConnection,
+    prefix: String,
+}
+
+impl QueueEventsProducerBuilder {
+    /// Create a new builder for the given queue name.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            connection: RedisConnection::default(),
+            prefix: "bull".to_string(),
+        }
+    }
+
+    /// Set the Redis connection configuration.
+    pub fn connection(mut self, conn: RedisConnection) -> Self {
+        self.connection = conn;
+        self
+    }
+
+    /// Set a custom key prefix (default: "bull").
+    pub fn prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.prefix = prefix.into();
+        self
+    }
+
+    /// Build the producer, establishing a Redis connection.
+    pub async fn build(self) -> BullmqResult<QueueEventsProducer> {
+        let conn = self.connection.get_manager().await?;
+        Ok(QueueEventsProducer {
+            name: self.name,
+            prefix: self.prefix,
+            conn,
+        })
+    }
+}
+
+impl QueueEventsProducer {
+    /// Publish a custom event to the queue's event stream.
+    ///
+    /// Uses the default max stream length (10,000).
+    pub async fn publish(
+        &self,
+        event_name: &str,
+        fields: &[(&str, &str)],
+    ) -> BullmqResult<()> {
+        self.publish_with_max_len(event_name, fields, DEFAULT_MAX_EVENTS).await
+    }
+
+    /// Publish a custom event with a specific max stream length.
+    pub async fn publish_with_max_len(
+        &self,
+        event_name: &str,
+        fields: &[(&str, &str)],
+        max_len: u64,
+    ) -> BullmqResult<()> {
+        let mut conn = self.conn.clone();
+        let events_key = format!("{}:{}:events", self.prefix, self.name);
+
+        let mut cmd = redis::cmd("XADD");
+        cmd.arg(&events_key)
+            .arg("MAXLEN")
+            .arg("~")
+            .arg(max_len)
+            .arg("*")
+            .arg("event")
+            .arg(event_name);
+
+        for (k, v) in fields {
+            cmd.arg(*k).arg(*v);
+        }
+
+        cmd.query_async::<String>(&mut conn).await?;
+        Ok(())
+    }
+}

--- a/src/scripts/commands/add_delayed_job.rs
+++ b/src/scripts/commands/add_delayed_job.rs
@@ -39,9 +39,7 @@ pub(crate) async fn add_delayed_job(
         max_events.to_string().into_bytes(),
         delayed_timestamp.to_string().into_bytes(),
     ];
-    let result = loader
-        .invoke("addDelayedJob", conn, &keys, &args)
-        .await?;
+    let result = loader.invoke("addDelayedJob", conn, &keys, &args).await?;
     match result {
         redis::Value::BulkString(bytes) => Ok(String::from_utf8_lossy(&bytes).to_string()),
         redis::Value::SimpleString(s) => Ok(s),

--- a/src/scripts/commands/add_delayed_job.rs
+++ b/src/scripts/commands/add_delayed_job.rs
@@ -1,0 +1,1 @@
+// TODO: Implement in Task 5+

--- a/src/scripts/commands/add_delayed_job.rs
+++ b/src/scripts/commands/add_delayed_job.rs
@@ -8,6 +8,7 @@ use super::key;
 /// Add a delayed job to the queue.
 ///
 /// Returns the job ID on success.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn add_delayed_job(
     loader: &ScriptLoader,
     conn: &mut ConnectionManager,

--- a/src/scripts/commands/add_delayed_job.rs
+++ b/src/scripts/commands/add_delayed_job.rs
@@ -1,1 +1,49 @@
-// TODO: Implement in Task 5+
+use redis::aio::ConnectionManager;
+
+use crate::error::BullmqResult;
+use crate::scripts::ScriptLoader;
+
+use super::key;
+
+/// Add a delayed job to the queue.
+///
+/// Returns the job ID on success.
+pub(crate) async fn add_delayed_job(
+    loader: &ScriptLoader,
+    conn: &mut ConnectionManager,
+    prefix: &str,
+    queue_name: &str,
+    job_id: &str,
+    name: &str,
+    data: &str,
+    timestamp: u64,
+    opts_json: &str,
+    max_events: u64,
+    delayed_timestamp: u64,
+) -> BullmqResult<String> {
+    let keys = vec![
+        key(prefix, queue_name, "delayed"),
+        key(prefix, queue_name, "meta"),
+        key(prefix, queue_name, "id"),
+        key(prefix, queue_name, "events"),
+        key(prefix, queue_name, "marker"),
+        format!("{}:{}:{}", prefix, queue_name, job_id),
+    ];
+    let args: Vec<Vec<u8>> = vec![
+        name.as_bytes().to_vec(),
+        data.as_bytes().to_vec(),
+        timestamp.to_string().into_bytes(),
+        job_id.as_bytes().to_vec(),
+        opts_json.as_bytes().to_vec(),
+        max_events.to_string().into_bytes(),
+        delayed_timestamp.to_string().into_bytes(),
+    ];
+    let result = loader
+        .invoke("addDelayedJob", conn, &keys, &args)
+        .await?;
+    match result {
+        redis::Value::BulkString(bytes) => Ok(String::from_utf8_lossy(&bytes).to_string()),
+        redis::Value::SimpleString(s) => Ok(s),
+        _ => Ok(job_id.to_string()),
+    }
+}

--- a/src/scripts/commands/add_log.rs
+++ b/src/scripts/commands/add_log.rs
@@ -20,10 +20,7 @@ pub(crate) async fn add_log(
     let job_key = format!("{}:{}:{}", prefix, queue_name, job_id);
     let logs_key = format!("{}:logs", job_key);
 
-    let keys = vec![
-        logs_key,
-        key(prefix, queue_name, "meta"),
-    ];
+    let keys = vec![logs_key, key(prefix, queue_name, "meta")];
     let args: Vec<Vec<u8>> = vec![
         log_line.as_bytes().to_vec(),
         max_log_count.to_string().into_bytes(),

--- a/src/scripts/commands/add_log.rs
+++ b/src/scripts/commands/add_log.rs
@@ -1,0 +1,1 @@
+// TODO: Implement in Task 5+

--- a/src/scripts/commands/add_log.rs
+++ b/src/scripts/commands/add_log.rs
@@ -1,1 +1,38 @@
-// TODO: Implement in Task 5+
+use redis::aio::ConnectionManager;
+
+use crate::error::BullmqResult;
+use crate::scripts::ScriptLoader;
+
+use super::key;
+
+/// Add a log entry to a job's log list.
+///
+/// Returns the current log count after insertion.
+pub(crate) async fn add_log(
+    loader: &ScriptLoader,
+    conn: &mut ConnectionManager,
+    prefix: &str,
+    queue_name: &str,
+    job_id: &str,
+    log_line: &str,
+    max_log_count: u64,
+) -> BullmqResult<u64> {
+    let job_key = format!("{}:{}:{}", prefix, queue_name, job_id);
+    let logs_key = format!("{}:logs", job_key);
+
+    let keys = vec![
+        logs_key,
+        key(prefix, queue_name, "meta"),
+    ];
+    let args: Vec<Vec<u8>> = vec![
+        log_line.as_bytes().to_vec(),
+        max_log_count.to_string().into_bytes(),
+    ];
+
+    let result = loader.invoke("addLog", conn, &keys, &args).await?;
+
+    match result {
+        redis::Value::Int(n) => Ok(n as u64),
+        _ => Ok(0),
+    }
+}

--- a/src/scripts/commands/add_parent_job.rs
+++ b/src/scripts/commands/add_parent_job.rs
@@ -5,11 +5,9 @@ use crate::scripts::ScriptLoader;
 
 use super::key;
 
-/// Add a delayed job to the queue.
-///
-/// Returns the job ID on success.
+/// Add a parent job directly into the waiting-children state.
 #[allow(clippy::too_many_arguments)]
-pub(crate) async fn add_delayed_job(
+pub(crate) async fn add_parent_job(
     loader: &ScriptLoader,
     conn: &mut ConnectionManager,
     prefix: &str,
@@ -20,49 +18,17 @@ pub(crate) async fn add_delayed_job(
     timestamp: u64,
     opts_json: &str,
     max_events: u64,
-    delayed_timestamp: u64,
+    parent: Option<(&str, &str, &str)>,
 ) -> BullmqResult<String> {
-    add_delayed_job_with_parent(
-        loader,
-        conn,
-        prefix,
-        queue_name,
-        job_id,
-        name,
-        data,
-        timestamp,
-        opts_json,
-        max_events,
-        delayed_timestamp,
-        None,
-    )
-    .await
-}
-
-/// Add a delayed job with optional flow parent metadata.
-#[allow(clippy::too_many_arguments)]
-pub(crate) async fn add_delayed_job_with_parent(
-    loader: &ScriptLoader,
-    conn: &mut ConnectionManager,
-    prefix: &str,
-    queue_name: &str,
-    job_id: &str,
-    name: &str,
-    data: &str,
-    timestamp: u64,
-    opts_json: &str,
-    max_events: u64,
-    delayed_timestamp: u64,
-    parent: Option<(&str, &str)>,
-) -> BullmqResult<String> {
-    let (parent_key, parent_data) = parent.unwrap_or(("", ""));
+    let (parent_dependencies_key, parent_key, parent_data) =
+        parent.unwrap_or(("", "", ""));
     let keys = vec![
-        key(prefix, queue_name, "delayed"),
+        key(prefix, queue_name, "waiting-children"),
         key(prefix, queue_name, "meta"),
         key(prefix, queue_name, "id"),
         key(prefix, queue_name, "events"),
-        key(prefix, queue_name, "marker"),
         format!("{}:{}:{}", prefix, queue_name, job_id),
+        parent_dependencies_key.to_string(),
     ];
     let args: Vec<Vec<u8>> = vec![
         name.as_bytes().to_vec(),
@@ -71,11 +37,10 @@ pub(crate) async fn add_delayed_job_with_parent(
         job_id.as_bytes().to_vec(),
         opts_json.as_bytes().to_vec(),
         max_events.to_string().into_bytes(),
-        delayed_timestamp.to_string().into_bytes(),
         parent_key.as_bytes().to_vec(),
         parent_data.as_bytes().to_vec(),
     ];
-    let result = loader.invoke("addDelayedJob", conn, &keys, &args).await?;
+    let result = loader.invoke("addParentJob", conn, &keys, &args).await?;
     match result {
         redis::Value::BulkString(bytes) => Ok(String::from_utf8_lossy(&bytes).to_string()),
         redis::Value::SimpleString(s) => Ok(s),

--- a/src/scripts/commands/add_parent_job.rs
+++ b/src/scripts/commands/add_parent_job.rs
@@ -20,8 +20,7 @@ pub(crate) async fn add_parent_job(
     max_events: u64,
     parent: Option<(&str, &str, &str)>,
 ) -> BullmqResult<String> {
-    let (parent_dependencies_key, parent_key, parent_data) =
-        parent.unwrap_or(("", "", ""));
+    let (parent_dependencies_key, parent_key, parent_data) = parent.unwrap_or(("", "", ""));
     let keys = vec![
         key(prefix, queue_name, "waiting-children"),
         key(prefix, queue_name, "meta"),

--- a/src/scripts/commands/add_prioritized_job.rs
+++ b/src/scripts/commands/add_prioritized_job.rs
@@ -21,6 +21,29 @@ pub(crate) async fn add_prioritized_job(
     opts_json: &str,
     max_events: u64,
 ) -> BullmqResult<String> {
+    add_prioritized_job_with_parent(
+        loader, conn, prefix, queue_name, job_id, name, data, timestamp, opts_json, max_events,
+        None,
+    )
+    .await
+}
+
+/// Add a prioritized job with optional flow parent metadata.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn add_prioritized_job_with_parent(
+    loader: &ScriptLoader,
+    conn: &mut ConnectionManager,
+    prefix: &str,
+    queue_name: &str,
+    job_id: &str,
+    name: &str,
+    data: &str,
+    timestamp: u64,
+    opts_json: &str,
+    max_events: u64,
+    parent: Option<(&str, &str)>,
+) -> BullmqResult<String> {
+    let (parent_key, parent_data) = parent.unwrap_or(("", ""));
     let keys = vec![
         key(prefix, queue_name, "wait"),
         key(prefix, queue_name, "meta"),
@@ -41,6 +64,8 @@ pub(crate) async fn add_prioritized_job(
         max_events.to_string().into_bytes(),
         key(prefix, queue_name, "prioritized").into_bytes(),
         key(prefix, queue_name, "pc").into_bytes(),
+        parent_key.as_bytes().to_vec(),
+        parent_data.as_bytes().to_vec(),
     ];
     let result = loader
         .invoke("addPrioritizedJob", conn, &keys, &args)

--- a/src/scripts/commands/add_prioritized_job.rs
+++ b/src/scripts/commands/add_prioritized_job.rs
@@ -1,0 +1,1 @@
+// TODO: Implement in Task 5+

--- a/src/scripts/commands/add_prioritized_job.rs
+++ b/src/scripts/commands/add_prioritized_job.rs
@@ -8,6 +8,7 @@ use super::key;
 /// Add a prioritized job to the queue.
 ///
 /// Returns the job ID on success.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn add_prioritized_job(
     loader: &ScriptLoader,
     conn: &mut ConnectionManager,

--- a/src/scripts/commands/add_prioritized_job.rs
+++ b/src/scripts/commands/add_prioritized_job.rs
@@ -1,1 +1,52 @@
-// TODO: Implement in Task 5+
+use redis::aio::ConnectionManager;
+
+use crate::error::BullmqResult;
+use crate::scripts::ScriptLoader;
+
+use super::key;
+
+/// Add a prioritized job to the queue.
+///
+/// Returns the job ID on success.
+pub(crate) async fn add_prioritized_job(
+    loader: &ScriptLoader,
+    conn: &mut ConnectionManager,
+    prefix: &str,
+    queue_name: &str,
+    job_id: &str,
+    name: &str,
+    data: &str,
+    timestamp: u64,
+    opts_json: &str,
+    max_events: u64,
+) -> BullmqResult<String> {
+    let keys = vec![
+        key(prefix, queue_name, "wait"),
+        key(prefix, queue_name, "meta"),
+        key(prefix, queue_name, "id"),
+        key(prefix, queue_name, "events"),
+        key(prefix, queue_name, "marker"),
+        key(prefix, queue_name, "stalled"),
+        format!("{}:{}:{}", prefix, queue_name, job_id),
+        key(prefix, queue_name, "active"),
+        key(prefix, queue_name, "completed"),
+    ];
+    let args: Vec<Vec<u8>> = vec![
+        name.as_bytes().to_vec(),
+        data.as_bytes().to_vec(),
+        timestamp.to_string().into_bytes(),
+        job_id.as_bytes().to_vec(),
+        opts_json.as_bytes().to_vec(),
+        max_events.to_string().into_bytes(),
+        key(prefix, queue_name, "prioritized").into_bytes(),
+        key(prefix, queue_name, "pc").into_bytes(),
+    ];
+    let result = loader
+        .invoke("addPrioritizedJob", conn, &keys, &args)
+        .await?;
+    match result {
+        redis::Value::BulkString(bytes) => Ok(String::from_utf8_lossy(&bytes).to_string()),
+        redis::Value::SimpleString(s) => Ok(s),
+        _ => Ok(job_id.to_string()),
+    }
+}

--- a/src/scripts/commands/add_standard_job.rs
+++ b/src/scripts/commands/add_standard_job.rs
@@ -21,6 +21,29 @@ pub(crate) async fn add_standard_job(
     opts_json: &str,
     max_events: u64,
 ) -> BullmqResult<String> {
+    add_standard_job_with_parent(
+        loader, conn, prefix, queue_name, job_id, name, data, timestamp, opts_json, max_events,
+        None,
+    )
+    .await
+}
+
+/// Add a standard job with optional flow parent metadata.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn add_standard_job_with_parent(
+    loader: &ScriptLoader,
+    conn: &mut ConnectionManager,
+    prefix: &str,
+    queue_name: &str,
+    job_id: &str,
+    name: &str,
+    data: &str,
+    timestamp: u64,
+    opts_json: &str,
+    max_events: u64,
+    parent: Option<(&str, &str)>,
+) -> BullmqResult<String> {
+    let (parent_key, parent_data) = parent.unwrap_or(("", ""));
     let keys = vec![
         key(prefix, queue_name, "wait"),
         key(prefix, queue_name, "meta"),
@@ -39,6 +62,8 @@ pub(crate) async fn add_standard_job(
         job_id.as_bytes().to_vec(),
         opts_json.as_bytes().to_vec(),
         max_events.to_string().into_bytes(),
+        parent_key.as_bytes().to_vec(),
+        parent_data.as_bytes().to_vec(),
     ];
     let result = loader.invoke("addStandardJob", conn, &keys, &args).await?;
     match result {

--- a/src/scripts/commands/add_standard_job.rs
+++ b/src/scripts/commands/add_standard_job.rs
@@ -1,0 +1,1 @@
+// TODO: Implement in Task 5+

--- a/src/scripts/commands/add_standard_job.rs
+++ b/src/scripts/commands/add_standard_job.rs
@@ -8,6 +8,7 @@ use super::key;
 /// Add a standard (non-prioritized, non-delayed) job to the queue.
 ///
 /// Returns the job ID on success.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn add_standard_job(
     loader: &ScriptLoader,
     conn: &mut ConnectionManager,

--- a/src/scripts/commands/add_standard_job.rs
+++ b/src/scripts/commands/add_standard_job.rs
@@ -1,1 +1,48 @@
-// TODO: Implement in Task 5+
+use redis::aio::ConnectionManager;
+
+use crate::error::BullmqResult;
+use crate::scripts::ScriptLoader;
+
+use super::key;
+
+/// Add a standard (non-prioritized, non-delayed) job to the queue.
+///
+/// Returns the job ID on success.
+pub(crate) async fn add_standard_job(
+    loader: &ScriptLoader,
+    conn: &mut ConnectionManager,
+    prefix: &str,
+    queue_name: &str,
+    job_id: &str,
+    name: &str,
+    data: &str,
+    timestamp: u64,
+    opts_json: &str,
+    max_events: u64,
+) -> BullmqResult<String> {
+    let keys = vec![
+        key(prefix, queue_name, "wait"),
+        key(prefix, queue_name, "meta"),
+        key(prefix, queue_name, "id"),
+        key(prefix, queue_name, "events"),
+        key(prefix, queue_name, "marker"),
+        key(prefix, queue_name, "stalled"),
+        format!("{}:{}:{}", prefix, queue_name, job_id),
+        key(prefix, queue_name, "active"),
+        key(prefix, queue_name, "completed"),
+    ];
+    let args: Vec<Vec<u8>> = vec![
+        name.as_bytes().to_vec(),
+        data.as_bytes().to_vec(),
+        timestamp.to_string().into_bytes(),
+        job_id.as_bytes().to_vec(),
+        opts_json.as_bytes().to_vec(),
+        max_events.to_string().into_bytes(),
+    ];
+    let result = loader.invoke("addStandardJob", conn, &keys, &args).await?;
+    match result {
+        redis::Value::BulkString(bytes) => Ok(String::from_utf8_lossy(&bytes).to_string()),
+        redis::Value::SimpleString(s) => Ok(s),
+        _ => Ok(job_id.to_string()),
+    }
+}

--- a/src/scripts/commands/change_priority.rs
+++ b/src/scripts/commands/change_priority.rs
@@ -1,0 +1,58 @@
+use redis::aio::ConnectionManager;
+
+use crate::error::{BullmqError, BullmqResult};
+use crate::scripts::ScriptLoader;
+
+use super::key;
+
+/// Change the priority of a job, moving it between wait and prioritized as needed.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn change_priority(
+    loader: &ScriptLoader,
+    conn: &mut ConnectionManager,
+    prefix: &str,
+    queue_name: &str,
+    job_id: &str,
+    priority: u32,
+    max_events: u64,
+    timestamp: u64,
+) -> BullmqResult<()> {
+    let job_key = format!("{}:{}:{}", prefix, queue_name, job_id);
+    let events_key = key(prefix, queue_name, "events");
+
+    let keys = vec![
+        key(prefix, queue_name, "meta"),
+        key(prefix, queue_name, "prioritized"),
+        key(prefix, queue_name, "wait"),
+        key(prefix, queue_name, "paused"),
+        key(prefix, queue_name, "active"),
+        key(prefix, queue_name, "pc"),
+        key(prefix, queue_name, "marker"),
+    ];
+    let args: Vec<Vec<u8>> = vec![
+        priority.to_string().into_bytes(),
+        job_id.as_bytes().to_vec(),
+        job_key.into_bytes(),
+        events_key.into_bytes(),
+        timestamp.to_string().into_bytes(),
+        max_events.to_string().into_bytes(),
+    ];
+
+    let result = loader.invoke("changePriority", conn, &keys, &args).await?;
+
+    match result {
+        redis::Value::Int(code) => {
+            if code == 0 {
+                Ok(())
+            } else if code == -1 {
+                Err(BullmqError::JobNotFound(job_id.to_string()))
+            } else {
+                Err(BullmqError::ScriptError(format!(
+                    "changePriority returned unexpected code: {}",
+                    code
+                )))
+            }
+        }
+        _ => Ok(()),
+    }
+}

--- a/src/scripts/commands/extend_lock.rs
+++ b/src/scripts/commands/extend_lock.rs
@@ -20,10 +20,7 @@ pub(crate) async fn extend_lock(
     let job_key = format!("{}:{}:{}", prefix, queue_name, job_id);
     let lock_key = format!("{}:lock", job_key);
 
-    let keys = vec![
-        lock_key,
-        key(prefix, queue_name, "stalled"),
-    ];
+    let keys = vec![lock_key, key(prefix, queue_name, "stalled")];
     let args: Vec<Vec<u8>> = vec![
         token.as_bytes().to_vec(),
         lock_duration.to_string().into_bytes(),

--- a/src/scripts/commands/extend_lock.rs
+++ b/src/scripts/commands/extend_lock.rs
@@ -1,0 +1,1 @@
+// TODO: Implement in Task 5+

--- a/src/scripts/commands/extend_lock.rs
+++ b/src/scripts/commands/extend_lock.rs
@@ -1,1 +1,45 @@
-// TODO: Implement in Task 5+
+use redis::aio::ConnectionManager;
+
+use crate::error::{BullmqError, BullmqResult};
+use crate::scripts::ScriptLoader;
+
+use super::key;
+
+/// Extend the lock on an active job.
+///
+/// Returns `Ok(())` on success, `Err(LockMismatch)` if the token doesn't match.
+pub(crate) async fn extend_lock(
+    loader: &ScriptLoader,
+    conn: &mut ConnectionManager,
+    prefix: &str,
+    queue_name: &str,
+    job_id: &str,
+    token: &str,
+    lock_duration: u64,
+) -> BullmqResult<()> {
+    let job_key = format!("{}:{}:{}", prefix, queue_name, job_id);
+    let lock_key = format!("{}:lock", job_key);
+
+    let keys = vec![
+        lock_key,
+        key(prefix, queue_name, "stalled"),
+    ];
+    let args: Vec<Vec<u8>> = vec![
+        token.as_bytes().to_vec(),
+        lock_duration.to_string().into_bytes(),
+        job_id.as_bytes().to_vec(),
+    ];
+
+    let result = loader.invoke("extendLock", conn, &keys, &args).await?;
+
+    match result {
+        redis::Value::Int(code) => {
+            if code == 0 {
+                Ok(())
+            } else {
+                Err(BullmqError::LockMismatch)
+            }
+        }
+        _ => Ok(()),
+    }
+}

--- a/src/scripts/commands/mod.rs
+++ b/src/scripts/commands/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod add_parent_job;
 pub(crate) mod add_delayed_job;
 pub(crate) mod add_log;
 pub(crate) mod add_prioritized_job;

--- a/src/scripts/commands/mod.rs
+++ b/src/scripts/commands/mod.rs
@@ -1,0 +1,11 @@
+pub(crate) mod add_standard_job;
+pub(crate) mod add_prioritized_job;
+pub(crate) mod add_delayed_job;
+pub(crate) mod move_to_active;
+pub(crate) mod move_to_finished;
+pub(crate) mod move_to_delayed;
+pub(crate) mod retry_job;
+pub(crate) mod move_stalled_jobs_to_wait;
+pub(crate) mod extend_lock;
+pub(crate) mod pause;
+pub(crate) mod add_log;

--- a/src/scripts/commands/mod.rs
+++ b/src/scripts/commands/mod.rs
@@ -1,16 +1,16 @@
-pub(crate) mod add_standard_job;
-pub(crate) mod add_prioritized_job;
 pub(crate) mod add_delayed_job;
-pub(crate) mod move_to_active;
-pub(crate) mod move_to_finished;
-pub(crate) mod move_to_delayed;
-pub(crate) mod retry_job;
-pub(crate) mod move_stalled_jobs_to_wait;
-pub(crate) mod extend_lock;
-pub(crate) mod pause;
 pub(crate) mod add_log;
+pub(crate) mod add_prioritized_job;
+pub(crate) mod add_standard_job;
 pub(crate) mod change_priority;
+pub(crate) mod extend_lock;
+pub(crate) mod move_stalled_jobs_to_wait;
+pub(crate) mod move_to_active;
+pub(crate) mod move_to_delayed;
+pub(crate) mod move_to_finished;
+pub(crate) mod pause;
 pub(crate) mod promote;
+pub(crate) mod retry_job;
 
 /// Build a Redis key: `{prefix}:{queue_name}:{suffix}`.
 pub(crate) fn key(prefix: &str, queue_name: &str, suffix: &str) -> String {

--- a/src/scripts/commands/mod.rs
+++ b/src/scripts/commands/mod.rs
@@ -1,6 +1,6 @@
-pub(crate) mod add_parent_job;
 pub(crate) mod add_delayed_job;
 pub(crate) mod add_log;
+pub(crate) mod add_parent_job;
 pub(crate) mod add_prioritized_job;
 pub(crate) mod add_standard_job;
 pub(crate) mod change_priority;

--- a/src/scripts/commands/mod.rs
+++ b/src/scripts/commands/mod.rs
@@ -9,3 +9,8 @@ pub(crate) mod move_stalled_jobs_to_wait;
 pub(crate) mod extend_lock;
 pub(crate) mod pause;
 pub(crate) mod add_log;
+
+/// Build a Redis key: `{prefix}:{queue_name}:{suffix}`.
+pub(crate) fn key(prefix: &str, queue_name: &str, suffix: &str) -> String {
+    format!("{}:{}:{}", prefix, queue_name, suffix)
+}

--- a/src/scripts/commands/mod.rs
+++ b/src/scripts/commands/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod extend_lock;
 pub(crate) mod pause;
 pub(crate) mod add_log;
 pub(crate) mod change_priority;
+pub(crate) mod promote;
 
 /// Build a Redis key: `{prefix}:{queue_name}:{suffix}`.
 pub(crate) fn key(prefix: &str, queue_name: &str, suffix: &str) -> String {

--- a/src/scripts/commands/mod.rs
+++ b/src/scripts/commands/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod move_stalled_jobs_to_wait;
 pub(crate) mod extend_lock;
 pub(crate) mod pause;
 pub(crate) mod add_log;
+pub(crate) mod change_priority;
 
 /// Build a Redis key: `{prefix}:{queue_name}:{suffix}`.
 pub(crate) fn key(prefix: &str, queue_name: &str, suffix: &str) -> String {

--- a/src/scripts/commands/move_stalled_jobs_to_wait.rs
+++ b/src/scripts/commands/move_stalled_jobs_to_wait.rs
@@ -1,0 +1,1 @@
+// TODO: Implement in Task 5+

--- a/src/scripts/commands/move_stalled_jobs_to_wait.rs
+++ b/src/scripts/commands/move_stalled_jobs_to_wait.rs
@@ -1,1 +1,71 @@
-// TODO: Implement in Task 5+
+use redis::aio::ConnectionManager;
+
+use crate::error::BullmqResult;
+use crate::scripts::ScriptLoader;
+
+use super::key;
+
+/// Result of the stalled jobs check.
+#[derive(Debug)]
+pub(crate) struct StalledJobsResult {
+    /// Number of jobs that were stalled and moved back to wait.
+    pub stalled: u64,
+    /// Number of jobs that exceeded max stall count and were failed.
+    pub failed: u64,
+}
+
+/// Check for stalled jobs and move them back to wait or fail them.
+pub(crate) async fn move_stalled_jobs_to_wait(
+    loader: &ScriptLoader,
+    conn: &mut ConnectionManager,
+    prefix: &str,
+    queue_name: &str,
+    max_stalled_count: u32,
+    stalled_interval: u64,
+    timestamp: u64,
+    max_events: u64,
+) -> BullmqResult<StalledJobsResult> {
+    let job_key_prefix = format!("{}:{}:", prefix, queue_name);
+
+    let keys = vec![
+        key(prefix, queue_name, "wait"),
+        key(prefix, queue_name, "active"),
+        key(prefix, queue_name, "prioritized"),
+        key(prefix, queue_name, "stalled"),
+        key(prefix, queue_name, "stalled-check"),
+        key(prefix, queue_name, "meta"),
+        key(prefix, queue_name, "paused"),
+        key(prefix, queue_name, "events"),
+    ];
+    let args: Vec<Vec<u8>> = vec![
+        max_stalled_count.to_string().into_bytes(),
+        stalled_interval.to_string().into_bytes(),
+        timestamp.to_string().into_bytes(),
+        max_events.to_string().into_bytes(),
+        job_key_prefix.into_bytes(),
+        key(prefix, queue_name, "marker").into_bytes(),
+        key(prefix, queue_name, "pc").into_bytes(),
+    ];
+
+    let result = loader
+        .invoke("moveStalledJobsToWait", conn, &keys, &args)
+        .await?;
+
+    match result {
+        redis::Value::Array(items) if items.len() >= 2 => {
+            let stalled = match &items[0] {
+                redis::Value::Int(n) => *n as u64,
+                _ => 0,
+            };
+            let failed = match &items[1] {
+                redis::Value::Int(n) => *n as u64,
+                _ => 0,
+            };
+            Ok(StalledJobsResult { stalled, failed })
+        }
+        _ => Ok(StalledJobsResult {
+            stalled: 0,
+            failed: 0,
+        }),
+    }
+}

--- a/src/scripts/commands/move_stalled_jobs_to_wait.rs
+++ b/src/scripts/commands/move_stalled_jobs_to_wait.rs
@@ -15,6 +15,7 @@ pub(crate) struct StalledJobsResult {
 }
 
 /// Check for stalled jobs and move them back to wait or fail them.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn move_stalled_jobs_to_wait(
     loader: &ScriptLoader,
     conn: &mut ConnectionManager,

--- a/src/scripts/commands/move_to_active.rs
+++ b/src/scripts/commands/move_to_active.rs
@@ -56,18 +56,19 @@ pub(crate) async fn move_to_active(
 }
 
 /// Parse the Lua return value into a `MoveToActiveResult`.
-pub(crate) fn parse_move_to_active_result(
-    value: redis::Value,
-) -> BullmqResult<MoveToActiveResult> {
+pub(crate) fn parse_move_to_active_result(value: redis::Value) -> BullmqResult<MoveToActiveResult> {
     match value {
         redis::Value::Array(items) if !items.is_empty() => {
             // First element is the job ID
             let job_id = match &items[0] {
-                redis::Value::BulkString(bytes) => {
-                    String::from_utf8_lossy(bytes).to_string()
-                }
+                redis::Value::BulkString(bytes) => String::from_utf8_lossy(bytes).to_string(),
                 redis::Value::SimpleString(s) => s.clone(),
-                _ => return Ok(MoveToActiveResult { job_id: None, job_data: HashMap::new() }),
+                _ => {
+                    return Ok(MoveToActiveResult {
+                        job_id: None,
+                        job_data: HashMap::new(),
+                    })
+                }
             };
 
             // Remaining elements are key-value pairs from HGETALL
@@ -77,7 +78,10 @@ pub(crate) fn parse_move_to_active_result(
                 let k = match &items[i] {
                     redis::Value::BulkString(b) => String::from_utf8_lossy(b).to_string(),
                     redis::Value::SimpleString(s) => s.clone(),
-                    _ => { i += 2; continue; }
+                    _ => {
+                        i += 2;
+                        continue;
+                    }
                 };
                 let v = match &items[i + 1] {
                     redis::Value::BulkString(b) => String::from_utf8_lossy(b).to_string(),

--- a/src/scripts/commands/move_to_active.rs
+++ b/src/scripts/commands/move_to_active.rs
@@ -1,0 +1,1 @@
+// TODO: Implement in Task 5+

--- a/src/scripts/commands/move_to_active.rs
+++ b/src/scripts/commands/move_to_active.rs
@@ -1,1 +1,100 @@
-// TODO: Implement in Task 5+
+use std::collections::HashMap;
+
+use redis::aio::ConnectionManager;
+
+use crate::error::BullmqResult;
+use crate::scripts::ScriptLoader;
+
+use super::key;
+
+/// Result of a moveToActive call.
+#[derive(Debug)]
+pub(crate) struct MoveToActiveResult {
+    /// The job ID, or `None` if no job was available.
+    pub job_id: Option<String>,
+    /// The job's hash fields as key-value pairs (only present when a job is returned).
+    pub job_data: HashMap<String, String>,
+}
+
+/// Move the next waiting/prioritized job to active state, acquiring a lock.
+///
+/// Returns the job ID and all hash fields on success, or `None` if no job available.
+pub(crate) async fn move_to_active(
+    loader: &ScriptLoader,
+    conn: &mut ConnectionManager,
+    prefix: &str,
+    queue_name: &str,
+    token: &str,
+    lock_duration: u64,
+    timestamp: u64,
+    max_events: u64,
+) -> BullmqResult<MoveToActiveResult> {
+    let job_key_prefix = format!("{}:{}:", prefix, queue_name);
+    let keys = vec![
+        key(prefix, queue_name, "wait"),
+        key(prefix, queue_name, "active"),
+        key(prefix, queue_name, "prioritized"),
+        key(prefix, queue_name, "events"),
+        key(prefix, queue_name, "stalled"),
+        key(prefix, queue_name, "limiter"),
+        key(prefix, queue_name, "delayed"),
+        key(prefix, queue_name, "paused"),
+        key(prefix, queue_name, "meta"),
+        key(prefix, queue_name, "pc"),
+        key(prefix, queue_name, "marker"),
+    ];
+    let args: Vec<Vec<u8>> = vec![
+        token.as_bytes().to_vec(),
+        lock_duration.to_string().into_bytes(),
+        timestamp.to_string().into_bytes(),
+        max_events.to_string().into_bytes(),
+        job_key_prefix.into_bytes(),
+    ];
+    let result = loader.invoke("moveToActive", conn, &keys, &args).await?;
+    parse_move_to_active_result(result)
+}
+
+/// Parse the Lua return value into a `MoveToActiveResult`.
+pub(crate) fn parse_move_to_active_result(
+    value: redis::Value,
+) -> BullmqResult<MoveToActiveResult> {
+    match value {
+        redis::Value::Array(items) if !items.is_empty() => {
+            // First element is the job ID
+            let job_id = match &items[0] {
+                redis::Value::BulkString(bytes) => {
+                    String::from_utf8_lossy(bytes).to_string()
+                }
+                redis::Value::SimpleString(s) => s.clone(),
+                _ => return Ok(MoveToActiveResult { job_id: None, job_data: HashMap::new() }),
+            };
+
+            // Remaining elements are key-value pairs from HGETALL
+            let mut job_data = HashMap::new();
+            let mut i = 1;
+            while i + 1 < items.len() {
+                let k = match &items[i] {
+                    redis::Value::BulkString(b) => String::from_utf8_lossy(b).to_string(),
+                    redis::Value::SimpleString(s) => s.clone(),
+                    _ => { i += 2; continue; }
+                };
+                let v = match &items[i + 1] {
+                    redis::Value::BulkString(b) => String::from_utf8_lossy(b).to_string(),
+                    redis::Value::SimpleString(s) => s.clone(),
+                    _ => String::new(),
+                };
+                job_data.insert(k, v);
+                i += 2;
+            }
+
+            Ok(MoveToActiveResult {
+                job_id: Some(job_id),
+                job_data,
+            })
+        }
+        _ => Ok(MoveToActiveResult {
+            job_id: None,
+            job_data: HashMap::new(),
+        }),
+    }
+}

--- a/src/scripts/commands/move_to_active.rs
+++ b/src/scripts/commands/move_to_active.rs
@@ -19,6 +19,7 @@ pub(crate) struct MoveToActiveResult {
 /// Move the next waiting/prioritized job to active state, acquiring a lock.
 ///
 /// Returns the job ID and all hash fields on success, or `None` if no job available.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn move_to_active(
     loader: &ScriptLoader,
     conn: &mut ConnectionManager,

--- a/src/scripts/commands/move_to_delayed.rs
+++ b/src/scripts/commands/move_to_delayed.rs
@@ -17,6 +17,7 @@ pub(crate) async fn move_to_delayed(
     timestamp: u64,
     delayed_timestamp: u64,
     max_events: u64,
+    attempts_made: u32,
 ) -> BullmqResult<()> {
     let job_key = format!("{}:{}:{}", prefix, queue_name, job_id);
     let lock_key = format!("{}:lock", job_key);
@@ -37,6 +38,7 @@ pub(crate) async fn move_to_delayed(
         job_id.as_bytes().to_vec(),
         delayed_timestamp.to_string().into_bytes(),
         max_events.to_string().into_bytes(),
+        attempts_made.to_string().into_bytes(),
     ];
 
     let result = loader

--- a/src/scripts/commands/move_to_delayed.rs
+++ b/src/scripts/commands/move_to_delayed.rs
@@ -41,9 +41,7 @@ pub(crate) async fn move_to_delayed(
         attempts_made.to_string().into_bytes(),
     ];
 
-    let result = loader
-        .invoke("moveToDelayed", conn, &keys, &args)
-        .await?;
+    let result = loader.invoke("moveToDelayed", conn, &keys, &args).await?;
 
     match result {
         redis::Value::Int(code) => {

--- a/src/scripts/commands/move_to_delayed.rs
+++ b/src/scripts/commands/move_to_delayed.rs
@@ -1,0 +1,1 @@
+// TODO: Implement in Task 5+

--- a/src/scripts/commands/move_to_delayed.rs
+++ b/src/scripts/commands/move_to_delayed.rs
@@ -1,1 +1,62 @@
-// TODO: Implement in Task 5+
+use redis::aio::ConnectionManager;
+
+use crate::error::{BullmqError, BullmqResult};
+use crate::scripts::ScriptLoader;
+
+use super::key;
+
+/// Move an active job back to the delayed state.
+pub(crate) async fn move_to_delayed(
+    loader: &ScriptLoader,
+    conn: &mut ConnectionManager,
+    prefix: &str,
+    queue_name: &str,
+    job_id: &str,
+    token: &str,
+    timestamp: u64,
+    delayed_timestamp: u64,
+    max_events: u64,
+) -> BullmqResult<()> {
+    let job_key = format!("{}:{}:{}", prefix, queue_name, job_id);
+    let lock_key = format!("{}:lock", job_key);
+
+    let keys = vec![
+        key(prefix, queue_name, "active"),
+        key(prefix, queue_name, "delayed"),
+        key(prefix, queue_name, "events"),
+        job_key,
+        lock_key,
+        key(prefix, queue_name, "meta"),
+        key(prefix, queue_name, "marker"),
+        key(prefix, queue_name, "stalled"),
+    ];
+    let args: Vec<Vec<u8>> = vec![
+        token.as_bytes().to_vec(),
+        timestamp.to_string().into_bytes(),
+        job_id.as_bytes().to_vec(),
+        delayed_timestamp.to_string().into_bytes(),
+        max_events.to_string().into_bytes(),
+    ];
+
+    let result = loader
+        .invoke("moveToDelayed", conn, &keys, &args)
+        .await?;
+
+    match result {
+        redis::Value::Int(code) => {
+            if code == 0 {
+                Ok(())
+            } else if code == -1 {
+                Err(BullmqError::JobNotFound(job_id.to_string()))
+            } else if code == -2 || code == -6 {
+                Err(BullmqError::LockMismatch)
+            } else {
+                Err(BullmqError::ScriptError(format!(
+                    "moveToDelayed returned unexpected code: {}",
+                    code
+                )))
+            }
+        }
+        _ => Ok(()),
+    }
+}

--- a/src/scripts/commands/move_to_delayed.rs
+++ b/src/scripts/commands/move_to_delayed.rs
@@ -6,6 +6,7 @@ use crate::scripts::ScriptLoader;
 use super::key;
 
 /// Move an active job back to the delayed state.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn move_to_delayed(
     loader: &ScriptLoader,
     conn: &mut ConnectionManager,

--- a/src/scripts/commands/move_to_finished.rs
+++ b/src/scripts/commands/move_to_finished.rs
@@ -61,16 +61,18 @@ pub(crate) async fn move_to_finished(
         result_data.as_bytes().to_vec(),
         target_state.as_bytes().to_vec(),
         max_events.to_string().into_bytes(),
-        if fetch_next { b"1".to_vec() } else { b"0".to_vec() },
+        if fetch_next {
+            b"1".to_vec()
+        } else {
+            b"0".to_vec()
+        },
         lock_duration.to_string().into_bytes(),
         job_id.as_bytes().to_vec(),
         attempts_made.to_string().into_bytes(),
         job_key_prefix.into_bytes(),
     ];
 
-    let result = loader
-        .invoke("moveToFinished", conn, &keys, &args)
-        .await?;
+    let result = loader.invoke("moveToFinished", conn, &keys, &args).await?;
 
     match &result {
         redis::Value::Int(code) => {

--- a/src/scripts/commands/move_to_finished.rs
+++ b/src/scripts/commands/move_to_finished.rs
@@ -1,0 +1,1 @@
+// TODO: Implement in Task 5+

--- a/src/scripts/commands/move_to_finished.rs
+++ b/src/scripts/commands/move_to_finished.rs
@@ -39,6 +39,8 @@ pub(crate) async fn move_to_finished(
     let lock_key = format!("{}:lock", job_key);
     let job_key_prefix = format!("{}:{}:", prefix, queue_name);
 
+    // Parent release now reads parentKey/parent metadata from the job hash, so
+    // this command keeps the existing BullMQ-compatible key/arg layout.
     let keys = vec![
         key(prefix, queue_name, "wait"),
         key(prefix, queue_name, "active"),

--- a/src/scripts/commands/move_to_finished.rs
+++ b/src/scripts/commands/move_to_finished.rs
@@ -79,9 +79,7 @@ pub(crate) async fn move_to_finished(
                 Ok(MoveToFinishedResult::Done)
             } else if code == -1 {
                 Err(BullmqError::JobNotFound(job_id.to_string()))
-            } else if code == -2 {
-                Err(BullmqError::LockMismatch)
-            } else if code == -6 {
+            } else if code == -2 || code == -6 {
                 Err(BullmqError::LockMismatch)
             } else {
                 Err(BullmqError::ScriptError(format!(

--- a/src/scripts/commands/move_to_finished.rs
+++ b/src/scripts/commands/move_to_finished.rs
@@ -1,1 +1,99 @@
-// TODO: Implement in Task 5+
+use redis::aio::ConnectionManager;
+
+use crate::error::{BullmqError, BullmqResult};
+use crate::scripts::ScriptLoader;
+
+use super::key;
+use super::move_to_active::{parse_move_to_active_result, MoveToActiveResult};
+
+/// Result of a moveToFinished call.
+#[derive(Debug)]
+pub(crate) enum MoveToFinishedResult {
+    /// The job was successfully finished (no next job fetched).
+    Done,
+    /// The job was finished and a next job was fetched.
+    NextJob(MoveToActiveResult),
+}
+
+/// Move a job from active to completed or failed, and optionally fetch the next job.
+///
+/// `target_state` should be `"completed"` or `"failed"`.
+/// `result_data` is the return value (for completed) or failure reason (for failed).
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn move_to_finished(
+    loader: &ScriptLoader,
+    conn: &mut ConnectionManager,
+    prefix: &str,
+    queue_name: &str,
+    job_id: &str,
+    token: &str,
+    timestamp: u64,
+    result_data: &str,
+    target_state: &str,
+    max_events: u64,
+    fetch_next: bool,
+    lock_duration: u64,
+    attempts_made: u32,
+) -> BullmqResult<MoveToFinishedResult> {
+    let job_key = format!("{}:{}:{}", prefix, queue_name, job_id);
+    let lock_key = format!("{}:lock", job_key);
+    let job_key_prefix = format!("{}:{}:", prefix, queue_name);
+
+    let keys = vec![
+        key(prefix, queue_name, "wait"),
+        key(prefix, queue_name, "active"),
+        key(prefix, queue_name, "prioritized"),
+        key(prefix, queue_name, "events"),
+        key(prefix, queue_name, "stalled"),
+        key(prefix, queue_name, "limiter"),
+        key(prefix, queue_name, "delayed"),
+        key(prefix, queue_name, "paused"),
+        key(prefix, queue_name, target_state),
+        key(prefix, queue_name, "meta"),
+        key(prefix, queue_name, "pc"),
+        key(prefix, queue_name, "marker"),
+        job_key,
+        lock_key,
+    ];
+    let args: Vec<Vec<u8>> = vec![
+        token.as_bytes().to_vec(),
+        timestamp.to_string().into_bytes(),
+        result_data.as_bytes().to_vec(),
+        target_state.as_bytes().to_vec(),
+        max_events.to_string().into_bytes(),
+        if fetch_next { b"1".to_vec() } else { b"0".to_vec() },
+        lock_duration.to_string().into_bytes(),
+        job_id.as_bytes().to_vec(),
+        attempts_made.to_string().into_bytes(),
+        job_key_prefix.into_bytes(),
+    ];
+
+    let result = loader
+        .invoke("moveToFinished", conn, &keys, &args)
+        .await?;
+
+    match &result {
+        redis::Value::Int(code) => {
+            let code = *code;
+            if code == 0 {
+                Ok(MoveToFinishedResult::Done)
+            } else if code == -1 {
+                Err(BullmqError::JobNotFound(job_id.to_string()))
+            } else if code == -2 {
+                Err(BullmqError::LockMismatch)
+            } else if code == -6 {
+                Err(BullmqError::LockMismatch)
+            } else {
+                Err(BullmqError::ScriptError(format!(
+                    "moveToFinished returned unexpected code: {}",
+                    code
+                )))
+            }
+        }
+        redis::Value::Array(_) => {
+            let next = parse_move_to_active_result(result)?;
+            Ok(MoveToFinishedResult::NextJob(next))
+        }
+        _ => Ok(MoveToFinishedResult::Done),
+    }
+}

--- a/src/scripts/commands/pause.rs
+++ b/src/scripts/commands/pause.rs
@@ -1,0 +1,1 @@
+// TODO: Implement in Task 5+

--- a/src/scripts/commands/pause.rs
+++ b/src/scripts/commands/pause.rs
@@ -1,1 +1,37 @@
-// TODO: Implement in Task 5+
+use redis::aio::ConnectionManager;
+
+use crate::error::BullmqResult;
+use crate::scripts::ScriptLoader;
+
+use super::key;
+
+/// Pause or resume a queue.
+///
+/// When `pause` is `true`, jobs are moved from wait to paused and the queue is marked paused.
+/// When `pause` is `false`, jobs are moved from paused to wait and the queue is resumed.
+pub(crate) async fn pause_queue(
+    loader: &ScriptLoader,
+    conn: &mut ConnectionManager,
+    prefix: &str,
+    queue_name: &str,
+    pause: bool,
+    max_events: u64,
+) -> BullmqResult<()> {
+    let keys = vec![
+        key(prefix, queue_name, "wait"),
+        key(prefix, queue_name, "paused"),
+        key(prefix, queue_name, "meta"),
+        key(prefix, queue_name, "events"),
+        key(prefix, queue_name, "delayed"),
+        key(prefix, queue_name, "prioritized"),
+        key(prefix, queue_name, "marker"),
+    ];
+    let action = if pause { "pause" } else { "resume" };
+    let args: Vec<Vec<u8>> = vec![
+        action.as_bytes().to_vec(),
+        max_events.to_string().into_bytes(),
+    ];
+
+    loader.invoke("pause", conn, &keys, &args).await?;
+    Ok(())
+}

--- a/src/scripts/commands/promote.rs
+++ b/src/scripts/commands/promote.rs
@@ -1,0 +1,58 @@
+use redis::aio::ConnectionManager;
+
+use crate::error::{BullmqError, BullmqResult};
+use crate::scripts::ScriptLoader;
+
+use super::key;
+
+/// Promote a delayed job to wait or prioritized.
+pub(crate) async fn promote(
+    loader: &ScriptLoader,
+    conn: &mut ConnectionManager,
+    prefix: &str,
+    queue_name: &str,
+    job_id: &str,
+    max_events: u64,
+    timestamp: u64,
+) -> BullmqResult<()> {
+    let job_key = format!("{}:{}:{}", prefix, queue_name, job_id);
+
+    let keys = vec![
+        key(prefix, queue_name, "delayed"),
+        key(prefix, queue_name, "wait"),
+        key(prefix, queue_name, "paused"),
+        key(prefix, queue_name, "meta"),
+        key(prefix, queue_name, "prioritized"),
+        key(prefix, queue_name, "active"),
+        key(prefix, queue_name, "pc"),
+        key(prefix, queue_name, "events"),
+        key(prefix, queue_name, "marker"),
+    ];
+    let args: Vec<Vec<u8>> = vec![
+        job_id.as_bytes().to_vec(),
+        job_key.into_bytes(),
+        timestamp.to_string().into_bytes(),
+        max_events.to_string().into_bytes(),
+    ];
+
+    let result = loader.invoke("promote", conn, &keys, &args).await?;
+
+    match result {
+        redis::Value::Int(code) => {
+            if code == 0 {
+                Ok(())
+            } else if code == -1 {
+                Err(BullmqError::Other(format!(
+                    "Job {} is not in delayed state",
+                    job_id
+                )))
+            } else {
+                Err(BullmqError::ScriptError(format!(
+                    "promote returned unexpected code: {}",
+                    code
+                )))
+            }
+        }
+        _ => Ok(()),
+    }
+}

--- a/src/scripts/commands/retry_job.rs
+++ b/src/scripts/commands/retry_job.rs
@@ -1,0 +1,1 @@
+// TODO: Implement in Task 5+

--- a/src/scripts/commands/retry_job.rs
+++ b/src/scripts/commands/retry_job.rs
@@ -9,6 +9,7 @@ use super::key;
 ///
 /// `push_cmd` should be `"RPUSH"` (retried jobs go to the back) or `"LPUSH"`.
 #[allow(clippy::too_many_arguments)]
+#[allow(dead_code)]
 pub(crate) async fn retry_job(
     loader: &ScriptLoader,
     conn: &mut ConnectionManager,

--- a/src/scripts/commands/retry_job.rs
+++ b/src/scripts/commands/retry_job.rs
@@ -1,1 +1,67 @@
-// TODO: Implement in Task 5+
+use redis::aio::ConnectionManager;
+
+use crate::error::{BullmqError, BullmqResult};
+use crate::scripts::ScriptLoader;
+
+use super::key;
+
+/// Retry a job by moving it from active back to wait or prioritized.
+///
+/// `push_cmd` should be `"RPUSH"` (retried jobs go to the back) or `"LPUSH"`.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn retry_job(
+    loader: &ScriptLoader,
+    conn: &mut ConnectionManager,
+    prefix: &str,
+    queue_name: &str,
+    job_id: &str,
+    token: &str,
+    push_cmd: &str,
+    max_events: u64,
+    attempts_made: u32,
+    priority: u32,
+) -> BullmqResult<()> {
+    let job_key = format!("{}:{}:{}", prefix, queue_name, job_id);
+
+    let keys = vec![
+        key(prefix, queue_name, "active"),
+        key(prefix, queue_name, "wait"),
+        key(prefix, queue_name, "stalled"),
+        key(prefix, queue_name, "paused"),
+        key(prefix, queue_name, "meta"),
+        key(prefix, queue_name, "events"),
+        key(prefix, queue_name, "delayed"),
+        key(prefix, queue_name, "prioritized"),
+        key(prefix, queue_name, "pc"),
+        key(prefix, queue_name, "marker"),
+        job_key,
+    ];
+    let args: Vec<Vec<u8>> = vec![
+        token.as_bytes().to_vec(),
+        push_cmd.as_bytes().to_vec(),
+        job_id.as_bytes().to_vec(),
+        max_events.to_string().into_bytes(),
+        attempts_made.to_string().into_bytes(),
+        priority.to_string().into_bytes(),
+    ];
+
+    let result = loader.invoke("retryJob", conn, &keys, &args).await?;
+
+    match result {
+        redis::Value::Int(code) => {
+            if code == 0 {
+                Ok(())
+            } else if code == -1 {
+                Err(BullmqError::JobNotFound(job_id.to_string()))
+            } else if code == -2 || code == -6 {
+                Err(BullmqError::LockMismatch)
+            } else {
+                Err(BullmqError::ScriptError(format!(
+                    "retryJob returned unexpected code: {}",
+                    code
+                )))
+            }
+        }
+        _ => Ok(()),
+    }
+}

--- a/src/scripts/mod.rs
+++ b/src/scripts/mod.rs
@@ -93,9 +93,10 @@ impl ScriptLoader {
         keys: &[String],
         args: &[Vec<u8>],
     ) -> BullmqResult<redis::Value> {
-        let script = self.scripts.get(name).ok_or_else(|| {
-            BullmqError::ScriptError(format!("Unknown script: {}", name))
-        })?;
+        let script = self
+            .scripts
+            .get(name)
+            .ok_or_else(|| BullmqError::ScriptError(format!("Unknown script: {}", name)))?;
         let mut invocation = script.prepare_invoke();
         for key in keys {
             invocation.key(key);
@@ -115,9 +116,7 @@ mod tests {
     #[test]
     fn test_resolve_includes() {
         let main = "local foo = 1\n--@include \"helper\"\nlocal bar = 2";
-        let includes = HashMap::from([
-            ("helper".to_string(), "local helper_val = 42".to_string()),
-        ]);
+        let includes = HashMap::from([("helper".to_string(), "local helper_val = 42".to_string())]);
         let resolved = resolve_includes(main, &includes);
         assert!(resolved.contains("local helper_val = 42"));
         assert!(resolved.contains("local foo = 1"));

--- a/src/scripts/mod.rs
+++ b/src/scripts/mod.rs
@@ -51,6 +51,7 @@ impl ScriptLoader {
         register!("addStandardJob", "addStandardJob-9.lua");
         register!("addPrioritizedJob", "addPrioritizedJob-9.lua");
         register!("addDelayedJob", "addDelayedJob-6.lua");
+        register!("addParentJob", "addParentJob-6.lua");
         register!("moveToActive", "moveToActive-11.lua");
         register!("moveToFinished", "moveToFinished-14.lua");
         register!("moveToDelayed", "moveToDelayed-8.lua");
@@ -107,6 +108,15 @@ impl ScriptLoader {
         let result: redis::Value = invocation.invoke_async(conn).await?;
         Ok(result)
     }
+
+    pub async fn load(&self, name: &str, conn: &mut ConnectionManager) -> BullmqResult<()> {
+        let script = self
+            .scripts
+            .get(name)
+            .ok_or_else(|| BullmqError::ScriptError(format!("Unknown script: {}", name)))?;
+        script.prepare_invoke().load_async(conn).await?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -151,6 +161,7 @@ mod tests {
         assert!(loader.scripts.contains_key("addStandardJob"));
         assert!(loader.scripts.contains_key("addPrioritizedJob"));
         assert!(loader.scripts.contains_key("addDelayedJob"));
+        assert!(loader.scripts.contains_key("addParentJob"));
         assert!(loader.scripts.contains_key("moveToActive"));
         assert!(loader.scripts.contains_key("moveToFinished"));
         assert!(loader.scripts.contains_key("moveToDelayed"));
@@ -161,6 +172,6 @@ mod tests {
         assert!(loader.scripts.contains_key("addLog"));
         assert!(loader.scripts.contains_key("changePriority"));
         assert!(loader.scripts.contains_key("promote"));
-        assert_eq!(loader.scripts.len(), 13);
+        assert_eq!(loader.scripts.len(), 14);
     }
 }

--- a/src/scripts/mod.rs
+++ b/src/scripts/mod.rs
@@ -1,0 +1,163 @@
+use std::collections::HashMap;
+
+use redis::aio::ConnectionManager;
+
+use crate::error::{BullmqError, BullmqResult};
+
+pub mod commands;
+
+/// Resolve `--@include "name"` directives by inlining the named include content.
+pub(crate) fn resolve_includes(source: &str, includes: &HashMap<String, String>) -> String {
+    let mut result = String::with_capacity(source.len() * 2);
+    for line in source.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("--@include") {
+            if let Some(name) = trimmed
+                .strip_prefix("--@include")
+                .and_then(|s| s.trim().strip_prefix('"'))
+                .and_then(|s| s.strip_suffix('"'))
+            {
+                if let Some(content) = includes.get(name) {
+                    result.push_str(content);
+                    result.push('\n');
+                }
+            }
+        } else {
+            result.push_str(line);
+            result.push('\n');
+        }
+    }
+    result
+}
+
+/// Loads, caches, and invokes Lua scripts via EVALSHA/EVAL.
+pub(crate) struct ScriptLoader {
+    scripts: HashMap<&'static str, redis::Script>,
+}
+
+impl ScriptLoader {
+    pub fn new() -> Self {
+        let includes = Self::load_includes();
+        let mut scripts = HashMap::new();
+
+        macro_rules! register {
+            ($name:literal, $file:literal) => {
+                let source = include_str!(concat!("../../lua/", $file));
+                let resolved = resolve_includes(source, &includes);
+                scripts.insert($name, redis::Script::new(&resolved));
+            };
+        }
+
+        register!("addStandardJob", "addStandardJob-9.lua");
+        register!("addPrioritizedJob", "addPrioritizedJob-9.lua");
+        register!("addDelayedJob", "addDelayedJob-6.lua");
+        register!("moveToActive", "moveToActive-11.lua");
+        register!("moveToFinished", "moveToFinished-14.lua");
+        register!("moveToDelayed", "moveToDelayed-8.lua");
+        register!("retryJob", "retryJob-11.lua");
+        register!("moveStalledJobsToWait", "moveStalledJobsToWait-8.lua");
+        register!("extendLock", "extendLock-2.lua");
+        register!("pause", "pause-7.lua");
+        register!("addLog", "addLog-2.lua");
+
+        Self { scripts }
+    }
+
+    fn load_includes() -> HashMap<String, String> {
+        let mut m = HashMap::new();
+        macro_rules! inc {
+            ($name:literal, $file:literal) => {
+                m.insert(
+                    $name.to_string(),
+                    include_str!(concat!("../../lua/includes/", $file)).to_string(),
+                );
+            };
+        }
+        inc!("storeJob", "storeJob.lua");
+        inc!("addBaseMarkerIfNeeded", "addBaseMarkerIfNeeded.lua");
+        inc!("addDelayMarkerIfNeeded", "addDelayMarkerIfNeeded.lua");
+        inc!("getDelayedScore", "getDelayedScore.lua");
+        inc!("getPriorityScore", "getPriorityScore.lua");
+        inc!("moveJobToWait", "moveJobToWait.lua");
+        inc!("promoteDelayedJobs", "promoteDelayedJobs.lua");
+        inc!("removeLock", "removeLock.lua");
+        m
+    }
+
+    pub async fn invoke(
+        &self,
+        name: &str,
+        conn: &mut ConnectionManager,
+        keys: &[String],
+        args: &[Vec<u8>],
+    ) -> BullmqResult<redis::Value> {
+        let script = self.scripts.get(name).ok_or_else(|| {
+            BullmqError::ScriptError(format!("Unknown script: {}", name))
+        })?;
+        let mut invocation = script.prepare_invoke();
+        for key in keys {
+            invocation.key(key);
+        }
+        for arg in args {
+            invocation.arg(arg.as_slice());
+        }
+        let result: redis::Value = invocation.invoke_async(conn).await?;
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resolve_includes() {
+        let main = "local foo = 1\n--@include \"helper\"\nlocal bar = 2";
+        let includes = HashMap::from([
+            ("helper".to_string(), "local helper_val = 42".to_string()),
+        ]);
+        let resolved = resolve_includes(main, &includes);
+        assert!(resolved.contains("local helper_val = 42"));
+        assert!(resolved.contains("local foo = 1"));
+        assert!(resolved.contains("local bar = 2"));
+        assert!(!resolved.contains("--@include"));
+    }
+
+    #[test]
+    fn test_resolve_includes_multiple() {
+        let main = "--@include \"a\"\n--@include \"b\"";
+        let includes = HashMap::from([
+            ("a".to_string(), "local a = 1".to_string()),
+            ("b".to_string(), "local b = 2".to_string()),
+        ]);
+        let resolved = resolve_includes(main, &includes);
+        assert!(resolved.contains("local a = 1"));
+        assert!(resolved.contains("local b = 2"));
+    }
+
+    #[test]
+    fn test_resolve_includes_missing() {
+        let main = "--@include \"nonexistent\"\nlocal x = 1";
+        let includes = HashMap::new();
+        let resolved = resolve_includes(main, &includes);
+        assert!(resolved.contains("local x = 1"));
+        assert!(!resolved.contains("nonexistent"));
+    }
+
+    #[test]
+    fn test_script_loader_creates_all_scripts() {
+        let loader = ScriptLoader::new();
+        assert!(loader.scripts.contains_key("addStandardJob"));
+        assert!(loader.scripts.contains_key("addPrioritizedJob"));
+        assert!(loader.scripts.contains_key("addDelayedJob"));
+        assert!(loader.scripts.contains_key("moveToActive"));
+        assert!(loader.scripts.contains_key("moveToFinished"));
+        assert!(loader.scripts.contains_key("moveToDelayed"));
+        assert!(loader.scripts.contains_key("retryJob"));
+        assert!(loader.scripts.contains_key("moveStalledJobsToWait"));
+        assert!(loader.scripts.contains_key("extendLock"));
+        assert!(loader.scripts.contains_key("pause"));
+        assert!(loader.scripts.contains_key("addLog"));
+        assert_eq!(loader.scripts.len(), 11);
+    }
+}

--- a/src/scripts/mod.rs
+++ b/src/scripts/mod.rs
@@ -77,13 +77,23 @@ impl ScriptLoader {
             };
         }
         inc!("storeJob", "storeJob.lua");
+        inc!("addJobInTargetList", "addJobInTargetList.lua");
+        inc!("addJobWithPriority", "addJobWithPriority.lua");
         inc!("addBaseMarkerIfNeeded", "addBaseMarkerIfNeeded.lua");
         inc!("addDelayMarkerIfNeeded", "addDelayMarkerIfNeeded.lua");
         inc!("getDelayedScore", "getDelayedScore.lua");
+        inc!("getTargetQueueList", "getTargetQueueList.lua");
         inc!("getPriorityScore", "getPriorityScore.lua");
         inc!("moveJobToWait", "moveJobToWait.lua");
+        inc!("moveParentToWait", "moveParentToWait.lua");
+        inc!("moveParentToWaitIfNeeded", "moveParentToWaitIfNeeded.lua");
+        inc!(
+            "moveParentToWaitIfNoPendingDependencies",
+            "moveParentToWaitIfNoPendingDependencies.lua"
+        );
         inc!("promoteDelayedJobs", "promoteDelayedJobs.lua");
         inc!("removeLock", "removeLock.lua");
+        inc!("updateParentDepsIfNeeded", "updateParentDepsIfNeeded.lua");
         m
     }
 

--- a/src/scripts/mod.rs
+++ b/src/scripts/mod.rs
@@ -59,6 +59,7 @@ impl ScriptLoader {
         register!("extendLock", "extendLock-2.lua");
         register!("pause", "pause-7.lua");
         register!("addLog", "addLog-2.lua");
+        register!("changePriority", "changePriority-7.lua");
 
         Self { scripts }
     }
@@ -158,6 +159,7 @@ mod tests {
         assert!(loader.scripts.contains_key("extendLock"));
         assert!(loader.scripts.contains_key("pause"));
         assert!(loader.scripts.contains_key("addLog"));
-        assert_eq!(loader.scripts.len(), 11);
+        assert!(loader.scripts.contains_key("changePriority"));
+        assert_eq!(loader.scripts.len(), 12);
     }
 }

--- a/src/scripts/mod.rs
+++ b/src/scripts/mod.rs
@@ -60,6 +60,7 @@ impl ScriptLoader {
         register!("pause", "pause-7.lua");
         register!("addLog", "addLog-2.lua");
         register!("changePriority", "changePriority-7.lua");
+        register!("promote", "promote-9.lua");
 
         Self { scripts }
     }
@@ -160,6 +161,7 @@ mod tests {
         assert!(loader.scripts.contains_key("pause"));
         assert!(loader.scripts.contains_key("addLog"));
         assert!(loader.scripts.contains_key("changePriority"));
-        assert_eq!(loader.scripts.len(), 12);
+        assert!(loader.scripts.contains_key("promote"));
+        assert_eq!(loader.scripts.len(), 13);
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,6 +8,8 @@ pub enum JobState {
     Wait,
     #[serde(rename = "paused")]
     Paused,
+    #[serde(rename = "prioritized")]
+    Prioritized,
     #[serde(rename = "waiting-children")]
     WaitingChildren,
     #[serde(rename = "delayed")]
@@ -25,6 +27,7 @@ impl std::fmt::Display for JobState {
         match self {
             JobState::Wait => write!(f, "wait"),
             JobState::Paused => write!(f, "paused"),
+            JobState::Prioritized => write!(f, "prioritized"),
             JobState::WaitingChildren => write!(f, "waiting-children"),
             JobState::Delayed => write!(f, "delayed"),
             JobState::Active => write!(f, "active"),
@@ -41,6 +44,7 @@ impl std::str::FromStr for JobState {
         match s {
             "wait" => Ok(JobState::Wait),
             "paused" => Ok(JobState::Paused),
+            "prioritized" => Ok(JobState::Prioritized),
             "waiting-children" => Ok(JobState::WaitingChildren),
             "delayed" => Ok(JobState::Delayed),
             "active" => Ok(JobState::Active),

--- a/src/types.rs
+++ b/src/types.rs
@@ -147,6 +147,9 @@ impl Default for WorkerOptions {
     }
 }
 
+/// Default maximum number of events to keep in the events stream.
+pub(crate) const DEFAULT_MAX_EVENTS: u64 = 10_000;
+
 mod duration_millis {
     use serde::{Deserialize, Deserializer, Serializer};
     use std::time::Duration;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
@@ -145,6 +146,12 @@ impl Default for WorkerOptions {
             skip_stalled_check: false,
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct JobDependencies {
+    pub processed: HashMap<String, serde_json::Value>,
+    pub unprocessed: Vec<String>,
 }
 
 /// Default maximum number of events to keep in the events stream.

--- a/src/types.rs
+++ b/src/types.rs
@@ -52,19 +52,35 @@ impl std::str::FromStr for JobState {
 }
 
 /// Options for creating a job.
-#[derive(Debug, Clone, Default)]
+///
+/// Serializes to JSON matching the BullMQ Node.js `opts` format.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct JobOptions {
     /// Job priority. Lower values = higher priority. Default is 0.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub priority: Option<u32>,
-    /// Delay before the job becomes available for processing.
+    /// Delay before the job becomes available for processing (in milliseconds).
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        with = "option_duration_millis",
+        default
+    )]
     pub delay: Option<Duration>,
     /// Maximum number of attempts (including the first). Default is 1 (no retry).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub attempts: Option<u32>,
     /// Backoff strategy for retries.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub backoff: Option<BackoffStrategy>,
-    /// Time-to-live: job expires after this duration.
+    /// Time-to-live: job expires after this duration (in milliseconds).
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        with = "option_duration_millis",
+        default
+    )]
     pub ttl: Option<Duration>,
     /// Custom job ID. Auto-generated if not provided.
+    #[serde(rename = "jobId", skip_serializing_if = "Option::is_none")]
     pub job_id: Option<String>,
 }
 
@@ -138,5 +154,22 @@ mod duration_millis {
     pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Duration, D::Error> {
         let ms = u64::deserialize(d)?;
         Ok(Duration::from_millis(ms))
+    }
+}
+
+mod option_duration_millis {
+    use serde::{Deserialize, Deserializer, Serializer};
+    use std::time::Duration;
+
+    pub fn serialize<S: Serializer>(d: &Option<Duration>, s: S) -> Result<S::Ok, S::Error> {
+        match d {
+            Some(dur) => s.serialize_u64(dur.as_millis() as u64),
+            None => s.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Option<Duration>, D::Error> {
+        let opt = Option::<u64>::deserialize(d)?;
+        Ok(opt.map(Duration::from_millis))
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,5 @@
-use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::time::Duration;
 
 /// Lifecycle state of a job.

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,19 +3,29 @@ use std::time::Duration;
 
 /// Lifecycle state of a job.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
 pub enum JobState {
-    Waiting,
+    #[serde(rename = "wait")]
+    Wait,
+    #[serde(rename = "paused")]
+    Paused,
+    #[serde(rename = "waiting-children")]
+    WaitingChildren,
+    #[serde(rename = "delayed")]
     Delayed,
+    #[serde(rename = "active")]
     Active,
+    #[serde(rename = "completed")]
     Completed,
+    #[serde(rename = "failed")]
     Failed,
 }
 
 impl std::fmt::Display for JobState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            JobState::Waiting => write!(f, "waiting"),
+            JobState::Wait => write!(f, "wait"),
+            JobState::Paused => write!(f, "paused"),
+            JobState::WaitingChildren => write!(f, "waiting-children"),
             JobState::Delayed => write!(f, "delayed"),
             JobState::Active => write!(f, "active"),
             JobState::Completed => write!(f, "completed"),
@@ -29,7 +39,9 @@ impl std::str::FromStr for JobState {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "waiting" => Ok(JobState::Waiting),
+            "wait" => Ok(JobState::Wait),
+            "paused" => Ok(JobState::Paused),
+            "waiting-children" => Ok(JobState::WaitingChildren),
             "delayed" => Ok(JobState::Delayed),
             "active" => Ok(JobState::Active),
             "completed" => Ok(JobState::Completed),
@@ -43,7 +55,7 @@ impl std::str::FromStr for JobState {
 #[derive(Debug, Clone, Default)]
 pub struct JobOptions {
     /// Job priority. Lower values = higher priority. Default is 0.
-    pub priority: Option<i32>,
+    pub priority: Option<u32>,
     /// Delay before the job becomes available for processing.
     pub delay: Option<Duration>,
     /// Maximum number of attempts (including the first). Default is 1 (no retry).
@@ -93,15 +105,24 @@ impl BackoffStrategy {
 pub struct WorkerOptions {
     /// Number of jobs to process concurrently. Default is 1.
     pub concurrency: usize,
-    /// How often to poll for new jobs. Default is 1 second.
-    pub poll_interval: Duration,
+    /// Duration a job lock is held before it can be considered stalled. Default is 30s.
+    pub lock_duration: Duration,
+    /// How often to check for stalled jobs. Default is 30s.
+    pub stalled_interval: Duration,
+    /// Maximum number of times a job can be recovered from stalled state. Default is 1.
+    pub max_stalled_count: u32,
+    /// Whether to skip the stalled-job check entirely. Default is false.
+    pub skip_stalled_check: bool,
 }
 
 impl Default for WorkerOptions {
     fn default() -> Self {
         Self {
             concurrency: 1,
-            poll_interval: Duration::from_secs(1),
+            lock_duration: Duration::from_secs(30),
+            stalled_interval: Duration::from_secs(30),
+            max_stalled_count: 1,
+            skip_stalled_check: false,
         }
     }
 }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -130,7 +130,8 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
         let concurrency = self.options.concurrency;
 
         // Channel for fast-path: moveToFinished can return the next job.
-        let (next_job_tx, next_job_rx) = tokio::sync::mpsc::channel::<move_to_active::MoveToActiveResult>(1);
+        // Capacity matches concurrency so concurrent handler completions don't drop prefetched jobs.
+        let (next_job_tx, next_job_rx) = tokio::sync::mpsc::channel::<move_to_active::MoveToActiveResult>(concurrency);
         let next_job_rx = Arc::new(Mutex::new(next_job_rx));
 
         let join_handle = tokio::spawn({
@@ -518,7 +519,12 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                                             Ok(move_to_finished::MoveToFinishedResult::NextJob(next)) => {
                                                 // Fast-path: send next job via channel.
                                                 if next.job_id.is_some() {
-                                                    let _ = next_job_tx.try_send(next);
+                                                    if let Err(e) = next_job_tx.try_send(next) {
+                                                        tracing::warn!(
+                                                            "Fast-path channel full, prefetched job will be recovered via stalled check: {:?}",
+                                                            e.into_inner().job_id
+                                                        );
+                                                    }
                                                 }
                                             }
                                             Ok(move_to_finished::MoveToFinishedResult::Done) => {}

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -268,15 +268,54 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                         Some(result)
                     } else {
                         // BZPOPMIN on the marker key with 5-second timeout.
-                        let bzpopmin_result: redis::RedisResult<Option<(String, String, f64)>> =
+                        let bzpopmin_result: redis::RedisResult<redis::Value> =
                             redis::cmd("BZPOPMIN")
                                 .arg(&marker_key)
                                 .arg(5.0_f64)
                                 .query_async(&mut blocking_conn)
                                 .await;
 
-                        match bzpopmin_result {
-                            Ok(Some((_key, member, score))) => {
+                        // Parse BZPOPMIN response manually:
+                        // - Nil or empty array = timeout
+                        // - Array of [key, member, score] = got a marker
+                        let parsed = match &bzpopmin_result {
+                            Ok(redis::Value::Array(items)) if items.len() >= 3 => {
+                                let member = match &items[1] {
+                                    redis::Value::BulkString(b) => String::from_utf8_lossy(b).to_string(),
+                                    redis::Value::SimpleString(s) => s.clone(),
+                                    _ => String::new(),
+                                };
+                                let score = match &items[2] {
+                                    redis::Value::BulkString(b) => String::from_utf8_lossy(b).parse::<f64>().unwrap_or(0.0),
+                                    redis::Value::Double(f) => *f,
+                                    redis::Value::Int(i) => *i as f64,
+                                    _ => 0.0,
+                                };
+                                Some((member, score))
+                            }
+                            Ok(redis::Value::Nil) | Ok(redis::Value::Array(_)) => None,
+                            Ok(_) => None,
+                            Err(_) => None,
+                        };
+
+                        // Check if the original result was a real error (not a timeout)
+                        if let Err(ref e) = bzpopmin_result {
+                            // Timeouts and type errors (Nil response) are normal for BZPOPMIN
+                            let msg = e.to_string();
+                            if msg.contains("timed out") || msg.contains("response was nil") ||
+                               msg.contains("not compatible") {
+                                continue;
+                            }
+                            tracing::warn!("BZPOPMIN error: {}, retrying after delay", e);
+                            tokio::select! {
+                                _ = tokio::time::sleep(Duration::from_secs(1)) => {},
+                                _ = shutdown_rx.changed() => break,
+                            }
+                            continue;
+                        }
+
+                        match parsed {
+                            Some((member, score)) => {
                                 if member == "0" {
                                     // Score 0 means a job is available: call moveToActive.
                                     let timestamp = now_ms();
@@ -306,7 +345,7 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                                     }
                                 } else if member == "1" {
                                     // Score is a timestamp for a delayed job.
-                                    // Sleep until that time (or at most 5s), then continue.
+                                    // Sleep until that time, then call moveToActive (which promotes delayed jobs).
                                     let now = now_ms();
                                     let target = score as u64;
                                     if target > now {
@@ -316,7 +355,27 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                                             _ = shutdown_rx.changed() => break,
                                         }
                                     }
-                                    continue;
+                                    // After sleeping, call moveToActive to promote and fetch delayed jobs
+                                    let timestamp = now_ms();
+                                    match move_to_active::move_to_active(
+                                        &scripts,
+                                        &mut cmd_conn,
+                                        &prefix,
+                                        &name,
+                                        &token,
+                                        lock_duration_ms,
+                                        timestamp,
+                                        DEFAULT_MAX_EVENTS,
+                                    )
+                                    .await
+                                    {
+                                        Ok(result) if result.job_id.is_some() => Some(result),
+                                        Ok(_) => { continue; }
+                                        Err(e) => {
+                                            tracing::warn!("moveToActive error after delay: {}", e);
+                                            continue;
+                                        }
+                                    }
                                 } else {
                                     // Unknown marker member, treat as a regular job marker.
                                     // Call moveToActive just in case.
@@ -342,16 +401,8 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                                     }
                                 }
                             }
-                            Ok(None) => {
+                            None => {
                                 // Timeout, no marker appeared. Continue the loop.
-                                continue;
-                            }
-                            Err(e) => {
-                                tracing::warn!("BZPOPMIN error: {}, retrying after delay", e);
-                                tokio::select! {
-                                    _ = tokio::time::sleep(Duration::from_secs(1)) => {},
-                                    _ = shutdown_rx.changed() => break,
-                                }
                                 continue;
                             }
                         }
@@ -485,6 +536,7 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                                                 timestamp,
                                                 delayed_timestamp,
                                                 DEFAULT_MAX_EVENTS,
+                                                new_attempts,
                                             )
                                             .await
                                             {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -18,10 +18,7 @@ type CompletedCallback = Arc<dyn Fn(&Job<serde_json::Value>) + Send + Sync>;
 type FailedCallback = Arc<dyn Fn(&Job<serde_json::Value>, &BullmqError) + Send + Sync>;
 use crate::scripts::commands::{extend_lock, move_stalled_jobs_to_wait, move_to_active, move_to_delayed, move_to_finished};
 use crate::scripts::ScriptLoader;
-use crate::types::WorkerOptions;
-
-/// Default maximum number of events to keep in the events stream.
-const DEFAULT_MAX_EVENTS: u64 = 10_000;
+use crate::types::{WorkerOptions, DEFAULT_MAX_EVENTS};
 
 /// A worker that processes jobs from a queue.
 ///

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -679,6 +679,8 @@ fn convert_job_to_value<T: Serialize>(job: &Job<T>) -> BullmqResult<Job<serde_js
         stacktrace: job.stacktrace.clone(),
         return_value: job.return_value.clone(),
         processed_by: job.processed_by.clone(),
+        ctx: None,
+        lock_token: None,
     })
 }
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -251,6 +251,15 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                 let mut cmd_conn = cmd_conn;
                 let marker_key = format!("{}:{}:marker", prefix, name);
 
+                // Bootstrap: add a marker so BZPOPMIN picks up pre-existing jobs.
+                // Idempotent — if "0" already exists, score is unchanged.
+                let _: redis::RedisResult<i64> = redis::cmd("ZADD")
+                    .arg(&marker_key)
+                    .arg(0i64)
+                    .arg("0")
+                    .query_async(&mut cmd_conn)
+                    .await;
+
                 loop {
                     // Check for shutdown.
                     if *shutdown_rx.borrow() {
@@ -402,8 +411,28 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                                 }
                             }
                             None => {
-                                // Timeout, no marker appeared. Continue the loop.
-                                continue;
+                                // Timeout — try moveToActive as recovery.
+                                // Handles lost markers (Redis failover, manual deletion, etc.)
+                                let timestamp = now_ms();
+                                match move_to_active::move_to_active(
+                                    &scripts,
+                                    &mut cmd_conn,
+                                    &prefix,
+                                    &name,
+                                    &token,
+                                    lock_duration_ms,
+                                    timestamp,
+                                    DEFAULT_MAX_EVENTS,
+                                )
+                                .await
+                                {
+                                    Ok(result) if result.job_id.is_some() => Some(result),
+                                    Ok(_) => { continue; }
+                                    Err(e) => {
+                                        tracing::debug!("moveToActive recovery check: {}", e);
+                                        continue;
+                                    }
+                                }
                             }
                         }
                     };

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -10,7 +10,7 @@ use tokio::sync::{watch, Mutex, Semaphore};
 
 use crate::connection::RedisConnection;
 use crate::error::{BullmqError, BullmqResult};
-use crate::job::Job;
+use crate::job::{Job, JobContext};
 
 /// Type alias for the on_completed callback.
 type CompletedCallback = Arc<dyn Fn(&Job<serde_json::Value>) + Send + Sync>;
@@ -412,13 +412,24 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                     if let Some(result) = move_result {
                         if let Some(job_id) = result.job_id {
                             // Deserialize the job from the hash data returned by moveToActive.
-                            let job: Job<T> = match Job::from_redis_hash(&job_id, &result.job_data) {
+                            let mut job: Job<T> = match Job::from_redis_hash(&job_id, &result.job_data) {
                                 Ok(j) => j,
                                 Err(e) => {
                                     tracing::error!("Failed to deserialize job {}: {}", job_id, e);
                                     continue;
                                 }
                             };
+
+                            // Inject connection context, lock token, and active state
+                            // for active-handle methods.
+                            job.ctx = Some(Arc::new(JobContext {
+                                conn: cmd_conn.clone(),
+                                scripts: scripts.clone(),
+                                prefix: prefix.clone(),
+                                queue_name: name.clone(),
+                            }));
+                            job.lock_token = Some(token.clone());
+                            job.state = crate::types::JobState::Active;
 
                             // Acquire a semaphore permit (may block if at concurrency limit).
                             let permit = tokio::select! {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,20 +1,22 @@
-use std::collections::HashMap;
+use std::collections::HashSet;
 use std::future::Future;
 use std::marker::PhantomData;
 use std::sync::Arc;
+use std::time::Duration;
 
-use chrono::Utc;
-use redis::aio::ConnectionManager;
-use redis::AsyncCommands;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use tokio::sync::{watch, Semaphore};
-use tokio::time::sleep;
+use tokio::sync::{watch, Mutex, Semaphore};
 
 use crate::connection::RedisConnection;
 use crate::error::{BullmqError, BullmqResult};
 use crate::job::Job;
-use crate::types::{JobState, WorkerOptions};
+use crate::scripts::commands::{extend_lock, move_stalled_jobs_to_wait, move_to_active, move_to_delayed, move_to_finished};
+use crate::scripts::ScriptLoader;
+use crate::types::WorkerOptions;
+
+/// Default maximum number of events to keep in the events stream.
+const DEFAULT_MAX_EVENTS: u64 = 10_000;
 
 /// A worker that processes jobs from a queue.
 ///
@@ -33,8 +35,7 @@ use crate::types::{JobState, WorkerOptions};
 /// let worker = WorkerBuilder::new("my_queue")
 ///     .connection(RedisConnection::new("redis://127.0.0.1:6379"))
 ///     .concurrency(5)
-///     .build::<MyJob>()
-///     .await?;
+///     .build::<MyJob>();
 ///
 /// let handle = worker.start(|job| async move {
 ///     println!("Processing: {:?}", job.data);
@@ -50,7 +51,8 @@ use crate::types::{JobState, WorkerOptions};
 pub struct Worker<T> {
     name: String,
     prefix: String,
-    conn: ConnectionManager,
+    conn: RedisConnection,
+    scripts: Arc<ScriptLoader>,
     options: WorkerOptions,
     on_completed: Option<Arc<dyn Fn(&Job<serde_json::Value>) + Send + Sync>>,
     on_failed: Option<Arc<dyn Fn(&Job<serde_json::Value>, &BullmqError) + Send + Sync>>,
@@ -78,273 +80,518 @@ impl WorkerHandle {
     }
 }
 
+/// Returns the current time as milliseconds since the Unix epoch.
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64
+}
+
 impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> {
     /// Start processing jobs with the given async handler.
+    ///
+    /// The handler receives a `Job<T>` and must return a `Result<(), Box<dyn Error>>`.
+    /// On success the job moves to completed; on error it is retried (if attempts
+    /// remain) or moved to failed.
     ///
     /// Returns a [`WorkerHandle`] that can be used to shut down the worker.
     pub async fn start<F, Fut>(self, handler: F) -> BullmqResult<WorkerHandle>
     where
         F: Fn(Job<T>) -> Fut + Send + Sync + 'static,
-        Fut: Future<Output = Result<(), BullmqError>> + Send,
+        Fut: Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send,
     {
+        // Create two independent ConnectionManager instances.
+        let blocking_conn = self.conn.get_manager().await?;
+        let cmd_conn = self.conn.get_manager().await?;
+
+        // Generate a unique worker token.
+        let token = uuid::Uuid::new_v4().to_string();
+
+        // Shared state for active job tracking (used by lock extender).
+        let active_jobs: Arc<Mutex<HashSet<String>>> = Arc::new(Mutex::new(HashSet::new()));
+
+        // Shutdown channel.
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
         let handler = Arc::new(handler);
         let semaphore = Arc::new(Semaphore::new(self.options.concurrency));
-        let poll_interval = self.options.poll_interval;
-        let conn = self.conn.clone();
+        let scripts = self.scripts.clone();
         let name = self.name.clone();
         let prefix = self.prefix.clone();
         let on_completed = self.on_completed.clone();
         let on_failed = self.on_failed.clone();
+        let lock_duration_ms = self.options.lock_duration.as_millis() as u64;
+        let stalled_interval = self.options.stalled_interval;
+        let max_stalled_count = self.options.max_stalled_count;
+        let skip_stalled_check = self.options.skip_stalled_check;
+        let concurrency = self.options.concurrency;
 
-        let join_handle = tokio::spawn(async move {
-            let mut shutdown_rx = shutdown_rx;
+        // Channel for fast-path: moveToFinished can return the next job.
+        let (next_job_tx, next_job_rx) = tokio::sync::mpsc::channel::<move_to_active::MoveToActiveResult>(1);
+        let next_job_rx = Arc::new(Mutex::new(next_job_rx));
 
-            loop {
-                // Check for shutdown
-                if *shutdown_rx.borrow() {
-                    break;
-                }
+        let join_handle = tokio::spawn({
+            let scripts = scripts.clone();
+            let name = name.clone();
+            let prefix = prefix.clone();
+            let token = token.clone();
+            let active_jobs = active_jobs.clone();
+            let shutdown_rx_main = shutdown_rx.clone();
 
-                // Move delayed jobs to waiting
-                if let Err(e) = promote_delayed_jobs(&conn, &prefix, &name).await {
-                    tracing::warn!("Error promoting delayed jobs: {}", e);
-                }
+            // Spawn the lock extender background task.
+            let lock_extender_handle = {
+                let scripts = scripts.clone();
+                let name = name.clone();
+                let prefix = prefix.clone();
+                let token = token.clone();
+                let active_jobs = active_jobs.clone();
+                let mut shutdown_rx = shutdown_rx.clone();
+                let mut cmd_conn = cmd_conn.clone();
+                let extend_interval = Duration::from_millis(lock_duration_ms / 2);
 
-                // Try to acquire a concurrency permit
-                let permit = match semaphore.clone().try_acquire_owned() {
-                    Ok(permit) => permit,
-                    Err(_) => {
-                        // All slots busy, wait and retry
+                tokio::spawn(async move {
+                    loop {
                         tokio::select! {
-                            _ = sleep(poll_interval) => continue,
+                            _ = tokio::time::sleep(extend_interval) => {},
                             _ = shutdown_rx.changed() => break,
                         }
-                    }
-                };
 
-                // Pop next job from waiting set
-                let mut conn_clone = conn.clone();
-                let waiting_key = format!("{}:{}:waiting", prefix, name);
+                        let job_ids: Vec<String> = {
+                            let set = active_jobs.lock().await;
+                            set.iter().cloned().collect()
+                        };
 
-                let result: redis::RedisResult<Vec<(String, f64)>> = redis::cmd("ZPOPMAX")
-                    .arg(&waiting_key)
-                    .arg(1)
-                    .query_async(&mut conn_clone)
-                    .await;
-
-                match result {
-                    Ok(items) if items.is_empty() => {
-                        // No jobs available, wait
-                        drop(permit);
-                        tokio::select! {
-                            _ = sleep(poll_interval) => continue,
-                            _ = shutdown_rx.changed() => break,
+                        for job_id in &job_ids {
+                            if let Err(e) = extend_lock::extend_lock(
+                                &scripts,
+                                &mut cmd_conn,
+                                &prefix,
+                                &name,
+                                job_id,
+                                &token,
+                                lock_duration_ms,
+                            )
+                            .await
+                            {
+                                match e {
+                                    BullmqError::LockMismatch => {
+                                        tracing::warn!(
+                                            "Lock mismatch extending lock for job {}, it may have been stalled",
+                                            job_id
+                                        );
+                                    }
+                                    _ => {
+                                        tracing::warn!("Error extending lock for job {}: {}", job_id, e);
+                                    }
+                                }
+                            }
                         }
                     }
-                    Ok(items) => {
-                        let (job_id, _score) = &items[0];
-                        let job_id = job_id.clone();
+                    tracing::debug!("Lock extender stopped");
+                })
+            };
 
-                        // Fetch job data from hash
-                        let job_key = format!("{}:{}:{}", prefix, name, job_id);
-                        let map: HashMap<String, String> =
-                            match conn_clone.hgetall(&job_key).await {
-                                Ok(m) => m,
+            // Spawn the stalled job checker background task.
+            let stalled_checker_handle = if !skip_stalled_check {
+                let scripts = scripts.clone();
+                let name = name.clone();
+                let prefix = prefix.clone();
+                let mut shutdown_rx = shutdown_rx.clone();
+                let mut cmd_conn = cmd_conn.clone();
+
+                Some(tokio::spawn(async move {
+                    loop {
+                        tokio::select! {
+                            _ = tokio::time::sleep(stalled_interval) => {},
+                            _ = shutdown_rx.changed() => break,
+                        }
+
+                        let timestamp = now_ms();
+                        match move_stalled_jobs_to_wait::move_stalled_jobs_to_wait(
+                            &scripts,
+                            &mut cmd_conn,
+                            &prefix,
+                            &name,
+                            max_stalled_count,
+                            stalled_interval.as_millis() as u64,
+                            timestamp,
+                            DEFAULT_MAX_EVENTS,
+                        )
+                        .await
+                        {
+                            Ok(result) => {
+                                if result.stalled > 0 || result.failed > 0 {
+                                    tracing::info!(
+                                        "Stalled jobs check: {} recovered, {} failed",
+                                        result.stalled,
+                                        result.failed
+                                    );
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!("Error checking stalled jobs: {}", e);
+                            }
+                        }
+                    }
+                    tracing::debug!("Stalled job checker stopped");
+                }))
+            } else {
+                None
+            };
+
+            async move {
+                let mut shutdown_rx = shutdown_rx_main;
+                let mut blocking_conn = blocking_conn;
+                let mut cmd_conn = cmd_conn;
+                let marker_key = format!("{}:{}:marker", prefix, name);
+
+                loop {
+                    // Check for shutdown.
+                    if *shutdown_rx.borrow() {
+                        break;
+                    }
+
+                    // Check fast-path channel first (next job from moveToFinished).
+                    let fast_path_result = {
+                        let mut rx = next_job_rx.lock().await;
+                        rx.try_recv().ok()
+                    };
+
+                    let move_result = if let Some(result) = fast_path_result {
+                        // We got a job from the fast-path channel.
+                        Some(result)
+                    } else {
+                        // BZPOPMIN on the marker key with 5-second timeout.
+                        let bzpopmin_result: redis::RedisResult<Option<(String, String, f64)>> =
+                            redis::cmd("BZPOPMIN")
+                                .arg(&marker_key)
+                                .arg(5.0_f64)
+                                .query_async(&mut blocking_conn)
+                                .await;
+
+                        match bzpopmin_result {
+                            Ok(Some((_key, member, score))) => {
+                                if member == "0" {
+                                    // Score 0 means a job is available: call moveToActive.
+                                    let timestamp = now_ms();
+                                    match move_to_active::move_to_active(
+                                        &scripts,
+                                        &mut cmd_conn,
+                                        &prefix,
+                                        &name,
+                                        &token,
+                                        lock_duration_ms,
+                                        timestamp,
+                                        DEFAULT_MAX_EVENTS,
+                                    )
+                                    .await
+                                    {
+                                        Ok(result) => {
+                                            if result.job_id.is_some() {
+                                                Some(result)
+                                            } else {
+                                                None
+                                            }
+                                        }
+                                        Err(e) => {
+                                            tracing::warn!("moveToActive error: {}", e);
+                                            None
+                                        }
+                                    }
+                                } else if member == "1" {
+                                    // Score is a timestamp for a delayed job.
+                                    // Sleep until that time (or at most 5s), then continue.
+                                    let now = now_ms();
+                                    let target = score as u64;
+                                    if target > now {
+                                        let wait_ms = (target - now).min(5_000);
+                                        tokio::select! {
+                                            _ = tokio::time::sleep(Duration::from_millis(wait_ms)) => {},
+                                            _ = shutdown_rx.changed() => break,
+                                        }
+                                    }
+                                    continue;
+                                } else {
+                                    // Unknown marker member, treat as a regular job marker.
+                                    // Call moveToActive just in case.
+                                    let timestamp = now_ms();
+                                    match move_to_active::move_to_active(
+                                        &scripts,
+                                        &mut cmd_conn,
+                                        &prefix,
+                                        &name,
+                                        &token,
+                                        lock_duration_ms,
+                                        timestamp,
+                                        DEFAULT_MAX_EVENTS,
+                                    )
+                                    .await
+                                    {
+                                        Ok(result) if result.job_id.is_some() => Some(result),
+                                        Ok(_) => None,
+                                        Err(e) => {
+                                            tracing::warn!("moveToActive error: {}", e);
+                                            None
+                                        }
+                                    }
+                                }
+                            }
+                            Ok(None) => {
+                                // Timeout, no marker appeared. Continue the loop.
+                                continue;
+                            }
+                            Err(e) => {
+                                tracing::warn!("BZPOPMIN error: {}, retrying after delay", e);
+                                tokio::select! {
+                                    _ = tokio::time::sleep(Duration::from_secs(1)) => {},
+                                    _ = shutdown_rx.changed() => break,
+                                }
+                                continue;
+                            }
+                        }
+                    };
+
+                    // If we have a job result from moveToActive, process it.
+                    if let Some(result) = move_result {
+                        if let Some(job_id) = result.job_id {
+                            // Deserialize the job from the hash data returned by moveToActive.
+                            let job: Job<T> = match Job::from_redis_hash(&job_id, &result.job_data) {
+                                Ok(j) => j,
                                 Err(e) => {
-                                    tracing::error!("Failed to fetch job {}: {}", job_id, e);
-                                    drop(permit);
+                                    tracing::error!("Failed to deserialize job {}: {}", job_id, e);
                                     continue;
                                 }
                             };
 
-                        if map.is_empty() {
-                            tracing::warn!("Job {} hash is empty, skipping", job_id);
-                            drop(permit);
-                            continue;
-                        }
-
-                        let mut job: Job<T> = match Job::from_redis_hash(&job_id, &map) {
-                            Ok(j) => j,
-                            Err(e) => {
-                                tracing::error!("Failed to deserialize job {}: {}", job_id, e);
-                                drop(permit);
-                                continue;
-                            }
-                        };
-
-                        // Mark as active
-                        job.state = JobState::Active;
-                        job.processed_on = Some(Utc::now());
-                        let _ = redis::cmd("SADD")
-                            .arg(format!("{}:{}:active", prefix, name))
-                            .arg(&job_id)
-                            .query_async::<()>(&mut conn_clone)
-                            .await;
-                        let _ = redis::cmd("HSET")
-                            .arg(&job_key)
-                            .arg("state")
-                            .arg("active")
-                            .arg("processed_on")
-                            .arg(Utc::now().timestamp_millis().to_string())
-                            .query_async::<()>(&mut conn_clone)
-                            .await;
-
-                        // Process in a spawned task
-                        let handler = handler.clone();
-                        let mut task_conn = conn.clone();
-                        let task_prefix = prefix.clone();
-                        let task_name = name.clone();
-                        let on_completed = on_completed.clone();
-                        let on_failed = on_failed.clone();
-
-                        tokio::spawn(async move {
-                            let _permit = permit;
-                            let job_key =
-                                format!("{}:{}:{}", task_prefix, task_name, job.id);
-
-                            match handler(job.clone()).await {
-                                Ok(()) => {
-                                    // Move to completed
-                                    let now = Utc::now();
-                                    let _ = redis::cmd("SREM")
-                                        .arg(format!(
-                                            "{}:{}:active",
-                                            task_prefix, task_name
-                                        ))
-                                        .arg(&job.id)
-                                        .query_async::<()>(&mut task_conn)
-                                        .await;
-                                    let _ = redis::cmd("ZADD")
-                                        .arg(format!(
-                                            "{}:{}:completed",
-                                            task_prefix, task_name
-                                        ))
-                                        .arg(now.timestamp_millis())
-                                        .arg(&job.id)
-                                        .query_async::<()>(&mut task_conn)
-                                        .await;
-                                    let _ = redis::cmd("HSET")
-                                        .arg(&job_key)
-                                        .arg("state")
-                                        .arg("completed")
-                                        .arg("finished_on")
-                                        .arg(now.timestamp_millis().to_string())
-                                        .query_async::<()>(&mut task_conn)
-                                        .await;
-
-                                    if let Some(ref cb) = on_completed {
-                                        if let Ok(val_job) = convert_job_to_value(&job) {
-                                            cb(&val_job);
-                                        }
+                            // Acquire a semaphore permit (may block if at concurrency limit).
+                            let permit = tokio::select! {
+                                p = semaphore.clone().acquire_owned() => {
+                                    match p {
+                                        Ok(permit) => permit,
+                                        Err(_) => break, // Semaphore closed
                                     }
+                                },
+                                _ = shutdown_rx.changed() => break,
+                            };
 
-                                    tracing::debug!("Job {} completed", job.id);
+                            // Spawn the job processing task.
+                            let handler = handler.clone();
+                            let scripts = scripts.clone();
+                            let mut task_conn = cmd_conn.clone();
+                            let task_prefix = prefix.clone();
+                            let task_name = name.clone();
+                            let task_token = token.clone();
+                            let on_completed = on_completed.clone();
+                            let on_failed = on_failed.clone();
+                            let active_jobs = active_jobs.clone();
+                            let next_job_tx = next_job_tx.clone();
+                            let task_lock_duration = lock_duration_ms;
+
+                            tokio::spawn(async move {
+                                let _permit = permit;
+                                let job_id = job.id.clone();
+
+                                // Register job ID in active_jobs set.
+                                {
+                                    let mut set = active_jobs.lock().await;
+                                    set.insert(job_id.clone());
                                 }
-                                Err(err) => {
-                                    let attempts = job.attempts_made + 1;
 
-                                    // Remove from active
-                                    let _ = redis::cmd("SREM")
-                                        .arg(format!(
-                                            "{}:{}:active",
-                                            task_prefix, task_name
-                                        ))
-                                        .arg(&job.id)
-                                        .query_async::<()>(&mut task_conn)
-                                        .await;
+                                // Run the user handler.
+                                match handler(job.clone()).await {
+                                    Ok(()) => {
+                                        // Success: call moveToFinished(completed) with fetchNext=true.
+                                        let timestamp = now_ms();
+                                        let attempts = job.attempts_made + 1;
 
-                                    if attempts < job.max_attempts {
-                                        // Retry: compute backoff delay and re-queue as delayed
-                                        let backoff_delay = job
-                                            .backoff
-                                            .as_ref()
-                                            .map(|b| b.delay_for_attempt(attempts))
-                                            .unwrap_or(std::time::Duration::from_secs(1));
-
-                                        let process_at = Utc::now().timestamp_millis()
-                                            + backoff_delay.as_millis() as i64;
-
-                                        let _ = redis::cmd("HSET")
-                                            .arg(&job_key)
-                                            .arg("state")
-                                            .arg("delayed")
-                                            .arg("attempts_made")
-                                            .arg(attempts)
-                                            .query_async::<()>(&mut task_conn)
-                                            .await;
-                                        let _ = redis::cmd("ZADD")
-                                            .arg(format!(
-                                                "{}:{}:delayed",
-                                                task_prefix, task_name
-                                            ))
-                                            .arg(process_at)
-                                            .arg(&job.id)
-                                            .query_async::<()>(&mut task_conn)
-                                            .await;
-
-                                        tracing::warn!(
-                                            "Job {} failed (attempt {}/{}), retrying in {:?}: {}",
-                                            job.id,
+                                        match move_to_finished::move_to_finished(
+                                            &scripts,
+                                            &mut task_conn,
+                                            &task_prefix,
+                                            &task_name,
+                                            &job_id,
+                                            &task_token,
+                                            timestamp,
+                                            "{}",  // return value (empty JSON object)
+                                            "completed",
+                                            DEFAULT_MAX_EVENTS,
+                                            true,  // fetchNext
+                                            task_lock_duration,
                                             attempts,
-                                            job.max_attempts,
-                                            backoff_delay,
-                                            err
-                                        );
-                                    } else {
-                                        // Max attempts reached, move to failed
-                                        let now = Utc::now();
-                                        let _ = redis::cmd("ZADD")
-                                            .arg(format!(
-                                                "{}:{}:failed",
-                                                task_prefix, task_name
-                                            ))
-                                            .arg(now.timestamp_millis())
-                                            .arg(&job.id)
-                                            .query_async::<()>(&mut task_conn)
-                                            .await;
-                                        let _ = redis::cmd("HSET")
-                                            .arg(&job_key)
-                                            .arg("state")
-                                            .arg("failed")
-                                            .arg("finished_on")
-                                            .arg(now.timestamp_millis().to_string())
-                                            .arg("failed_reason")
-                                            .arg(err.to_string())
-                                            .arg("attempts_made")
-                                            .arg(attempts)
-                                            .query_async::<()>(&mut task_conn)
-                                            .await;
-
-                                        if let Some(ref cb) = on_failed {
-                                            if let Ok(val_job) = convert_job_to_value(&job) {
-                                                cb(&val_job, &err);
+                                        )
+                                        .await
+                                        {
+                                            Ok(move_to_finished::MoveToFinishedResult::NextJob(next)) => {
+                                                // Fast-path: send next job via channel.
+                                                if next.job_id.is_some() {
+                                                    let _ = next_job_tx.try_send(next);
+                                                }
+                                            }
+                                            Ok(move_to_finished::MoveToFinishedResult::Done) => {}
+                                            Err(BullmqError::LockMismatch) => {
+                                                tracing::warn!(
+                                                    "Lock mismatch finishing job {} (completed) - job may have been stalled",
+                                                    job_id
+                                                );
+                                            }
+                                            Err(e) => {
+                                                tracing::error!(
+                                                    "Error moving job {} to completed: {}",
+                                                    job_id,
+                                                    e
+                                                );
                                             }
                                         }
 
-                                        tracing::error!(
-                                            "Job {} permanently failed after {} attempts: {}",
-                                            job.id,
-                                            attempts,
-                                            err
-                                        );
+                                        // Invoke on_completed callback.
+                                        if let Some(ref cb) = on_completed {
+                                            if let Ok(val_job) = convert_job_to_value(&job) {
+                                                cb(&val_job);
+                                            }
+                                        }
+
+                                        tracing::debug!("Job {} completed", job_id);
+                                    }
+                                    Err(err) => {
+                                        let new_attempts = job.attempts_made + 1;
+                                        let max_attempts = job.opts.attempts.unwrap_or(1);
+
+                                        if new_attempts < max_attempts {
+                                            // Retries remaining: call moveToDelayed with backoff.
+                                            let backoff_delay = job
+                                                .opts
+                                                .backoff
+                                                .as_ref()
+                                                .map(|b| b.delay_for_attempt(job.attempts_made))
+                                                .unwrap_or(Duration::from_secs(1));
+
+                                            let timestamp = now_ms();
+                                            let delayed_timestamp =
+                                                timestamp + backoff_delay.as_millis() as u64;
+
+                                            match move_to_delayed::move_to_delayed(
+                                                &scripts,
+                                                &mut task_conn,
+                                                &task_prefix,
+                                                &task_name,
+                                                &job_id,
+                                                &task_token,
+                                                timestamp,
+                                                delayed_timestamp,
+                                                DEFAULT_MAX_EVENTS,
+                                            )
+                                            .await
+                                            {
+                                                Ok(()) => {
+                                                    tracing::warn!(
+                                                        "Job {} failed (attempt {}/{}), retrying in {:?}: {}",
+                                                        job_id,
+                                                        new_attempts,
+                                                        max_attempts,
+                                                        backoff_delay,
+                                                        err
+                                                    );
+                                                }
+                                                Err(BullmqError::LockMismatch) => {
+                                                    tracing::warn!(
+                                                        "Lock mismatch moving job {} to delayed - job may have been stalled",
+                                                        job_id
+                                                    );
+                                                }
+                                                Err(e) => {
+                                                    tracing::error!(
+                                                        "Error moving job {} to delayed: {}",
+                                                        job_id,
+                                                        e
+                                                    );
+                                                }
+                                            }
+
+                                            // Invoke on_failed callback even for retries.
+                                            if let Some(ref cb) = on_failed {
+                                                if let Ok(val_job) = convert_job_to_value(&job) {
+                                                    let bullmq_err = BullmqError::Other(err.to_string());
+                                                    cb(&val_job, &bullmq_err);
+                                                }
+                                            }
+                                        } else {
+                                            // No retries left: call moveToFinished(failed).
+                                            let timestamp = now_ms();
+                                            let failed_reason = err.to_string();
+
+                                            match move_to_finished::move_to_finished(
+                                                &scripts,
+                                                &mut task_conn,
+                                                &task_prefix,
+                                                &task_name,
+                                                &job_id,
+                                                &task_token,
+                                                timestamp,
+                                                &failed_reason,
+                                                "failed",
+                                                DEFAULT_MAX_EVENTS,
+                                                false, // don't fetch next on failure
+                                                task_lock_duration,
+                                                new_attempts,
+                                            )
+                                            .await
+                                            {
+                                                Ok(_) => {}
+                                                Err(BullmqError::LockMismatch) => {
+                                                    tracing::warn!(
+                                                        "Lock mismatch finishing job {} (failed) - job may have been stalled",
+                                                        job_id
+                                                    );
+                                                }
+                                                Err(e) => {
+                                                    tracing::error!(
+                                                        "Error moving job {} to failed: {}",
+                                                        job_id,
+                                                        e
+                                                    );
+                                                }
+                                            }
+
+                                            // Invoke on_failed callback.
+                                            if let Some(ref cb) = on_failed {
+                                                if let Ok(val_job) = convert_job_to_value(&job) {
+                                                    let bullmq_err = BullmqError::Other(err.to_string());
+                                                    cb(&val_job, &bullmq_err);
+                                                }
+                                            }
+
+                                            tracing::error!(
+                                                "Job {} permanently failed after {} attempts: {}",
+                                                job_id,
+                                                new_attempts,
+                                                err
+                                            );
+                                        }
                                     }
                                 }
-                            }
-                        });
-                    }
-                    Err(e) => {
-                        tracing::error!("Redis error while fetching job: {}", e);
-                        drop(permit);
-                        tokio::select! {
-                            _ = sleep(poll_interval) => continue,
-                            _ = shutdown_rx.changed() => break,
+
+                                // Unregister job ID from active_jobs.
+                                {
+                                    let mut set = active_jobs.lock().await;
+                                    set.remove(&job_id);
+                                }
+                            });
                         }
                     }
                 }
-            }
 
-            tracing::info!("Worker '{}' shut down", name);
+                // Graceful shutdown: wait for all in-flight jobs by acquiring all permits.
+                tracing::info!("Worker '{}' shutting down, waiting for in-flight jobs...", name);
+                let _ = semaphore.acquire_many(concurrency as u32).await;
+                tracing::info!("Worker '{}' shut down", name);
+
+                // Stop background tasks.
+                lock_extender_handle.abort();
+                if let Some(handle) = stalled_checker_handle {
+                    handle.abort();
+                }
+            }
         });
 
         Ok(WorkerHandle {
@@ -352,63 +599,6 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
             join_handle,
         })
     }
-}
-
-/// Move delayed jobs whose timestamp has passed to the waiting set.
-async fn promote_delayed_jobs(
-    conn: &ConnectionManager,
-    prefix: &str,
-    queue_name: &str,
-) -> BullmqResult<()> {
-    let mut conn = conn.clone();
-    let delayed_key = format!("{}:{}:delayed", prefix, queue_name);
-    let waiting_key = format!("{}:{}:waiting", prefix, queue_name);
-    let now = Utc::now().timestamp_millis();
-
-    // Get all delayed jobs whose score (process_at) is <= now
-    let jobs: Vec<(String, f64)> = redis::cmd("ZRANGEBYSCORE")
-        .arg(&delayed_key)
-        .arg(0i64)
-        .arg(now)
-        .arg("WITHSCORES")
-        .query_async(&mut conn)
-        .await?;
-
-    for (job_id, _score) in &jobs {
-        // Move from delayed to waiting
-        redis::cmd("ZREM")
-            .arg(&delayed_key)
-            .arg(job_id)
-            .query_async::<()>(&mut conn)
-            .await?;
-
-        // Get priority from job hash
-        let job_key = format!("{}:{}:{}", prefix, queue_name, job_id);
-        let priority: i32 = redis::cmd("HGET")
-            .arg(&job_key)
-            .arg("priority")
-            .query_async::<Option<i32>>(&mut conn)
-            .await?
-            .unwrap_or(0);
-
-        let score = -(priority as f64);
-        redis::cmd("ZADD")
-            .arg(&waiting_key)
-            .arg(score)
-            .arg(job_id)
-            .query_async::<()>(&mut conn)
-            .await?;
-
-        // Update state in hash
-        redis::cmd("HSET")
-            .arg(&job_key)
-            .arg("state")
-            .arg("waiting")
-            .query_async::<()>(&mut conn)
-            .await?;
-    }
-
-    Ok(())
 }
 
 /// Convert a `Job<T>` to `Job<serde_json::Value>` for type-erased callbacks.
@@ -419,18 +609,19 @@ fn convert_job_to_value<T: Serialize>(job: &Job<T>) -> BullmqResult<Job<serde_js
         name: job.name.clone(),
         data: value,
         state: job.state,
+        opts: job.opts.clone(),
         timestamp: job.timestamp,
         priority: job.priority,
         delay: job.delay,
         attempts_made: job.attempts_made,
-        max_attempts: job.max_attempts,
-        backoff: job.backoff.clone(),
-        ttl: job.ttl,
-        progress: job.progress,
+        attempts_started: job.attempts_started,
+        progress: job.progress.clone(),
         processed_on: job.processed_on,
         finished_on: job.finished_on,
         failed_reason: job.failed_reason.clone(),
+        stacktrace: job.stacktrace.clone(),
         return_value: job.return_value.clone(),
+        processed_by: job.processed_by.clone(),
     })
 }
 
@@ -475,9 +666,27 @@ impl WorkerBuilder {
         self
     }
 
-    /// Set the polling interval (default: 1 second).
-    pub fn poll_interval(mut self, d: std::time::Duration) -> Self {
-        self.options.poll_interval = d;
+    /// Set the duration a job lock is held before it can be considered stalled (default: 30s).
+    pub fn lock_duration(mut self, d: Duration) -> Self {
+        self.options.lock_duration = d;
+        self
+    }
+
+    /// Set how often to check for stalled jobs (default: 30s).
+    pub fn stalled_interval(mut self, d: Duration) -> Self {
+        self.options.stalled_interval = d;
+        self
+    }
+
+    /// Set the maximum number of times a job can be recovered from stalled state (default: 1).
+    pub fn max_stalled_count(mut self, n: u32) -> Self {
+        self.options.max_stalled_count = n;
+        self
+    }
+
+    /// Set whether to skip the stalled-job check entirely (default: false).
+    pub fn skip_stalled_check(mut self, skip: bool) -> Self {
+        self.options.skip_stalled_check = skip;
         self
     }
 
@@ -499,19 +708,21 @@ impl WorkerBuilder {
         self
     }
 
-    /// Build the worker, establishing the Redis connection.
-    pub async fn build<T: Serialize + DeserializeOwned + Send + Sync + 'static>(
-        self,
-    ) -> BullmqResult<Worker<T>> {
-        let conn = self.connection.get_manager().await?;
-        Ok(Worker {
+    /// Build the worker.
+    ///
+    /// Does not establish any Redis connections yet -- connections are created
+    /// lazily when [`Worker::start`] is called.
+    pub fn build<T: Serialize + DeserializeOwned + Send + Sync + 'static>(self) -> Worker<T> {
+        let scripts = Arc::new(ScriptLoader::new());
+        Worker {
             name: self.name,
             prefix: self.prefix,
-            conn,
+            conn: self.connection,
+            scripts,
             options: self.options,
             on_completed: self.on_completed,
             on_failed: self.on_failed,
             _phantom: PhantomData,
-        })
+        }
     }
 }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -16,9 +16,14 @@ use crate::job::{Job, JobContext};
 type CompletedCallback = Arc<dyn Fn(&Job<serde_json::Value>) + Send + Sync>;
 /// Type alias for the on_failed callback.
 type FailedCallback = Arc<dyn Fn(&Job<serde_json::Value>, &BullmqError) + Send + Sync>;
-use crate::scripts::commands::{extend_lock, move_stalled_jobs_to_wait, move_to_active, move_to_delayed, move_to_finished};
+use crate::scripts::commands::{
+    extend_lock, move_stalled_jobs_to_wait, move_to_active, move_to_delayed, move_to_finished,
+};
 use crate::scripts::ScriptLoader;
 use crate::types::{WorkerOptions, DEFAULT_MAX_EVENTS};
+
+const MARKER_BLOCK_TIMEOUT: Duration = Duration::from_secs(5);
+const BLOCKING_CONN_RESPONSE_TIMEOUT: Duration = Duration::from_secs(6);
 
 /// A worker that processes jobs from a queue.
 ///
@@ -104,7 +109,10 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
         Fut: Future<Output = Result<(), Box<dyn std::error::Error + Send + Sync>>> + Send,
     {
         // Create two independent ConnectionManager instances.
-        let blocking_conn = self.conn.get_manager().await?;
+        let blocking_conn = self
+            .conn
+            .get_manager_with_response_timeout(Some(BLOCKING_CONN_RESPONSE_TIMEOUT))
+            .await?;
         let cmd_conn = self.conn.get_manager().await?;
 
         // Generate a unique worker token.
@@ -131,7 +139,8 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
 
         // Channel for fast-path: moveToFinished can return the next job.
         // Capacity matches concurrency so concurrent handler completions don't drop prefetched jobs.
-        let (next_job_tx, next_job_rx) = tokio::sync::mpsc::channel::<move_to_active::MoveToActiveResult>(concurrency);
+        let (next_job_tx, next_job_rx) =
+            tokio::sync::mpsc::channel::<move_to_active::MoveToActiveResult>(concurrency);
         let next_job_rx = Arc::new(Mutex::new(next_job_rx));
 
         let join_handle = tokio::spawn({
@@ -185,7 +194,11 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                                         );
                                     }
                                     _ => {
-                                        tracing::warn!("Error extending lock for job {}: {}", job_id, e);
+                                        tracing::warn!(
+                                            "Error extending lock for job {}: {}",
+                                            job_id,
+                                            e
+                                        );
                                     }
                                 }
                             }
@@ -278,7 +291,7 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                         let bzpopmin_result: redis::RedisResult<redis::Value> =
                             redis::cmd("BZPOPMIN")
                                 .arg(&marker_key)
-                                .arg(5.0_f64)
+                                .arg(MARKER_BLOCK_TIMEOUT.as_secs_f64())
                                 .query_async(&mut blocking_conn)
                                 .await;
 
@@ -288,12 +301,16 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                         let parsed = match &bzpopmin_result {
                             Ok(redis::Value::Array(items)) if items.len() >= 3 => {
                                 let member = match &items[1] {
-                                    redis::Value::BulkString(b) => String::from_utf8_lossy(b).to_string(),
+                                    redis::Value::BulkString(b) => {
+                                        String::from_utf8_lossy(b).to_string()
+                                    }
                                     redis::Value::SimpleString(s) => s.clone(),
                                     _ => String::new(),
                                 };
                                 let score = match &items[2] {
-                                    redis::Value::BulkString(b) => String::from_utf8_lossy(b).parse::<f64>().unwrap_or(0.0),
+                                    redis::Value::BulkString(b) => {
+                                        String::from_utf8_lossy(b).parse::<f64>().unwrap_or(0.0)
+                                    }
                                     redis::Value::Double(f) => *f,
                                     redis::Value::Int(i) => *i as f64,
                                     _ => 0.0,
@@ -307,18 +324,14 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
 
                         // Check if the original result was a real error (not a timeout)
                         if let Err(ref e) = bzpopmin_result {
-                            // Timeouts and type errors (Nil response) are normal for BZPOPMIN
-                            let msg = e.to_string();
-                            if msg.contains("timed out") || msg.contains("response was nil") ||
-                               msg.contains("not compatible") {
+                            if !is_bzpopmin_timeout(e) {
+                                tracing::warn!("BZPOPMIN error: {}, retrying after delay", e);
+                                tokio::select! {
+                                    _ = tokio::time::sleep(Duration::from_secs(1)) => {},
+                                    _ = shutdown_rx.changed() => break,
+                                }
                                 continue;
                             }
-                            tracing::warn!("BZPOPMIN error: {}, retrying after delay", e);
-                            tokio::select! {
-                                _ = tokio::time::sleep(Duration::from_secs(1)) => {},
-                                _ = shutdown_rx.changed() => break,
-                            }
-                            continue;
                         }
 
                         match parsed {
@@ -377,7 +390,9 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                                     .await
                                     {
                                         Ok(result) if result.job_id.is_some() => Some(result),
-                                        Ok(_) => { continue; }
+                                        Ok(_) => {
+                                            continue;
+                                        }
                                         Err(e) => {
                                             tracing::warn!("moveToActive error after delay: {}", e);
                                             continue;
@@ -425,7 +440,9 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                                 .await
                                 {
                                     Ok(result) if result.job_id.is_some() => Some(result),
-                                    Ok(_) => { continue; }
+                                    Ok(_) => {
+                                        continue;
+                                    }
                                     Err(e) => {
                                         tracing::debug!("moveToActive recovery check: {}", e);
                                         continue;
@@ -439,13 +456,18 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                     if let Some(result) = move_result {
                         if let Some(job_id) = result.job_id {
                             // Deserialize the job from the hash data returned by moveToActive.
-                            let mut job: Job<T> = match Job::from_redis_hash(&job_id, &result.job_data) {
-                                Ok(j) => j,
-                                Err(e) => {
-                                    tracing::error!("Failed to deserialize job {}: {}", job_id, e);
-                                    continue;
-                                }
-                            };
+                            let mut job: Job<T> =
+                                match Job::from_redis_hash(&job_id, &result.job_data) {
+                                    Ok(j) => j,
+                                    Err(e) => {
+                                        tracing::error!(
+                                            "Failed to deserialize job {}: {}",
+                                            job_id,
+                                            e
+                                        );
+                                        continue;
+                                    }
+                                };
 
                             // Inject connection context, lock token, and active state
                             // for active-handle methods.
@@ -507,16 +529,20 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                                             &job_id,
                                             &task_token,
                                             timestamp,
-                                            "{}",  // return value (empty JSON object)
+                                            "{}", // return value (empty JSON object)
                                             "completed",
                                             DEFAULT_MAX_EVENTS,
-                                            true,  // fetchNext
+                                            true, // fetchNext
                                             task_lock_duration,
                                             attempts,
                                         )
                                         .await
                                         {
-                                            Ok(move_to_finished::MoveToFinishedResult::NextJob(next)) => {
+                                            Ok(
+                                                move_to_finished::MoveToFinishedResult::NextJob(
+                                                    next,
+                                                ),
+                                            ) => {
                                                 // Fast-path: send next job via channel.
                                                 if next.job_id.is_some() {
                                                     if let Err(e) = next_job_tx.try_send(next) {
@@ -611,7 +637,8 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                                             // Invoke on_failed callback even for retries.
                                             if let Some(ref cb) = on_failed {
                                                 if let Ok(val_job) = convert_job_to_value(&job) {
-                                                    let bullmq_err = BullmqError::Other(err.to_string());
+                                                    let bullmq_err =
+                                                        BullmqError::Other(err.to_string());
                                                     cb(&val_job, &bullmq_err);
                                                 }
                                             }
@@ -656,7 +683,8 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                                             // Invoke on_failed callback.
                                             if let Some(ref cb) = on_failed {
                                                 if let Ok(val_job) = convert_job_to_value(&job) {
-                                                    let bullmq_err = BullmqError::Other(err.to_string());
+                                                    let bullmq_err =
+                                                        BullmqError::Other(err.to_string());
                                                     cb(&val_job, &bullmq_err);
                                                 }
                                             }
@@ -682,7 +710,10 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                 }
 
                 // Graceful shutdown: wait for all in-flight jobs by acquiring all permits.
-                tracing::info!("Worker '{}' shutting down, waiting for in-flight jobs...", name);
+                tracing::info!(
+                    "Worker '{}' shutting down, waiting for in-flight jobs...",
+                    name
+                );
                 let _ = semaphore.acquire_many(concurrency as u32).await;
                 tracing::info!("Worker '{}' shut down", name);
 
@@ -699,6 +730,11 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
             join_handle,
         })
     }
+}
+
+fn is_bzpopmin_timeout(error: &redis::RedisError) -> bool {
+    let msg = error.to_string();
+    msg.contains("timed out") || msg.contains("response was nil") || msg.contains("not compatible")
 }
 
 /// Convert a `Job<T>` to `Job<serde_json::Value>` for type-erased callbacks.

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -11,6 +11,11 @@ use tokio::sync::{watch, Mutex, Semaphore};
 use crate::connection::RedisConnection;
 use crate::error::{BullmqError, BullmqResult};
 use crate::job::Job;
+
+/// Type alias for the on_completed callback.
+type CompletedCallback = Arc<dyn Fn(&Job<serde_json::Value>) + Send + Sync>;
+/// Type alias for the on_failed callback.
+type FailedCallback = Arc<dyn Fn(&Job<serde_json::Value>, &BullmqError) + Send + Sync>;
 use crate::scripts::commands::{extend_lock, move_stalled_jobs_to_wait, move_to_active, move_to_delayed, move_to_finished};
 use crate::scripts::ScriptLoader;
 use crate::types::WorkerOptions;
@@ -54,8 +59,8 @@ pub struct Worker<T> {
     conn: RedisConnection,
     scripts: Arc<ScriptLoader>,
     options: WorkerOptions,
-    on_completed: Option<Arc<dyn Fn(&Job<serde_json::Value>) + Send + Sync>>,
-    on_failed: Option<Arc<dyn Fn(&Job<serde_json::Value>, &BullmqError) + Send + Sync>>,
+    on_completed: Option<CompletedCallback>,
+    on_failed: Option<FailedCallback>,
     _phantom: PhantomData<T>,
 }
 
@@ -631,8 +636,8 @@ pub struct WorkerBuilder {
     connection: RedisConnection,
     prefix: String,
     options: WorkerOptions,
-    on_completed: Option<Arc<dyn Fn(&Job<serde_json::Value>) + Send + Sync>>,
-    on_failed: Option<Arc<dyn Fn(&Job<serde_json::Value>, &BullmqError) + Send + Sync>>,
+    on_completed: Option<CompletedCallback>,
+    on_failed: Option<FailedCallback>,
 }
 
 impl WorkerBuilder {

--- a/tests/compat/README.md
+++ b/tests/compat/README.md
@@ -1,0 +1,21 @@
+# Cross-Language Compatibility Tests
+
+These tests verify that bullmq-rs v2 produces Redis data that BullMQ Node.js can read and vice versa.
+
+## Prerequisites
+
+- Redis running on localhost:6379 (or set REDIS_URL)
+- Node.js 18+
+- `npm install` in this directory
+
+## Running
+
+```bash
+# Rust adds job, Node.js verifies it
+cargo run --example basic_queue  # add some jobs first
+node rust_producer_node_reader.js
+
+# Node.js adds job, Rust reads it
+node node_producer.js
+cargo run --example basic_worker  # process the job
+```

--- a/tests/compat/node_producer.js
+++ b/tests/compat/node_producer.js
@@ -1,0 +1,33 @@
+/**
+ * Adds a job using BullMQ Node.js for bullmq-rs to process.
+ *
+ * After running this, start a Rust worker to process the job:
+ *   cargo run --example basic_worker
+ */
+const { Queue } = require('bullmq');
+
+const REDIS_URL = process.env.REDIS_URL || 'redis://127.0.0.1:6379';
+
+async function main() {
+  const queue = new Queue('emails', {
+    connection: { url: REDIS_URL },
+  });
+
+  try {
+    const job = await queue.add('welcome', {
+      to: 'user@example.com',
+      subject: 'Hello from Node.js',
+      body: 'This job was created by BullMQ Node.js',
+    });
+
+    console.log(`Added job ${job.id} via BullMQ Node.js`);
+    console.log('Now run: cargo run --example basic_worker');
+  } finally {
+    await queue.close();
+  }
+}
+
+main().catch((err) => {
+  console.error('FAILED:', err.message);
+  process.exit(1);
+});

--- a/tests/compat/package.json
+++ b/tests/compat/package.json
@@ -1,0 +1,11 @@
+{
+  "private": true,
+  "description": "Cross-language compatibility tests for bullmq-rs v2",
+  "scripts": {
+    "test": "echo 'Run individual test scripts manually — see README'"
+  },
+  "dependencies": {
+    "bullmq": "^5.8.0",
+    "ioredis": "^5.0.0"
+  }
+}

--- a/tests/compat/rust_producer_node_reader.js
+++ b/tests/compat/rust_producer_node_reader.js
@@ -1,0 +1,47 @@
+/**
+ * Verifies that jobs added by bullmq-rs can be read by BullMQ Node.js.
+ *
+ * Run `cargo run --example basic_queue` first to populate the queue,
+ * then run this script.
+ */
+const { Queue } = require('bullmq');
+
+const REDIS_URL = process.env.REDIS_URL || 'redis://127.0.0.1:6379';
+
+async function main() {
+  const queue = new Queue('emails', {
+    connection: { url: REDIS_URL },
+  });
+
+  try {
+    const counts = await queue.getJobCounts();
+    console.log('Job counts:', counts);
+
+    if (counts.waiting === 0 && counts.delayed === 0) {
+      console.log('No jobs found. Run `cargo run --example basic_queue` first.');
+      process.exit(1);
+    }
+
+    // Try to read a waiting job
+    const jobs = await queue.getJobs(['waiting', 'delayed'], 0, 10);
+    console.log(`Found ${jobs.length} jobs`);
+
+    for (const job of jobs) {
+      console.log(`  Job ${job.id}: name=${job.name}, data=${JSON.stringify(job.data)}`);
+      // Verify we can read the data without WRONGTYPE errors
+      if (!job.data) {
+        console.error(`  ERROR: Job ${job.id} has no data`);
+        process.exit(1);
+      }
+    }
+
+    console.log('SUCCESS: All jobs readable by BullMQ Node.js');
+  } finally {
+    await queue.close();
+  }
+}
+
+main().catch((err) => {
+  console.error('FAILED:', err.message);
+  process.exit(1);
+});

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1359,6 +1359,7 @@ async fn test_flow_add_same_queue_parent_enters_waiting_children() {
         .build::<TestJob>()
         .await
         .unwrap();
+    queue.drain().await.unwrap();
 
     let producer = FlowProducerBuilder::new()
         .connection(conn.clone())
@@ -1443,6 +1444,7 @@ async fn test_flow_add_rejects_existing_custom_child_id() {
         .build::<TestJob>()
         .await
         .unwrap();
+    queue.drain().await.unwrap();
     let producer = FlowProducerBuilder::new()
         .connection(conn.clone())
         .build()
@@ -1503,6 +1505,220 @@ async fn test_flow_add_rejects_existing_custom_child_id() {
         .await
         .unwrap();
     assert!(parent_keys.is_empty());
+}
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_flow_add_rejects_duplicate_custom_ids_within_flow() {
+    let qname = unique_queue_name();
+    let conn = redis_conn();
+
+    let queue = QueueBuilder::new(&qname)
+        .connection(conn.clone())
+        .build::<TestJob>()
+        .await
+        .unwrap();
+    queue.drain().await.unwrap();
+    let producer = FlowProducerBuilder::new()
+        .connection(conn.clone())
+        .build()
+        .await
+        .unwrap();
+
+    let duplicate_id = "duplicate-child-id".to_string();
+    let flow = FlowJob {
+        name: "parent".into(),
+        queue_name: qname.clone(),
+        data: TestJob {
+            value: "parent".into(),
+        },
+        prefix: None,
+        opts: None,
+        children: vec![
+            FlowJob {
+                name: "child-a".into(),
+                queue_name: qname.clone(),
+                data: TestJob {
+                    value: "child-a".into(),
+                },
+                prefix: None,
+                opts: Some(JobOptions {
+                    job_id: Some(duplicate_id.clone()),
+                    ..Default::default()
+                }),
+                children: vec![],
+            },
+            FlowJob {
+                name: "child-b".into(),
+                queue_name: qname.clone(),
+                data: TestJob {
+                    value: "child-b".into(),
+                },
+                prefix: None,
+                opts: Some(JobOptions {
+                    job_id: Some(duplicate_id.clone()),
+                    ..Default::default()
+                }),
+                children: vec![],
+            },
+        ],
+    };
+
+    let err = producer.add(flow).await.unwrap_err();
+    assert!(
+        err.to_string().contains("duplicated within the flow"),
+        "unexpected error: {err}"
+    );
+    assert_eq!(queue.get_waiting_children_count().await.unwrap(), 0);
+    assert_eq!(queue.get_waiting_count().await.unwrap(), 0);
+}
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_flow_add_same_queue_parent_with_delayed_child_tracks_metadata() {
+    let qname = unique_queue_name();
+    let conn = redis_conn();
+
+    let queue = QueueBuilder::new(&qname)
+        .connection(conn.clone())
+        .build::<TestJob>()
+        .await
+        .unwrap();
+    queue.drain().await.unwrap();
+    let producer = FlowProducerBuilder::new()
+        .connection(conn.clone())
+        .build()
+        .await
+        .unwrap();
+
+    let flow = FlowJob {
+        name: "parent".into(),
+        queue_name: qname.clone(),
+        data: TestJob {
+            value: "parent".into(),
+        },
+        prefix: None,
+        opts: None,
+        children: vec![FlowJob {
+            name: "child".into(),
+            queue_name: qname.clone(),
+            data: TestJob {
+                value: "child".into(),
+            },
+            prefix: None,
+            opts: Some(JobOptions {
+                delay: Some(Duration::from_secs(60)),
+                ..Default::default()
+            }),
+            children: vec![],
+        }],
+    };
+
+    let node = producer.add(flow).await.unwrap();
+    assert_eq!(queue.get_waiting_children_count().await.unwrap(), 1);
+    assert_eq!(queue.get_delayed_count().await.unwrap(), 1);
+
+    let parent_key = format!("bull:{}:{}", qname, node.job.id);
+    let child_key = format!("bull:{}:{}", qname, node.children[0].job.id);
+
+    let mut raw = raw_redis_conn().await;
+    let parent_meta: (Option<String>, Option<String>) = redis::cmd("HMGET")
+        .arg(child_key)
+        .arg("parentKey")
+        .arg("parent")
+        .query_async(&mut raw)
+        .await
+        .unwrap();
+    assert_eq!(parent_meta.0.as_deref(), Some(parent_key.as_str()));
+
+    let parent_json: serde_json::Value =
+        serde_json::from_str(parent_meta.1.as_deref().unwrap()).unwrap();
+    assert_eq!(parent_json["id"], node.job.id);
+    assert_eq!(parent_json["queue"], format!("bull:{qname}"));
+}
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_flow_remove_and_drain_cleanup_waiting_children_and_dependencies() {
+    let qname = unique_queue_name();
+    let conn = redis_conn();
+
+    let queue = QueueBuilder::new(&qname)
+        .connection(conn.clone())
+        .build::<TestJob>()
+        .await
+        .unwrap();
+    queue.drain().await.unwrap();
+    let producer = FlowProducerBuilder::new()
+        .connection(conn.clone())
+        .build()
+        .await
+        .unwrap();
+
+    let flow = FlowJob {
+        name: "parent".into(),
+        queue_name: qname.clone(),
+        data: TestJob {
+            value: "parent".into(),
+        },
+        prefix: None,
+        opts: None,
+        children: vec![FlowJob {
+            name: "child".into(),
+            queue_name: qname.clone(),
+            data: TestJob {
+                value: "child".into(),
+            },
+            prefix: None,
+            opts: None,
+            children: vec![],
+        }],
+    };
+
+    let node = producer.add(flow.clone()).await.unwrap();
+    let parent_id = node.job.id.clone();
+    let child_id = node.children[0].job.id.clone();
+    let parent_deps_key = format!("bull:{}:{}:dependencies", qname, parent_id);
+
+    queue.remove(&parent_id).await.unwrap();
+    assert_eq!(queue.get_waiting_children_count().await.unwrap(), 0);
+
+    let mut raw = raw_redis_conn().await;
+    let deps_exists: bool = redis::cmd("EXISTS")
+        .arg(&parent_deps_key)
+        .query_async(&mut raw)
+        .await
+        .unwrap();
+    assert!(!deps_exists);
+
+    let child_after_parent_remove = queue.get_job(&child_id).await.unwrap();
+    assert!(child_after_parent_remove.is_some());
+
+    let second = producer.add(flow.clone()).await.unwrap();
+    let second_parent_deps_key = format!("bull:{}:{}:dependencies", qname, second.job.id);
+    second.job.remove().await.unwrap();
+
+    let second_deps_exists: bool = redis::cmd("EXISTS")
+        .arg(&second_parent_deps_key)
+        .query_async(&mut raw)
+        .await
+        .unwrap();
+    assert!(!second_deps_exists);
+    assert_eq!(queue.get_waiting_children_count().await.unwrap(), 0);
+
+    let third = producer.add(flow).await.unwrap();
+    let third_parent_deps_key = format!("bull:{}:{}:dependencies", qname, third.job.id);
+    queue.drain().await.unwrap();
+
+    assert_eq!(queue.get_waiting_children_count().await.unwrap(), 0);
+    assert_eq!(queue.get_waiting_count().await.unwrap(), 0);
+
+    let third_deps_exists: bool = redis::cmd("EXISTS")
+        .arg(&third_parent_deps_key)
+        .query_async(&mut raw)
+        .await
+        .unwrap();
+    assert!(!third_deps_exists);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -895,6 +895,78 @@ async fn test_concurrent_workers() {
 }
 
 // ---------------------------------------------------------------------------
+// 19. test_job_change_priority
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_job_change_priority() {
+    let conn = RedisConnection::new(
+        std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string()),
+    );
+    let queue = QueueBuilder::new(&unique_queue_name())
+        .connection(conn)
+        .build::<String>()
+        .await
+        .unwrap();
+
+    // Add a standard (priority=0) job — goes to wait list
+    let mut job = queue.add("test", "data".to_string(), None).await.unwrap();
+    assert_eq!(job.priority, 0);
+
+    // Change priority to 5 — should move to prioritized set
+    job.change_priority(5).await.unwrap();
+    assert_eq!(job.priority, 5);
+
+    // Verify it's now in prioritized state
+    let state = job.get_state().await.unwrap();
+    assert_eq!(state, JobState::Prioritized);
+
+    // Change back to 0 — should move to wait list
+    job.change_priority(0).await.unwrap();
+    assert_eq!(job.priority, 0);
+
+    let state = job.get_state().await.unwrap();
+    assert_eq!(state, JobState::Wait);
+
+    queue.drain().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// 20. test_job_promote
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_job_promote() {
+    let conn = RedisConnection::new(
+        std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string()),
+    );
+    let queue = QueueBuilder::new(&unique_queue_name())
+        .connection(conn)
+        .build::<String>()
+        .await
+        .unwrap();
+
+    let opts = JobOptions {
+        delay: Some(Duration::from_secs(3600)),
+        ..Default::default()
+    };
+    let mut job = queue.add("test", "data".to_string(), Some(opts)).await.unwrap();
+
+    let state = job.get_state().await.unwrap();
+    assert_eq!(state, JobState::Delayed);
+
+    job.promote().await.unwrap();
+    assert_eq!(job.delay, 0);
+
+    let state = job.get_state().await.unwrap();
+    assert_eq!(state, JobState::Wait);
+
+    queue.drain().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
 // 18. test_job_remove
 // ---------------------------------------------------------------------------
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -150,6 +150,320 @@ async fn test_queue_job_counts() {
 }
 
 // ---------------------------------------------------------------------------
+// 3. test_queue_count_methods
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_queue_count_methods() {
+    let qname = unique_queue_name();
+    let conn = redis_conn();
+
+    let queue = QueueBuilder::new(&qname)
+        .connection(conn)
+        .build::<TestJob>()
+        .await
+        .unwrap();
+
+    for i in 0..3 {
+        queue
+            .add(
+                "std",
+                TestJob {
+                    value: format!("s{}", i),
+                },
+                None,
+            )
+            .await
+            .unwrap();
+    }
+
+    let delayed_opts = JobOptions {
+        delay: Some(Duration::from_secs(3600)),
+        ..Default::default()
+    };
+    queue
+        .add(
+            "delayed",
+            TestJob { value: "d0".into() },
+            Some(delayed_opts),
+        )
+        .await
+        .unwrap();
+
+    let prio_opts = JobOptions {
+        priority: Some(5),
+        ..Default::default()
+    };
+    queue
+        .add("prio", TestJob { value: "p0".into() }, Some(prio_opts))
+        .await
+        .unwrap();
+
+    let total = queue.count().await.unwrap();
+    assert_eq!(total, 5);
+    assert_eq!(queue.get_waiting_count().await.unwrap(), 3);
+    assert_eq!(queue.get_active_count().await.unwrap(), 0);
+    assert_eq!(queue.get_delayed_count().await.unwrap(), 1);
+    assert_eq!(queue.get_prioritized_count().await.unwrap(), 1);
+    assert_eq!(queue.get_completed_count().await.unwrap(), 0);
+    assert_eq!(queue.get_failed_count().await.unwrap(), 0);
+    assert_eq!(queue.get_waiting_children_count().await.unwrap(), 0);
+
+    queue.drain().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// 4. test_queue_get_jobs
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_queue_get_jobs() {
+    let qname = unique_queue_name();
+    let conn = redis_conn();
+
+    let queue = QueueBuilder::new(&qname)
+        .connection(conn)
+        .build::<TestJob>()
+        .await
+        .unwrap();
+
+    for i in 0..3 {
+        queue
+            .add(
+                "std",
+                TestJob {
+                    value: format!("job-{}", i),
+                },
+                None,
+            )
+            .await
+            .unwrap();
+    }
+
+    let delayed_opts = JobOptions {
+        delay: Some(Duration::from_secs(3600)),
+        ..Default::default()
+    };
+    queue
+        .add(
+            "delayed",
+            TestJob {
+                value: "delayed-0".into(),
+            },
+            Some(delayed_opts),
+        )
+        .await
+        .unwrap();
+
+    let waiting = queue
+        .get_jobs(&[JobState::Wait], 0, -1, true)
+        .await
+        .unwrap();
+    assert_eq!(waiting.len(), 3);
+
+    let mixed = queue
+        .get_jobs(&[JobState::Wait, JobState::Delayed], 0, -1, true)
+        .await
+        .unwrap();
+    assert_eq!(mixed.len(), 4);
+
+    let page = queue.get_jobs(&[JobState::Wait], 0, 1, true).await.unwrap();
+    assert_eq!(page.len(), 2);
+
+    let mut first = waiting.into_iter().next().unwrap();
+    let state = first.get_state().await.unwrap();
+    assert_eq!(state, JobState::Wait);
+
+    queue.drain().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// 5. test_queue_convenience_getters
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_queue_convenience_getters() {
+    let qname = unique_queue_name();
+    let conn = redis_conn();
+
+    let queue = QueueBuilder::new(&qname)
+        .connection(conn.clone())
+        .build::<TestJob>()
+        .await
+        .unwrap();
+
+    for i in 0..3 {
+        queue
+            .add(
+                "std",
+                TestJob {
+                    value: format!("w{}", i),
+                },
+                None,
+            )
+            .await
+            .unwrap();
+    }
+
+    let delayed_opts = JobOptions {
+        delay: Some(Duration::from_secs(3600)),
+        ..Default::default()
+    };
+    queue
+        .add(
+            "delayed",
+            TestJob { value: "d0".into() },
+            Some(delayed_opts),
+        )
+        .await
+        .unwrap();
+
+    let prio_opts = JobOptions {
+        priority: Some(5),
+        ..Default::default()
+    };
+    queue
+        .add("prio", TestJob { value: "p0".into() }, Some(prio_opts))
+        .await
+        .unwrap();
+
+    let waiting = queue.get_waiting(0, -1).await.unwrap();
+    assert_eq!(waiting.len(), 3);
+    assert!(waiting[0].timestamp <= waiting[1].timestamp);
+    assert!(waiting[1].timestamp <= waiting[2].timestamp);
+
+    let delayed = queue.get_delayed(0, -1).await.unwrap();
+    assert_eq!(delayed.len(), 1);
+
+    let prioritized = queue.get_prioritized(0, -1).await.unwrap();
+    assert_eq!(prioritized.len(), 1);
+
+    let active = queue.get_active(0, -1).await.unwrap();
+    assert_eq!(active.len(), 0);
+
+    let completed = queue.get_completed(0, -1).await.unwrap();
+    assert_eq!(completed.len(), 0);
+
+    let failed = queue.get_failed(0, -1).await.unwrap();
+    assert_eq!(failed.len(), 0);
+
+    let waiting_children = queue.get_waiting_children(0, -1).await.unwrap();
+    assert_eq!(waiting_children.len(), 0);
+
+    queue.drain().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// 6. test_queue_get_waiting_includes_paused
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_queue_get_waiting_includes_paused() {
+    let qname = unique_queue_name();
+    let conn = redis_conn();
+
+    let queue = QueueBuilder::new(&qname)
+        .connection(conn)
+        .build::<TestJob>()
+        .await
+        .unwrap();
+
+    queue
+        .add("before_pause", TestJob { value: "a".into() }, None)
+        .await
+        .unwrap();
+
+    queue.pause().await.unwrap();
+
+    queue
+        .add("after_pause", TestJob { value: "b".into() }, None)
+        .await
+        .unwrap();
+
+    let waiting = queue.get_waiting(0, -1).await.unwrap();
+    assert_eq!(waiting.len(), 2);
+
+    queue.resume().await.unwrap();
+    queue.drain().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// 7. test_queue_get_completed_and_failed
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_queue_get_completed_and_failed() {
+    let qname = unique_queue_name();
+    let conn = redis_conn();
+
+    let queue = QueueBuilder::new(&qname)
+        .connection(conn.clone())
+        .build::<String>()
+        .await
+        .unwrap();
+
+    queue.add("ok", "success".to_string(), None).await.unwrap();
+    queue
+        .add("fail", "will_fail".to_string(), None)
+        .await
+        .unwrap();
+
+    let worker = WorkerBuilder::new(&qname)
+        .connection(conn.clone())
+        .concurrency(1)
+        .skip_stalled_check(true)
+        .build::<String>();
+
+    let processed = Arc::new(Mutex::new(0u32));
+    let processed_clone = processed.clone();
+
+    let handle = worker
+        .start(move |job| {
+            let processed = processed_clone.clone();
+            async move {
+                let mut p = processed.lock().await;
+                *p += 1;
+                if job.data == "will_fail" {
+                    Err("intentional failure".into())
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .await
+        .unwrap();
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    loop {
+        if *processed.lock().await >= 2 {
+            break;
+        }
+        if tokio::time::Instant::now() > deadline {
+            panic!("Timed out waiting for jobs to process");
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    handle.shutdown();
+    handle.wait().await.unwrap();
+
+    let completed = queue.get_completed(0, -1).await.unwrap();
+    assert_eq!(completed.len(), 1);
+    assert_eq!(completed[0].data, "success");
+
+    let failed = queue.get_failed(0, -1).await.unwrap();
+    assert_eq!(failed.len(), 1);
+    assert_eq!(failed[0].data, "will_fail");
+
+    queue.drain().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
 // 3. test_queue_remove_job
 // ---------------------------------------------------------------------------
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -808,15 +808,14 @@ async fn test_job_get_state_delayed() {
 #[tokio::test]
 #[ignore = "requires running Redis"]
 async fn test_concurrent_workers() {
+    let qname = unique_queue_name();
     let conn = redis_conn();
 
-    let queue = QueueBuilder::new("test_concurrent_v2")
+    let queue = QueueBuilder::new(&qname)
         .connection(conn.clone())
         .build::<TestJob>()
         .await
         .unwrap();
-
-    queue.drain().await.unwrap();
 
     // Add 10 jobs
     for i in 0..10 {
@@ -836,10 +835,11 @@ async fn test_concurrent_workers() {
 
     // Start worker 1
     let count1 = processed_count.clone();
-    let worker1 = WorkerBuilder::new("test_concurrent_v2")
+    let worker1 = WorkerBuilder::new(&qname)
         .connection(conn.clone())
         .concurrency(3)
-        .skip_stalled_check(true)
+        .lock_duration(Duration::from_secs(5))
+        .stalled_interval(Duration::from_secs(3))
         .build::<TestJob>();
 
     let handle1 = worker1
@@ -857,10 +857,11 @@ async fn test_concurrent_workers() {
 
     // Start worker 2
     let count2 = processed_count.clone();
-    let worker2 = WorkerBuilder::new("test_concurrent_v2")
+    let worker2 = WorkerBuilder::new(&qname)
         .connection(conn)
         .concurrency(3)
-        .skip_stalled_check(true)
+        .lock_duration(Duration::from_secs(5))
+        .stalled_interval(Duration::from_secs(3))
         .build::<TestJob>();
 
     let handle2 = worker2
@@ -876,8 +877,20 @@ async fn test_concurrent_workers() {
         .await
         .unwrap();
 
-    // Wait for all jobs to be processed
-    tokio::time::sleep(Duration::from_secs(10)).await;
+    // Wait for all jobs to be processed. With two workers competing,
+    // stalled job recovery may be needed for the last job, so allow
+    // enough time for multiple stalled check cycles.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
+    loop {
+        let c = *processed_count.lock().await;
+        if c >= 10 {
+            break;
+        }
+        if tokio::time::Instant::now() > deadline {
+            panic!("Timed out: only {}/10 jobs processed by concurrent workers", c);
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
 
     handle1.shutdown();
     handle2.shutdown();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -967,6 +967,33 @@ async fn test_job_promote() {
 }
 
 // ---------------------------------------------------------------------------
+// 21. test_job_stubs_not_implemented
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_job_stubs_not_implemented() {
+    let queue = QueueBuilder::new(&unique_queue_name())
+        .connection(redis_conn())
+        .build::<String>()
+        .await
+        .unwrap();
+
+    let job = queue.add("test", "data".to_string(), None).await.unwrap();
+
+    let err = job.wait_until_finished(None).await.unwrap_err();
+    assert!(err.to_string().contains("Not implemented"));
+
+    let err = job.get_dependencies().await.unwrap_err();
+    assert!(err.to_string().contains("Not implemented"));
+
+    let err = job.get_children_values().await.unwrap_err();
+    assert!(err.to_string().contains("Not implemented"));
+
+    queue.drain().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
 // 18. test_job_remove
 // ---------------------------------------------------------------------------
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1863,6 +1863,20 @@ async fn test_flow_releases_parent_to_prioritized() {
         .await
         .unwrap();
 
+    let existing = parent
+        .add(
+            "existing-priority",
+            TestJob {
+                value: "existing".into(),
+            },
+            Some(JobOptions {
+                priority: Some(10),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
     let child_worker = WorkerBuilder::new(&child_queue)
         .connection(conn.clone())
         .build::<TestJob>();
@@ -1916,16 +1930,41 @@ async fn test_flow_releases_parent_to_prioritized() {
     let counts = parent.get_job_counts().await.unwrap();
 
     assert_eq!(*counts.get(&JobState::WaitingChildren).unwrap(), 0);
-    assert_eq!(*counts.get(&JobState::Prioritized).unwrap(), 1);
+    assert_eq!(*counts.get(&JobState::Prioritized).unwrap(), 2);
     assert_eq!(
         parent.get_waiting_count().await.unwrap(),
         0,
         "unexpected counts after prioritized parent release: {counts:?}"
     );
 
+    let prioritized_key = format!("bull:{parent_queue}:prioritized");
+    let existing_score: Option<f64> = redis::cmd("ZSCORE")
+        .arg(&prioritized_key)
+        .arg(&existing.id)
+        .query_async(&mut raw)
+        .await
+        .unwrap();
+    let parent_score: Option<f64> = redis::cmd("ZSCORE")
+        .arg(&prioritized_key)
+        .arg(&node.job.id)
+        .query_async(&mut raw)
+        .await
+        .unwrap();
+    let existing_score = existing_score.expect("existing prioritized job missing");
+    let parent_score = parent_score.expect("released parent missing from prioritized");
+    let priority_base = 10f64 * 4_294_967_296f64;
+    assert!(
+        existing_score >= priority_base && parent_score >= priority_base,
+        "prioritized scores must use BullMQ getPriorityScore base; existing={existing_score}, parent={parent_score}"
+    );
+    assert!(
+        parent_score > existing_score,
+        "same-priority parent released later should get a larger BullMQ score; existing={existing_score}, parent={parent_score}"
+    );
+
     let prioritized = parent.get_prioritized(0, -1).await.unwrap();
-    assert_eq!(prioritized.len(), 1);
-    assert_eq!(prioritized[0].id, node.job.id);
+    let prioritized_ids: Vec<String> = prioritized.into_iter().map(|job| job.id).collect();
+    assert_eq!(prioritized_ids, vec![existing.id.clone(), node.job.id.clone()]);
 
     child_handle.shutdown();
     child_handle.wait().await.unwrap();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1607,13 +1607,22 @@ async fn test_flow_parent_runs_after_all_children_complete() {
         .await
         .unwrap();
 
-    tokio::time::sleep(Duration::from_secs(2)).await;
-
-    let seen = seen.lock().await.clone();
-    assert_eq!(seen, vec!["child:c1", "child:c2", "parent:p"]);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        let current = seen.lock().await.clone();
+        if current == vec!["child:c1", "child:c2", "parent:p"] {
+            break;
+        }
+        if tokio::time::Instant::now() > deadline {
+            panic!("Timed out waiting for flow completion, saw {current:?}");
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
 
     child_handle.shutdown();
     parent_handle.shutdown();
+    child_handle.wait().await.unwrap();
+    parent_handle.wait().await.unwrap();
 }
 
 #[tokio::test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1846,6 +1846,209 @@ async fn test_flow_releases_parent_with_bullmq_wait_order() {
 
 #[tokio::test]
 #[ignore = "requires running Redis"]
+async fn test_flow_releases_parent_to_prioritized() {
+    let parent_queue = unique_queue_name();
+    let child_queue = unique_queue_name();
+    let conn = redis_conn();
+
+    let parent = QueueBuilder::new(&parent_queue)
+        .connection(conn.clone())
+        .build::<TestJob>()
+        .await
+        .unwrap();
+
+    let producer = FlowProducerBuilder::new()
+        .connection(conn.clone())
+        .build()
+        .await
+        .unwrap();
+
+    let child_worker = WorkerBuilder::new(&child_queue)
+        .connection(conn.clone())
+        .build::<TestJob>();
+    let child_handle = child_worker
+        .start(|_job| async move { Ok(()) })
+        .await
+        .unwrap();
+
+    let node = producer
+        .add(FlowJob {
+            name: "parent".into(),
+            queue_name: parent_queue.clone(),
+            data: TestJob { value: "p".into() },
+            prefix: None,
+            opts: Some(JobOptions {
+                priority: Some(10),
+                ..Default::default()
+            }),
+            children: vec![FlowJob {
+                name: "child".into(),
+                queue_name: child_queue.clone(),
+                data: TestJob { value: "c1".into() },
+                prefix: None,
+                opts: None,
+                children: vec![],
+            }],
+        })
+        .await
+        .unwrap();
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        if parent.get_waiting_children_count().await.unwrap() == 0 {
+            break;
+        }
+        if tokio::time::Instant::now() > deadline {
+            panic!("Timed out waiting for prioritized parent release");
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    let mut raw = raw_redis_conn().await;
+    let stored_priority: i64 = redis::cmd("HGET")
+        .arg(format!("bull:{}:{}", parent_queue, node.job.id))
+        .arg("priority")
+        .query_async(&mut raw)
+        .await
+        .unwrap();
+    assert_eq!(stored_priority, 10);
+
+    let counts = parent.get_job_counts().await.unwrap();
+
+    assert_eq!(*counts.get(&JobState::WaitingChildren).unwrap(), 0);
+    assert_eq!(*counts.get(&JobState::Prioritized).unwrap(), 1);
+    assert_eq!(
+        parent.get_waiting_count().await.unwrap(),
+        0,
+        "unexpected counts after prioritized parent release: {counts:?}"
+    );
+
+    let prioritized = parent.get_prioritized(0, -1).await.unwrap();
+    assert_eq!(prioritized.len(), 1);
+    assert_eq!(prioritized[0].id, node.job.id);
+
+    child_handle.shutdown();
+    child_handle.wait().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_flow_releases_parent_to_paused_queue() {
+    let parent_queue = unique_queue_name();
+    let child_queue = unique_queue_name();
+    let conn = redis_conn();
+
+    let parent = QueueBuilder::new(&parent_queue)
+        .connection(conn.clone())
+        .build::<TestJob>()
+        .await
+        .unwrap();
+
+    let producer = FlowProducerBuilder::new()
+        .connection(conn.clone())
+        .build()
+        .await
+        .unwrap();
+
+    parent.pause().await.unwrap();
+    assert!(parent.is_paused().await.unwrap());
+
+    let parent_seen = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+    let parent_seen_worker = parent_seen.clone();
+
+    let parent_worker = WorkerBuilder::new(&parent_queue)
+        .connection(conn.clone())
+        .build::<TestJob>();
+    let parent_handle = parent_worker
+        .start(move |job| {
+            let parent_seen_worker = parent_seen_worker.clone();
+            async move {
+                parent_seen_worker
+                    .lock()
+                    .await
+                    .push(format!("parent:{}", job.data.value));
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+    let child_worker = WorkerBuilder::new(&child_queue)
+        .connection(conn.clone())
+        .build::<TestJob>();
+    let child_handle = child_worker
+        .start(|_job| async move { Ok(()) })
+        .await
+        .unwrap();
+
+    producer
+        .add(FlowJob {
+            name: "parent".into(),
+            queue_name: parent_queue.clone(),
+            data: TestJob { value: "p".into() },
+            prefix: None,
+            opts: None,
+            children: vec![FlowJob {
+                name: "child".into(),
+                queue_name: child_queue.clone(),
+                data: TestJob { value: "c1".into() },
+                prefix: None,
+                opts: None,
+                children: vec![],
+            }],
+        })
+        .await
+        .unwrap();
+
+    let release_deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        let parent_released = parent.get_waiting_children_count().await.unwrap() == 0;
+        let waiting_includes_parent = parent.get_waiting_count().await.unwrap() == 1;
+        if parent_released && waiting_includes_parent {
+            break;
+        }
+        if tokio::time::Instant::now() > release_deadline {
+            panic!("Timed out waiting for paused parent release");
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    let counts = parent.get_job_counts().await.unwrap();
+    assert_eq!(*counts.get(&JobState::WaitingChildren).unwrap(), 0);
+    assert_eq!(*counts.get(&JobState::Paused).unwrap(), 1);
+    assert_eq!(*counts.get(&JobState::Wait).unwrap(), 0);
+    assert_eq!(parent.get_waiting_count().await.unwrap(), 1);
+
+    tokio::time::sleep(Duration::from_millis(750)).await;
+    assert!(
+        parent_seen.lock().await.is_empty(),
+        "parent job should not be claimed while queue is paused"
+    );
+    assert_eq!(parent.get_completed_count().await.unwrap(), 0);
+
+    parent.resume().await.unwrap();
+
+    let completion_deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        if parent.get_completed_count().await.unwrap() == 1 {
+            break;
+        }
+        if tokio::time::Instant::now() > completion_deadline {
+            panic!("Timed out waiting for parent completion after resume");
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    assert_eq!(parent_seen.lock().await.as_slice(), ["parent:p"]);
+
+    child_handle.shutdown();
+    parent_handle.shutdown();
+    child_handle.wait().await.unwrap();
+    parent_handle.wait().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
 async fn test_flow_add_rejects_existing_custom_child_id() {
     let qname = unique_queue_name();
     let conn = redis_conn();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,5 +1,6 @@
 use bullmq_rs::*;
 use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Mutex;
@@ -25,12 +26,15 @@ async fn raw_redis_conn() -> redis::aio::ConnectionManager {
 
 /// Helper: generate a unique queue name for tests that need isolation.
 fn unique_queue_name() -> String {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
     use std::time::{SystemTime, UNIX_EPOCH};
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
-        .subsec_nanos();
-    format!("test_unique_{}", nanos)
+        .as_nanos();
+    let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    format!("test_unique_{}_{}_{}", pid, nanos, counter)
 }
 
 // ---------------------------------------------------------------------------
@@ -1719,6 +1723,119 @@ async fn test_flow_remove_and_drain_cleanup_waiting_children_and_dependencies() 
         .await
         .unwrap();
     assert!(!third_deps_exists);
+}
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_flow_add_rejects_watch_window_collision_cleanly() {
+    let qname = unique_queue_name();
+    let conn = redis_conn();
+
+    let queue = QueueBuilder::new(&qname)
+        .connection(conn.clone())
+        .build::<TestJob>()
+        .await
+        .unwrap();
+    queue.drain().await.unwrap();
+
+    let producer = FlowProducerBuilder::new()
+        .connection(conn.clone())
+        .build()
+        .await
+        .unwrap();
+
+    let colliding_id = "watched-colliding-child-id".to_string();
+    let hook_open_key = format!("test:flow-hook-open:{qname}");
+    let hook_release_key = format!("test:flow-hook-release:{qname}");
+    std::env::set_var("BULLMQ_RS_FLOW_ADD_WATCH_HOOK_QUEUE", &qname);
+    std::env::set_var("BULLMQ_RS_FLOW_ADD_WATCH_HOOK_OPEN_KEY", &hook_open_key);
+    std::env::set_var("BULLMQ_RS_FLOW_ADD_WATCH_HOOK_RELEASE_KEY", &hook_release_key);
+
+    let flow = FlowJob {
+        name: "parent".into(),
+        queue_name: qname.clone(),
+        data: TestJob {
+            value: "parent".into(),
+        },
+        prefix: None,
+        opts: None,
+        children: vec![FlowJob {
+            name: "child".into(),
+            queue_name: qname.clone(),
+            data: TestJob {
+                value: "child".into(),
+            },
+            prefix: None,
+            opts: Some(JobOptions {
+                job_id: Some(colliding_id.clone()),
+                ..Default::default()
+            }),
+            children: vec![],
+        }],
+    };
+
+    let add_handle = tokio::spawn(async move { producer.add(flow).await });
+
+    let mut raw = raw_redis_conn().await;
+    for _ in 0..200 {
+        let open: bool = redis::cmd("EXISTS")
+            .arg(&hook_open_key)
+            .query_async(&mut raw)
+            .await
+            .unwrap();
+        if open {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    let open: bool = redis::cmd("EXISTS")
+        .arg(&hook_open_key)
+        .query_async(&mut raw)
+        .await
+        .unwrap();
+    assert!(open, "watch hook did not open");
+
+    queue
+        .add(
+            "competing",
+            TestJob {
+                value: "competing".into(),
+            },
+            Some(JobOptions {
+                job_id: Some(colliding_id.clone()),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+    redis::cmd("SET")
+        .arg(&hook_release_key)
+        .arg("1")
+        .query_async::<redis::Value>(&mut raw)
+        .await
+        .unwrap();
+
+    let result = add_handle.await.unwrap();
+    std::env::remove_var("BULLMQ_RS_FLOW_ADD_WATCH_HOOK_QUEUE");
+    std::env::remove_var("BULLMQ_RS_FLOW_ADD_WATCH_HOOK_OPEN_KEY");
+    std::env::remove_var("BULLMQ_RS_FLOW_ADD_WATCH_HOOK_RELEASE_KEY");
+
+    let err = result.unwrap_err();
+    assert!(
+        err.to_string().contains("transaction aborted"),
+        "unexpected error: {err}"
+    );
+
+    assert_eq!(queue.get_waiting_children_count().await.unwrap(), 0);
+    assert_eq!(queue.get_waiting_count().await.unwrap(), 1);
+
+    let parent_keys: Vec<String> = redis::cmd("KEYS")
+        .arg(format!("bull:{qname}:*:dependencies"))
+        .query_async(&mut raw)
+        .await
+        .unwrap();
+    assert!(parent_keys.is_empty());
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1837,7 +1837,6 @@ async fn test_flow_add_rejects_watch_window_collision_cleanly() {
         .unwrap();
     assert!(parent_keys.is_empty());
 }
-
 // ---------------------------------------------------------------------------
 // 22. test_worker_processes_preexisting_jobs
 // ---------------------------------------------------------------------------

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1345,6 +1345,75 @@ async fn test_job_remove() {
 }
 
 // ---------------------------------------------------------------------------
+// 19. test_flow_add_same_queue_parent_enters_waiting_children
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_flow_add_same_queue_parent_enters_waiting_children() {
+    let qname = unique_queue_name();
+    let conn = redis_conn();
+
+    let queue = QueueBuilder::new(&qname)
+        .connection(conn.clone())
+        .build::<TestJob>()
+        .await
+        .unwrap();
+
+    let producer = FlowProducerBuilder::new()
+        .connection(conn.clone())
+        .build()
+        .await
+        .unwrap();
+
+    let flow = FlowJob {
+        name: "parent".into(),
+        queue_name: qname.clone(),
+        data: TestJob {
+            value: "parent".into(),
+        },
+        prefix: None,
+        opts: None,
+        children: vec![FlowJob {
+            name: "child".into(),
+            queue_name: qname.clone(),
+            data: TestJob {
+                value: "child".into(),
+            },
+            prefix: None,
+            opts: None,
+            children: vec![],
+        }],
+    };
+
+    let node = producer.add(flow).await.unwrap();
+
+    assert_eq!(node.children.len(), 1);
+    assert_eq!(queue.get_waiting_children_count().await.unwrap(), 1);
+    assert_eq!(queue.get_waiting_count().await.unwrap(), 1);
+
+    let parent_key = format!("bull:{}:{}", qname, node.job.id);
+    let child_key = format!("bull:{}:{}", qname, node.children[0].job.id);
+
+    let mut raw = raw_redis_conn().await;
+    let deps: Vec<String> = redis::cmd("SMEMBERS")
+        .arg(format!("{parent_key}:dependencies"))
+        .query_async(&mut raw)
+        .await
+        .unwrap();
+    assert_eq!(deps, vec![child_key.clone()]);
+
+    let parent_meta: (Option<String>, Option<String>) = redis::cmd("HMGET")
+        .arg(child_key)
+        .arg("parentKey")
+        .arg("parent")
+        .query_async(&mut raw)
+        .await
+        .unwrap();
+    assert_eq!(parent_meta.0.as_deref(), Some(parent_key.as_str()));
+}
+
+// ---------------------------------------------------------------------------
 // 22. test_worker_processes_preexisting_jobs
 // ---------------------------------------------------------------------------
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -893,3 +893,30 @@ async fn test_concurrent_workers() {
 
     queue.drain().await.unwrap();
 }
+
+// ---------------------------------------------------------------------------
+// 18. test_job_remove
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_job_remove() {
+    let conn = RedisConnection::new(
+        std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string()),
+    );
+    let queue = QueueBuilder::new(&unique_queue_name())
+        .connection(conn)
+        .build::<String>()
+        .await
+        .unwrap();
+
+    let job = queue.add("test", "data".to_string(), None).await.unwrap();
+    let job_id = job.id.clone();
+
+    job.remove().await.unwrap();
+
+    let fetched = queue.get_job(&job_id).await.unwrap();
+    assert!(fetched.is_none());
+
+    queue.drain().await.unwrap();
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1627,6 +1627,176 @@ async fn test_flow_parent_runs_after_all_children_complete() {
 
 #[tokio::test]
 #[ignore = "requires running Redis"]
+async fn test_flow_releases_delayed_parent_to_delayed() {
+    let parent_queue = unique_queue_name();
+    let child_queue = unique_queue_name();
+    let conn = redis_conn();
+
+    let parent = QueueBuilder::new(&parent_queue)
+        .connection(conn.clone())
+        .build::<TestJob>()
+        .await
+        .unwrap();
+    let child = QueueBuilder::new(&child_queue)
+        .connection(conn.clone())
+        .build::<TestJob>()
+        .await
+        .unwrap();
+
+    let producer = FlowProducerBuilder::new()
+        .connection(conn.clone())
+        .build()
+        .await
+        .unwrap();
+
+    let seen = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+    let child_seen = seen.clone();
+
+    let child_worker = WorkerBuilder::new(&child_queue)
+        .connection(conn.clone())
+        .build::<TestJob>();
+    let child_handle = child_worker
+        .start(move |job| {
+            let child_seen = child_seen.clone();
+            async move {
+                child_seen
+                    .lock()
+                    .await
+                    .push(format!("child:{}", job.data.value));
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+    let node = producer
+        .add(FlowJob {
+            name: "parent".into(),
+            queue_name: parent_queue.clone(),
+            data: TestJob { value: "p".into() },
+            prefix: None,
+            opts: Some(JobOptions {
+                delay: Some(Duration::from_secs(60)),
+                ..Default::default()
+            }),
+            children: vec![FlowJob {
+                name: "child".into(),
+                queue_name: child_queue.clone(),
+                data: TestJob { value: "c1".into() },
+                prefix: None,
+                opts: None,
+                children: vec![],
+            }],
+        })
+        .await
+        .unwrap();
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        let child_done = seen.lock().await.as_slice() == ["child:c1"];
+        let parent_released = parent.get_waiting_children_count().await.unwrap() == 0;
+        if child_done && parent_released {
+            break;
+        }
+        if tokio::time::Instant::now() > deadline {
+            panic!(
+                "Timed out waiting for delayed parent release, saw {:?}",
+                seen.lock().await
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    assert_eq!(parent.get_waiting_count().await.unwrap(), 0);
+    assert_eq!(parent.get_delayed_count().await.unwrap(), 1);
+    assert_eq!(child.get_completed_count().await.unwrap(), 1);
+
+    let delayed = parent.get_delayed(0, -1).await.unwrap();
+    assert_eq!(delayed.len(), 1);
+    assert_eq!(delayed[0].id, node.job.id);
+
+    child_handle.shutdown();
+    child_handle.wait().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_flow_releases_parent_with_bullmq_wait_order() {
+    let parent_queue = unique_queue_name();
+    let child_queue = unique_queue_name();
+    let conn = redis_conn();
+
+    let parent = QueueBuilder::new(&parent_queue)
+        .connection(conn.clone())
+        .build::<TestJob>()
+        .await
+        .unwrap();
+
+    let producer = FlowProducerBuilder::new()
+        .connection(conn.clone())
+        .build()
+        .await
+        .unwrap();
+
+    let existing = parent
+        .add(
+            "existing",
+            TestJob {
+                value: "existing".into(),
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    let child_worker = WorkerBuilder::new(&child_queue)
+        .connection(conn.clone())
+        .build::<TestJob>();
+    let child_handle = child_worker
+        .start(|_job| async move { Ok(()) })
+        .await
+        .unwrap();
+
+    let node = producer
+        .add(FlowJob {
+            name: "parent".into(),
+            queue_name: parent_queue.clone(),
+            data: TestJob { value: "p".into() },
+            prefix: None,
+            opts: None,
+            children: vec![FlowJob {
+                name: "child".into(),
+                queue_name: child_queue.clone(),
+                data: TestJob { value: "c1".into() },
+                prefix: None,
+                opts: None,
+                children: vec![],
+            }],
+        })
+        .await
+        .unwrap();
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        if parent.get_waiting_children_count().await.unwrap() == 0 {
+            break;
+        }
+        if tokio::time::Instant::now() > deadline {
+            panic!("Timed out waiting for parent release");
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    let waiting = parent.get_waiting(0, -1).await.unwrap();
+    let waiting_ids: Vec<String> = waiting.into_iter().map(|job| job.id).collect();
+    assert_eq!(waiting_ids, vec![node.job.id.clone(), existing.id.clone()]);
+
+    child_handle.shutdown();
+    child_handle.wait().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
 async fn test_flow_add_rejects_existing_custom_child_id() {
     let qname = unique_queue_name();
     let conn = redis_conn();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1439,6 +1439,65 @@ async fn test_flow_add_same_queue_parent_enters_waiting_children() {
 
 #[tokio::test]
 #[ignore = "requires running Redis"]
+async fn test_flow_add_cross_queue_tree_tracks_all_dependencies() {
+    let parent_queue = unique_queue_name();
+    let child_queue = unique_queue_name();
+    let conn = redis_conn();
+
+    let parent = QueueBuilder::new(&parent_queue)
+        .connection(conn.clone())
+        .build::<TestJob>()
+        .await
+        .unwrap();
+
+    let child = QueueBuilder::new(&child_queue)
+        .connection(conn.clone())
+        .build::<TestJob>()
+        .await
+        .unwrap();
+
+    let producer = FlowProducerBuilder::new()
+        .connection(conn.clone())
+        .build()
+        .await
+        .unwrap();
+
+    let node = producer
+        .add(FlowJob {
+            name: "parent".into(),
+            queue_name: parent_queue.clone(),
+            data: TestJob { value: "p".into() },
+            prefix: None,
+            opts: None,
+            children: vec![
+                FlowJob {
+                    name: "c1".into(),
+                    queue_name: child_queue.clone(),
+                    data: TestJob { value: "c1".into() },
+                    prefix: None,
+                    opts: None,
+                    children: vec![],
+                },
+                FlowJob {
+                    name: "c2".into(),
+                    queue_name: child_queue.clone(),
+                    data: TestJob { value: "c2".into() },
+                    prefix: None,
+                    opts: None,
+                    children: vec![],
+                },
+            ],
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(parent.get_waiting_children_count().await.unwrap(), 1);
+    assert_eq!(child.get_waiting_count().await.unwrap(), 2);
+    assert_eq!(node.children.len(), 2);
+}
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
 async fn test_flow_add_rejects_existing_custom_child_id() {
     let qname = unique_queue_name();
     let conn = redis_conn();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -633,7 +633,119 @@ async fn test_events_stream() {
 }
 
 // ---------------------------------------------------------------------------
-// 11. test_concurrent_workers
+// 11. test_job_update_progress
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_job_update_progress() {
+    let queue = QueueBuilder::new("test_update_progress_v2")
+        .connection(redis_conn())
+        .build::<String>()
+        .await
+        .unwrap();
+
+    queue.drain().await.unwrap();
+
+    let mut job = queue.add("test", "data".to_string(), None).await.unwrap();
+
+    let progress = serde_json::json!({"percent": 50});
+    job.update_progress(progress.clone()).await.unwrap();
+
+    // Verify local state updated
+    assert_eq!(job.progress, Some(progress.clone()));
+
+    // Verify Redis state updated
+    let fetched = queue.get_job(&job.id).await.unwrap().unwrap();
+    assert_eq!(fetched.progress, Some(progress));
+
+    queue.drain().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// 12. test_job_log
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_job_log() {
+    let queue = QueueBuilder::new("test_job_log_v2")
+        .connection(redis_conn())
+        .build::<String>()
+        .await
+        .unwrap();
+
+    queue.drain().await.unwrap();
+
+    let job = queue.add("test", "data".to_string(), None).await.unwrap();
+
+    let count = job.log("first log").await.unwrap();
+    assert_eq!(count, 1);
+    let count = job.log("second log").await.unwrap();
+    assert_eq!(count, 2);
+
+    let logs = queue.get_logs(&job.id, 0, -1).await.unwrap();
+    assert_eq!(logs, vec!["first log", "second log"]);
+
+    queue.drain().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// 13. test_job_update_data
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_job_update_data() {
+    let queue = QueueBuilder::new("test_update_data_v2")
+        .connection(redis_conn())
+        .build::<String>()
+        .await
+        .unwrap();
+
+    queue.drain().await.unwrap();
+
+    let mut job = queue.add("test", "original".to_string(), None).await.unwrap();
+
+    job.update_data("updated".to_string()).await.unwrap();
+
+    assert_eq!(job.data, "updated");
+
+    let fetched = queue.get_job(&job.id).await.unwrap().unwrap();
+    assert_eq!(fetched.data, "updated");
+
+    queue.drain().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// 14. test_job_clear_logs
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_job_clear_logs() {
+    let queue = QueueBuilder::new("test_clear_logs_v2")
+        .connection(redis_conn())
+        .build::<String>()
+        .await
+        .unwrap();
+
+    queue.drain().await.unwrap();
+
+    let job = queue.add("test", "data".to_string(), None).await.unwrap();
+    job.log("entry 1").await.unwrap();
+    job.log("entry 2").await.unwrap();
+
+    job.clear_logs().await.unwrap();
+
+    let logs = queue.get_logs(&job.id, 0, -1).await.unwrap();
+    assert!(logs.is_empty());
+
+    queue.drain().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// 15. test_concurrent_workers
 // ---------------------------------------------------------------------------
 
 #[tokio::test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -23,6 +23,16 @@ async fn raw_redis_conn() -> redis::aio::ConnectionManager {
     redis::aio::ConnectionManager::new(client).await.unwrap()
 }
 
+/// Helper: generate a unique queue name for tests that need isolation.
+fn unique_queue_name() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .subsec_nanos();
+    format!("test_unique_{}", nanos)
+}
+
 // ---------------------------------------------------------------------------
 // 1. test_queue_add_and_get_job
 // ---------------------------------------------------------------------------
@@ -745,7 +755,54 @@ async fn test_job_clear_logs() {
 }
 
 // ---------------------------------------------------------------------------
-// 15. test_concurrent_workers
+// 15. test_job_get_state
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_job_get_state() {
+    let queue = QueueBuilder::new(&unique_queue_name())
+        .connection(redis_conn())
+        .build::<String>()
+        .await
+        .unwrap();
+
+    let mut job = queue.add("test", "data".to_string(), None).await.unwrap();
+    let state = job.get_state().await.unwrap();
+    assert_eq!(state, JobState::Wait);
+    assert!(job.is_waiting().await.unwrap());
+    assert!(!job.is_completed().await.unwrap());
+
+    queue.drain().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// 16. test_job_get_state_delayed
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_job_get_state_delayed() {
+    let queue = QueueBuilder::new(&unique_queue_name())
+        .connection(redis_conn())
+        .build::<String>()
+        .await
+        .unwrap();
+
+    let opts = JobOptions {
+        delay: Some(Duration::from_secs(3600)),
+        ..Default::default()
+    };
+    let mut job = queue.add("test", "data".to_string(), Some(opts)).await.unwrap();
+    let state = job.get_state().await.unwrap();
+    assert_eq!(state, JobState::Delayed);
+    assert!(job.is_delayed().await.unwrap());
+
+    queue.drain().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// 17. test_concurrent_workers
 // ---------------------------------------------------------------------------
 
 #[tokio::test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1411,6 +1411,98 @@ async fn test_flow_add_same_queue_parent_enters_waiting_children() {
         .await
         .unwrap();
     assert_eq!(parent_meta.0.as_deref(), Some(parent_key.as_str()));
+
+    let parent_json: serde_json::Value =
+        serde_json::from_str(parent_meta.1.as_deref().unwrap()).unwrap();
+    assert_eq!(parent_json["id"], node.job.id);
+    assert_eq!(parent_json["queue"], format!("bull:{qname}"));
+
+    let mut child_job = node.children[0].job.clone();
+    child_job
+        .update_progress(serde_json::json!({ "step": 1 }))
+        .await
+        .unwrap();
+
+    let progress: String = redis::cmd("HGET")
+        .arg(format!("bull:{}:{}", qname, node.children[0].job.id))
+        .arg("progress")
+        .query_async(&mut raw)
+        .await
+        .unwrap();
+    assert_eq!(progress, r#"{"step":1}"#);
+}
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_flow_add_rejects_existing_custom_child_id() {
+    let qname = unique_queue_name();
+    let conn = redis_conn();
+
+    let queue = QueueBuilder::new(&qname)
+        .connection(conn.clone())
+        .build::<TestJob>()
+        .await
+        .unwrap();
+    let producer = FlowProducerBuilder::new()
+        .connection(conn.clone())
+        .build()
+        .await
+        .unwrap();
+
+    let existing_child_id = "existing-child-id".to_string();
+    queue
+        .add(
+            "existing",
+            TestJob {
+                value: "already-there".into(),
+            },
+            Some(JobOptions {
+                job_id: Some(existing_child_id.clone()),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+    let flow = FlowJob {
+        name: "parent".into(),
+        queue_name: qname.clone(),
+        data: TestJob {
+            value: "parent".into(),
+        },
+        prefix: None,
+        opts: None,
+        children: vec![FlowJob {
+            name: "child".into(),
+            queue_name: qname.clone(),
+            data: TestJob {
+                value: "child".into(),
+            },
+            prefix: None,
+            opts: Some(JobOptions {
+                job_id: Some(existing_child_id.clone()),
+                ..Default::default()
+            }),
+            children: vec![],
+        }],
+    };
+
+    let err = producer.add(flow).await.unwrap_err();
+    assert!(
+        err.to_string().contains("already exists"),
+        "unexpected error: {err}"
+    );
+
+    assert_eq!(queue.get_waiting_children_count().await.unwrap(), 0);
+    assert_eq!(queue.get_waiting_count().await.unwrap(), 1);
+
+    let mut raw = raw_redis_conn().await;
+    let parent_keys: Vec<String> = redis::cmd("KEYS")
+        .arg(format!("bull:{qname}:*:dependencies"))
+        .query_async(&mut raw)
+        .await
+        .unwrap();
+    assert!(parent_keys.is_empty());
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1529,6 +1529,95 @@ async fn test_flow_add_cross_queue_tree_tracks_all_dependencies() {
 
 #[tokio::test]
 #[ignore = "requires running Redis"]
+async fn test_flow_parent_runs_after_all_children_complete() {
+    let parent_queue = unique_queue_name();
+    let child_queue = unique_queue_name();
+    let conn = redis_conn();
+
+    let producer = FlowProducerBuilder::new()
+        .connection(conn.clone())
+        .build()
+        .await
+        .unwrap();
+
+    let seen = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+    let child_seen = seen.clone();
+    let parent_seen = seen.clone();
+
+    let child_worker = WorkerBuilder::new(&child_queue)
+        .connection(conn.clone())
+        .build::<TestJob>();
+    let child_handle = child_worker
+        .start(move |job| {
+            let child_seen = child_seen.clone();
+            async move {
+                child_seen
+                    .lock()
+                    .await
+                    .push(format!("child:{}", job.data.value));
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+    let parent_worker = WorkerBuilder::new(&parent_queue)
+        .connection(conn.clone())
+        .build::<TestJob>();
+    let parent_handle = parent_worker
+        .start(move |job| {
+            let parent_seen = parent_seen.clone();
+            async move {
+                parent_seen
+                    .lock()
+                    .await
+                    .push(format!("parent:{}", job.data.value));
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+    producer
+        .add(FlowJob {
+            name: "parent".into(),
+            queue_name: parent_queue.clone(),
+            data: TestJob { value: "p".into() },
+            prefix: None,
+            opts: None,
+            children: vec![
+                FlowJob {
+                    name: "child-1".into(),
+                    queue_name: child_queue.clone(),
+                    data: TestJob { value: "c1".into() },
+                    prefix: None,
+                    opts: None,
+                    children: vec![],
+                },
+                FlowJob {
+                    name: "child-2".into(),
+                    queue_name: child_queue.clone(),
+                    data: TestJob { value: "c2".into() },
+                    prefix: None,
+                    opts: None,
+                    children: vec![],
+                },
+            ],
+        })
+        .await
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let seen = seen.lock().await.clone();
+    assert_eq!(seen, vec!["child:c1", "child:c2", "parent:p"]);
+
+    child_handle.shutdown();
+    parent_handle.shutdown();
+}
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
 async fn test_flow_add_rejects_existing_custom_child_id() {
     let qname = unique_queue_name();
     let conn = redis_conn();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1112,6 +1112,105 @@ async fn test_worker_processes_preexisting_jobs() {
 }
 
 // ---------------------------------------------------------------------------
+// 23. test_worker_recovers_waiting_job_without_marker
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_worker_recovers_waiting_job_without_marker() {
+    let qname = unique_queue_name();
+    let conn = redis_conn();
+
+    let queue = QueueBuilder::new(&qname)
+        .connection(conn.clone())
+        .build::<TestJob>()
+        .await
+        .unwrap();
+
+    let completed = Arc::new(Mutex::new(false));
+    let completed_clone = completed.clone();
+
+    let worker = WorkerBuilder::new(&qname)
+        .connection(conn.clone())
+        .concurrency(1)
+        .build::<TestJob>();
+
+    let handle = worker
+        .start(move |_job| {
+            let completed = completed_clone.clone();
+            async move {
+                *completed.lock().await = true;
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+    // Let the worker settle into its idle blocking loop.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let mut raw = raw_redis_conn().await;
+    let job_id = "manual-no-marker";
+    let wait_key = format!("bull:{}:wait", qname);
+    let marker_key = format!("bull:{}:marker", qname);
+    let job_key = format!("bull:{}:{}", qname, job_id);
+    let data = serde_json::to_string(&TestJob {
+        value: "manual".into(),
+    })
+    .unwrap();
+
+    redis::cmd("HSET")
+        .arg(&job_key)
+        .arg("name")
+        .arg("manual")
+        .arg("data")
+        .arg(&data)
+        .arg("opts")
+        .arg("{}")
+        .arg("timestamp")
+        .arg("1")
+        .arg("delay")
+        .arg("0")
+        .arg("priority")
+        .arg("0")
+        .arg("atm")
+        .arg("0")
+        .arg("ats")
+        .arg("0")
+        .query_async::<()>(&mut raw)
+        .await
+        .unwrap();
+
+    redis::cmd("LPUSH")
+        .arg(&wait_key)
+        .arg(job_id)
+        .query_async::<()>(&mut raw)
+        .await
+        .unwrap();
+
+    redis::cmd("DEL")
+        .arg(&marker_key)
+        .query_async::<()>(&mut raw)
+        .await
+        .unwrap();
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(8);
+    loop {
+        if *completed.lock().await {
+            break;
+        }
+        if tokio::time::Instant::now() > deadline {
+            panic!("Timed out waiting for worker to recover a wait job without a marker");
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    handle.shutdown();
+    handle.wait().await.unwrap();
+    queue.drain().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
 // 24. test_queue_events_basic_flow
 // ---------------------------------------------------------------------------
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1876,7 +1876,6 @@ async fn test_flow_releases_parent_to_prioritized() {
         )
         .await
         .unwrap();
-
     let child_worker = WorkerBuilder::new(&child_queue)
         .connection(conn.clone())
         .build::<TestJob>();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1102,6 +1102,201 @@ async fn test_worker_processes_preexisting_jobs() {
 }
 
 // ---------------------------------------------------------------------------
+// 24. test_queue_events_basic_flow
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_queue_events_basic_flow() {
+    let qname = unique_queue_name();
+    let conn = redis_conn();
+
+    // Start QueueEvents with last_event_id "0" to get all events from the beginning
+    let mut qe = QueueEventsBuilder::new(&qname)
+        .connection(conn.clone())
+        .last_event_id("0")
+        .blocking_timeout(2_000)
+        .build()
+        .await
+        .unwrap();
+
+    let mut rx = qe.subscribe();
+
+    // Add a job
+    let queue = QueueBuilder::new(&qname)
+        .connection(conn.clone())
+        .build::<TestJob>()
+        .await
+        .unwrap();
+
+    queue
+        .add("test_job", TestJob { value: "hello".into() }, None)
+        .await
+        .unwrap();
+
+    // Start a worker to process it
+    let worker = WorkerBuilder::new(&qname)
+        .connection(conn.clone())
+        .concurrency(1)
+        .build::<TestJob>();
+
+    let handle = worker
+        .start(|_job| async move { Ok(()) })
+        .await
+        .unwrap();
+
+    // Collect events until we see Completed (max 10s)
+    let mut events = Vec::new();
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        tokio::select! {
+            result = rx.recv() => {
+                match result {
+                    Ok((event, _stream_id)) => {
+                        events.push(event);
+                        if events.iter().any(|e| matches!(e, QueueEvent::Completed { .. })) {
+                            break;
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+            _ = tokio::time::sleep_until(deadline) => {
+                panic!("Timed out waiting for events. Got: {:?}", events);
+            }
+        }
+    }
+
+    // Verify we got the key lifecycle events
+    assert!(events.iter().any(|e| matches!(e, QueueEvent::Added { .. })));
+    assert!(events.iter().any(|e| matches!(e, QueueEvent::Waiting { .. })));
+    assert!(events.iter().any(|e| matches!(e, QueueEvent::Active { .. })));
+    assert!(events.iter().any(|e| matches!(e, QueueEvent::Completed { .. })));
+
+    handle.shutdown();
+    handle.wait().await.unwrap();
+    qe.close().await.unwrap();
+    queue.drain().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// 25. test_queue_events_producer
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_queue_events_producer() {
+    let qname = unique_queue_name();
+    let conn = redis_conn();
+
+    let mut qe = QueueEventsBuilder::new(&qname)
+        .connection(conn.clone())
+        .last_event_id("0")
+        .blocking_timeout(2_000)
+        .build()
+        .await
+        .unwrap();
+
+    let mut rx = qe.subscribe();
+
+    let producer = QueueEventsProducerBuilder::new(&qname)
+        .connection(conn.clone())
+        .build()
+        .await
+        .unwrap();
+
+    producer
+        .publish("my_custom_event", &[("jobId", "99"), ("status", "exported")])
+        .await
+        .unwrap();
+
+    // Wait for the custom event
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        tokio::select! {
+            result = rx.recv() => {
+                match result {
+                    Ok((QueueEvent::Unknown { event, fields }, _)) => {
+                        assert_eq!(event, "my_custom_event");
+                        assert_eq!(fields.get("jobId").unwrap(), "99");
+                        assert_eq!(fields.get("status").unwrap(), "exported");
+                        break;
+                    }
+                    Ok(_) => continue,
+                    Err(_) => panic!("Channel closed"),
+                }
+            }
+            _ = tokio::time::sleep_until(deadline) => {
+                panic!("Timed out waiting for custom event");
+            }
+        }
+    }
+
+    qe.close().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// 26. test_queue_events_multiple_subscribers
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_queue_events_multiple_subscribers() {
+    let qname = unique_queue_name();
+    let conn = redis_conn();
+
+    let mut qe = QueueEventsBuilder::new(&qname)
+        .connection(conn.clone())
+        .last_event_id("0")
+        .blocking_timeout(2_000)
+        .build()
+        .await
+        .unwrap();
+
+    let mut rx1 = qe.subscribe();
+    let mut rx2 = qe.subscribe();
+
+    let producer = QueueEventsProducerBuilder::new(&qname)
+        .connection(conn.clone())
+        .build()
+        .await
+        .unwrap();
+
+    producer
+        .publish("test_event", &[("data", "hello")])
+        .await
+        .unwrap();
+
+    let timeout = Duration::from_secs(5);
+    let (e1, _) = tokio::time::timeout(timeout, rx1.recv()).await.unwrap().unwrap();
+    let (e2, _) = tokio::time::timeout(timeout, rx2.recv()).await.unwrap().unwrap();
+
+    assert_eq!(e1, e2);
+
+    qe.close().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// 27. test_queue_events_shutdown
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_queue_events_shutdown() {
+    let qname = unique_queue_name();
+    let conn = redis_conn();
+
+    let mut qe = QueueEventsBuilder::new(&qname)
+        .connection(conn)
+        .blocking_timeout(2_000)
+        .build()
+        .await
+        .unwrap();
+
+    qe.close().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
 // 23. test_worker_continuous_processing_no_stall
 // ---------------------------------------------------------------------------
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1494,6 +1494,37 @@ async fn test_flow_add_cross_queue_tree_tracks_all_dependencies() {
     assert_eq!(parent.get_waiting_children_count().await.unwrap(), 1);
     assert_eq!(child.get_waiting_count().await.unwrap(), 2);
     assert_eq!(node.children.len(), 2);
+
+    let parent_key = format!("bull:{}:{}", parent_queue, node.job.id);
+    let child_keys: std::collections::HashSet<String> = node
+        .children
+        .iter()
+        .map(|child_node| format!("bull:{}:{}", child_queue, child_node.job.id))
+        .collect();
+
+    let mut raw = raw_redis_conn().await;
+    let deps: std::collections::HashSet<String> = redis::cmd("SMEMBERS")
+        .arg(format!("{parent_key}:dependencies"))
+        .query_async(&mut raw)
+        .await
+        .unwrap();
+    assert_eq!(deps, child_keys);
+
+    for child_key in &child_keys {
+        let parent_meta: (Option<String>, Option<String>) = redis::cmd("HMGET")
+            .arg(child_key)
+            .arg("parentKey")
+            .arg("parent")
+            .query_async(&mut raw)
+            .await
+            .unwrap();
+        assert_eq!(parent_meta.0.as_deref(), Some(parent_key.as_str()));
+
+        let parent_json: serde_json::Value =
+            serde_json::from_str(parent_meta.1.as_deref().unwrap()).unwrap();
+        assert_eq!(parent_json["id"], node.job.id);
+        assert_eq!(parent_json["queue"], format!("bull:{parent_queue}"));
+    }
 }
 
 #[tokio::test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -18,8 +18,7 @@ fn redis_conn() -> RedisConnection {
 
 /// Helper: get a raw redis ConnectionManager for direct Redis commands in tests.
 async fn raw_redis_conn() -> redis::aio::ConnectionManager {
-    let url =
-        std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string());
+    let url = std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string());
     let client = redis::Client::open(url.as_str()).unwrap();
     redis::aio::ConnectionManager::new(client).await.unwrap()
 }
@@ -92,7 +91,10 @@ async fn test_queue_add_and_get_job() {
         .query_async(&mut conn)
         .await
         .unwrap();
-    assert!(data.contains("hello"), "data field should contain serialized job data");
+    assert!(
+        data.contains("hello"),
+        "data field should contain serialized job data"
+    );
 
     let timestamp: String = redis::cmd("HGET")
         .arg(&job_key)
@@ -573,10 +575,7 @@ async fn test_worker_processes_job() {
         .skip_stalled_check(true)
         .build::<TestJob>();
 
-    let handle = worker
-        .start(|_job| async move { Ok(()) })
-        .await
-        .unwrap();
+    let handle = worker.start(|_job| async move { Ok(()) }).await.unwrap();
 
     // Wait for processing
     tokio::time::sleep(Duration::from_secs(3)).await;
@@ -631,8 +630,7 @@ async fn test_worker_retry_then_fail() {
 
     let handle = worker
         .start(|_job| async move {
-            let err: Box<dyn std::error::Error + Send + Sync> =
-                "intentional failure".into();
+            let err: Box<dyn std::error::Error + Send + Sync> = "intentional failure".into();
             Err(err)
         })
         .await
@@ -817,10 +815,7 @@ async fn test_pause_resume() {
         .skip_stalled_check(true)
         .build::<TestJob>();
 
-    let handle = worker
-        .start(|_job| async move { Ok(()) })
-        .await
-        .unwrap();
+    let handle = worker.start(|_job| async move { Ok(()) }).await.unwrap();
 
     tokio::time::sleep(Duration::from_secs(3)).await;
     handle.shutdown();
@@ -921,10 +916,7 @@ async fn test_events_stream() {
         .skip_stalled_check(true)
         .build::<TestJob>();
 
-    let handle = worker
-        .start(|_job| async move { Ok(()) })
-        .await
-        .unwrap();
+    let handle = worker.start(|_job| async move { Ok(()) }).await.unwrap();
 
     tokio::time::sleep(Duration::from_secs(3)).await;
     handle.shutdown();
@@ -1033,7 +1025,10 @@ async fn test_job_update_data() {
 
     queue.drain().await.unwrap();
 
-    let mut job = queue.add("test", "original".to_string(), None).await.unwrap();
+    let mut job = queue
+        .add("test", "original".to_string(), None)
+        .await
+        .unwrap();
 
     job.update_data("updated".to_string()).await.unwrap();
 
@@ -1111,7 +1106,10 @@ async fn test_job_get_state_delayed() {
         delay: Some(Duration::from_secs(3600)),
         ..Default::default()
     };
-    let mut job = queue.add("test", "data".to_string(), Some(opts)).await.unwrap();
+    let mut job = queue
+        .add("test", "data".to_string(), Some(opts))
+        .await
+        .unwrap();
     let state = job.get_state().await.unwrap();
     assert_eq!(state, JobState::Delayed);
     assert!(job.is_delayed().await.unwrap());
@@ -1205,7 +1203,10 @@ async fn test_concurrent_workers() {
             break;
         }
         if tokio::time::Instant::now() > deadline {
-            panic!("Timed out: only {}/10 jobs processed by concurrent workers", c);
+            panic!(
+                "Timed out: only {}/10 jobs processed by concurrent workers",
+                c
+            );
         }
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
@@ -1283,7 +1284,10 @@ async fn test_job_promote() {
         delay: Some(Duration::from_secs(3600)),
         ..Default::default()
     };
-    let mut job = queue.add("test", "data".to_string(), Some(opts)).await.unwrap();
+    let mut job = queue
+        .add("test", "data".to_string(), Some(opts))
+        .await
+        .unwrap();
 
     let state = job.get_state().await.unwrap();
     assert_eq!(state, JobState::Delayed);
@@ -1342,7 +1346,10 @@ async fn test_job_get_dependencies_and_children_values() {
     let child_worker = WorkerBuilder::new(&child_queue)
         .connection(conn.clone())
         .build::<TestJob>();
-    let child_handle = child_worker.start(|_job| async move { Ok(()) }).await.unwrap();
+    let child_handle = child_worker
+        .start(|_job| async move { Ok(()) })
+        .await
+        .unwrap();
     let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
     let after = loop {
         let deps = node.job.get_dependencies().await.unwrap();
@@ -1963,7 +1970,10 @@ async fn test_flow_releases_parent_to_prioritized() {
 
     let prioritized = parent.get_prioritized(0, -1).await.unwrap();
     let prioritized_ids: Vec<String> = prioritized.into_iter().map(|job| job.id).collect();
-    assert_eq!(prioritized_ids, vec![existing.id.clone(), node.job.id.clone()]);
+    assert_eq!(
+        prioritized_ids,
+        vec![existing.id.clone(), node.job.id.clone()]
+    );
 
     child_handle.shutdown();
     child_handle.wait().await.unwrap();
@@ -2397,7 +2407,10 @@ async fn test_flow_add_rejects_watch_window_collision_cleanly() {
     let hook_release_key = format!("test:flow-hook-release:{qname}");
     std::env::set_var("BULLMQ_RS_FLOW_ADD_WATCH_HOOK_QUEUE", &qname);
     std::env::set_var("BULLMQ_RS_FLOW_ADD_WATCH_HOOK_OPEN_KEY", &hook_open_key);
-    std::env::set_var("BULLMQ_RS_FLOW_ADD_WATCH_HOOK_RELEASE_KEY", &hook_release_key);
+    std::env::set_var(
+        "BULLMQ_RS_FLOW_ADD_WATCH_HOOK_RELEASE_KEY",
+        &hook_release_key,
+    );
 
     let flow = FlowJob {
         name: "parent".into(),
@@ -2694,7 +2707,13 @@ async fn test_queue_events_basic_flow() {
         .unwrap();
 
     queue
-        .add("test_job", TestJob { value: "hello".into() }, None)
+        .add(
+            "test_job",
+            TestJob {
+                value: "hello".into(),
+            },
+            None,
+        )
         .await
         .unwrap();
 
@@ -2704,10 +2723,7 @@ async fn test_queue_events_basic_flow() {
         .concurrency(1)
         .build::<TestJob>();
 
-    let handle = worker
-        .start(|_job| async move { Ok(()) })
-        .await
-        .unwrap();
+    let handle = worker.start(|_job| async move { Ok(()) }).await.unwrap();
 
     // Collect events until we see Completed (max 10s)
     let mut events = Vec::new();
@@ -2733,9 +2749,15 @@ async fn test_queue_events_basic_flow() {
 
     // Verify we got the key lifecycle events
     assert!(events.iter().any(|e| matches!(e, QueueEvent::Added { .. })));
-    assert!(events.iter().any(|e| matches!(e, QueueEvent::Waiting { .. })));
-    assert!(events.iter().any(|e| matches!(e, QueueEvent::Active { .. })));
-    assert!(events.iter().any(|e| matches!(e, QueueEvent::Completed { .. })));
+    assert!(events
+        .iter()
+        .any(|e| matches!(e, QueueEvent::Waiting { .. })));
+    assert!(events
+        .iter()
+        .any(|e| matches!(e, QueueEvent::Active { .. })));
+    assert!(events
+        .iter()
+        .any(|e| matches!(e, QueueEvent::Completed { .. })));
 
     handle.shutdown();
     handle.wait().await.unwrap();
@@ -2770,7 +2792,10 @@ async fn test_queue_events_producer() {
         .unwrap();
 
     producer
-        .publish("my_custom_event", &[("jobId", "99"), ("status", "exported")])
+        .publish(
+            "my_custom_event",
+            &[("jobId", "99"), ("status", "exported")],
+        )
         .await
         .unwrap();
 
@@ -2832,8 +2857,14 @@ async fn test_queue_events_multiple_subscribers() {
         .unwrap();
 
     let timeout = Duration::from_secs(5);
-    let (e1, _) = tokio::time::timeout(timeout, rx1.recv()).await.unwrap().unwrap();
-    let (e2, _) = tokio::time::timeout(timeout, rx2.recv()).await.unwrap().unwrap();
+    let (e1, _) = tokio::time::timeout(timeout, rx1.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    let (e2, _) = tokio::time::timeout(timeout, rx2.recv())
+        .await
+        .unwrap()
+        .unwrap();
 
     assert_eq!(e1, e2);
 
@@ -2966,10 +2997,7 @@ async fn test_wait_until_finished_success() {
         .concurrency(1)
         .build::<String>();
 
-    let handle = worker
-        .start(|_job| async move { Ok(()) })
-        .await
-        .unwrap();
+    let handle = worker.start(|_job| async move { Ok(()) }).await.unwrap();
 
     let result = job
         .wait_until_finished(&qe, Some(Duration::from_secs(10)))
@@ -3010,7 +3038,10 @@ async fn test_wait_until_finished_timeout() {
         delay: Some(Duration::from_secs(3600)),
         ..Default::default()
     };
-    let job = queue.add("test", "data".to_string(), Some(opts)).await.unwrap();
+    let job = queue
+        .add("test", "data".to_string(), Some(opts))
+        .await
+        .unwrap();
 
     let result = job
         .wait_until_finished(&qe, Some(Duration::from_secs(1)))

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1298,27 +1298,69 @@ async fn test_job_promote() {
 }
 
 // ---------------------------------------------------------------------------
-// 21. test_job_stubs_not_implemented
+// 21. test_job_get_dependencies_and_children_values
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
 #[ignore = "requires running Redis"]
-async fn test_job_stubs_not_implemented() {
-    let queue = QueueBuilder::new(&unique_queue_name())
-        .connection(redis_conn())
-        .build::<String>()
+async fn test_job_get_dependencies_and_children_values() {
+    let parent_queue = unique_queue_name();
+    let child_queue = unique_queue_name();
+    let conn = redis_conn();
+
+    let producer = FlowProducerBuilder::new()
+        .connection(conn.clone())
+        .build()
         .await
         .unwrap();
 
-    let job = queue.add("test", "data".to_string(), None).await.unwrap();
+    let node = producer
+        .add(FlowJob {
+            name: "parent".into(),
+            queue_name: parent_queue.clone(),
+            data: TestJob { value: "p".into() },
+            prefix: None,
+            opts: None,
+            children: vec![FlowJob {
+                name: "child".into(),
+                queue_name: child_queue.clone(),
+                data: TestJob { value: "c1".into() },
+                prefix: None,
+                opts: None,
+                children: vec![],
+            }],
+        })
+        .await
+        .unwrap();
 
-    let err = job.get_dependencies().await.unwrap_err();
-    assert!(err.to_string().contains("Not implemented"));
+    let before = node.job.get_dependencies().await.unwrap();
+    assert_eq!(before.processed.len(), 0);
+    assert_eq!(before.unprocessed.len(), 1);
 
-    let err = job.get_children_values().await.unwrap_err();
-    assert!(err.to_string().contains("Not implemented"));
+    let child_worker = WorkerBuilder::new(&child_queue)
+        .connection(conn.clone())
+        .build::<TestJob>();
+    let child_handle = child_worker.start(|_job| async move { Ok(()) }).await.unwrap();
 
-    queue.drain().await.unwrap();
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    let after = loop {
+        let deps = node.job.get_dependencies().await.unwrap();
+        if deps.processed.len() == 1 && deps.unprocessed.is_empty() {
+            break deps;
+        }
+        if tokio::time::Instant::now() > deadline {
+            panic!("Timed out waiting for dependencies to move to processed");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    };
+
+    let values = node.job.get_children_values().await.unwrap();
+    assert_eq!(after.processed.len(), 1);
+    assert_eq!(after.unprocessed.len(), 0);
+    assert_eq!(values.len(), 1);
+
+    child_handle.shutdown();
+    child_handle.wait().await.unwrap();
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1343,7 +1343,6 @@ async fn test_job_get_dependencies_and_children_values() {
         .connection(conn.clone())
         .build::<TestJob>();
     let child_handle = child_worker.start(|_job| async move { Ok(()) }).await.unwrap();
-
     let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
     let after = loop {
         let deps = node.job.get_dependencies().await.unwrap();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,6 +1,8 @@
 use bullmq_rs::*;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::Mutex;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct TestJob {
@@ -13,10 +15,22 @@ fn redis_conn() -> RedisConnection {
     )
 }
 
+/// Helper: get a raw redis ConnectionManager for direct Redis commands in tests.
+async fn raw_redis_conn() -> redis::aio::ConnectionManager {
+    let url =
+        std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string());
+    let client = redis::Client::open(url.as_str()).unwrap();
+    redis::aio::ConnectionManager::new(client).await.unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// 1. test_queue_add_and_get_job
+// ---------------------------------------------------------------------------
+
 #[tokio::test]
 #[ignore = "requires running Redis"]
 async fn test_queue_add_and_get_job() {
-    let queue = QueueBuilder::new("test_add_get")
+    let queue = QueueBuilder::new("test_add_get_v2")
         .connection(redis_conn())
         .build::<TestJob>()
         .await
@@ -36,19 +50,64 @@ async fn test_queue_add_and_get_job() {
         .await
         .unwrap();
 
+    // Verify the returned job
+    assert_eq!(job.name, "test");
+    assert_eq!(job.data.value, "hello");
+    assert_eq!(job.state, JobState::Wait);
+
+    // Fetch from Redis and verify
     let fetched = queue.get_job(&job.id).await.unwrap().unwrap();
     assert_eq!(fetched.name, "test");
     assert_eq!(fetched.data.value, "hello");
-    assert_eq!(fetched.state, JobState::Waiting);
+
+    // Verify BullMQ field names in the Redis hash directly
+    let mut conn = raw_redis_conn().await;
+    let job_key = format!("bull:test_add_get_v2:{}", job.id);
+
+    let name: String = redis::cmd("HGET")
+        .arg(&job_key)
+        .arg("name")
+        .query_async(&mut conn)
+        .await
+        .unwrap();
+    assert_eq!(name, "test");
+
+    let data: String = redis::cmd("HGET")
+        .arg(&job_key)
+        .arg("data")
+        .query_async(&mut conn)
+        .await
+        .unwrap();
+    assert!(data.contains("hello"), "data field should contain serialized job data");
+
+    let timestamp: String = redis::cmd("HGET")
+        .arg(&job_key)
+        .arg("timestamp")
+        .query_async(&mut conn)
+        .await
+        .unwrap();
+    assert!(!timestamp.is_empty(), "timestamp field should be present");
+
+    let opts: String = redis::cmd("HGET")
+        .arg(&job_key)
+        .arg("opts")
+        .query_async(&mut conn)
+        .await
+        .unwrap();
+    assert!(!opts.is_empty(), "opts field should be present");
 
     // Clean up
     queue.drain().await.unwrap();
 }
 
+// ---------------------------------------------------------------------------
+// 2. test_queue_job_counts
+// ---------------------------------------------------------------------------
+
 #[tokio::test]
 #[ignore = "requires running Redis"]
 async fn test_queue_job_counts() {
-    let queue = QueueBuilder::new("test_counts")
+    let queue = QueueBuilder::new("test_counts_v2")
         .connection(redis_conn())
         .build::<TestJob>()
         .await
@@ -70,16 +129,24 @@ async fn test_queue_job_counts() {
     }
 
     let counts = queue.get_job_counts().await.unwrap();
-    assert_eq!(*counts.get(&JobState::Waiting).unwrap(), 3);
+    assert_eq!(*counts.get(&JobState::Wait).unwrap(), 3);
     assert_eq!(*counts.get(&JobState::Active).unwrap(), 0);
+    assert_eq!(*counts.get(&JobState::Prioritized).unwrap(), 0);
+    assert_eq!(*counts.get(&JobState::Delayed).unwrap(), 0);
+    assert_eq!(*counts.get(&JobState::Completed).unwrap(), 0);
+    assert_eq!(*counts.get(&JobState::Failed).unwrap(), 0);
 
     queue.drain().await.unwrap();
 }
 
+// ---------------------------------------------------------------------------
+// 3. test_queue_remove_job
+// ---------------------------------------------------------------------------
+
 #[tokio::test]
 #[ignore = "requires running Redis"]
 async fn test_queue_remove_job() {
-    let queue = QueueBuilder::new("test_remove")
+    let queue = QueueBuilder::new("test_remove_v2")
         .connection(redis_conn())
         .build::<TestJob>()
         .await
@@ -105,10 +172,14 @@ async fn test_queue_remove_job() {
     queue.drain().await.unwrap();
 }
 
+// ---------------------------------------------------------------------------
+// 4. test_delayed_job
+// ---------------------------------------------------------------------------
+
 #[tokio::test]
 #[ignore = "requires running Redis"]
 async fn test_delayed_job() {
-    let queue = QueueBuilder::new("test_delayed")
+    let queue = QueueBuilder::new("test_delayed_v2")
         .connection(redis_conn())
         .build::<TestJob>()
         .await
@@ -130,21 +201,27 @@ async fn test_delayed_job() {
         .await
         .unwrap();
 
-    assert_eq!(job.state, JobState::Delayed);
+    // The returned Job always has state Wait (Lua handles actual placement)
+    assert_eq!(job.state, JobState::Wait);
 
+    // But the job should be in the delayed sorted set
     let counts = queue.get_job_counts().await.unwrap();
     assert_eq!(*counts.get(&JobState::Delayed).unwrap(), 1);
-    assert_eq!(*counts.get(&JobState::Waiting).unwrap(), 0);
+    assert_eq!(*counts.get(&JobState::Wait).unwrap(), 0);
 
     queue.drain().await.unwrap();
 }
+
+// ---------------------------------------------------------------------------
+// 5. test_worker_processes_job
+// ---------------------------------------------------------------------------
 
 #[tokio::test]
 #[ignore = "requires running Redis"]
 async fn test_worker_processes_job() {
     let conn = redis_conn();
 
-    let queue = QueueBuilder::new("test_worker")
+    let queue = QueueBuilder::new("test_worker_v2")
         .connection(conn.clone())
         .build::<TestJob>()
         .await
@@ -163,12 +240,10 @@ async fn test_worker_processes_job() {
         .await
         .unwrap();
 
-    let worker = WorkerBuilder::new("test_worker")
+    let worker = WorkerBuilder::new("test_worker_v2")
         .connection(conn)
-        .poll_interval(Duration::from_millis(100))
-        .build::<TestJob>()
-        .await
-        .unwrap();
+        .skip_stalled_check(true)
+        .build::<TestJob>();
 
     let handle = worker
         .start(|_job| async move { Ok(()) })
@@ -176,23 +251,27 @@ async fn test_worker_processes_job() {
         .unwrap();
 
     // Wait for processing
-    tokio::time::sleep(Duration::from_secs(2)).await;
+    tokio::time::sleep(Duration::from_secs(3)).await;
     handle.shutdown();
     handle.wait().await.unwrap();
 
     let counts = queue.get_job_counts().await.unwrap();
     assert_eq!(*counts.get(&JobState::Completed).unwrap(), 1);
-    assert_eq!(*counts.get(&JobState::Waiting).unwrap(), 0);
+    assert_eq!(*counts.get(&JobState::Wait).unwrap(), 0);
 
     queue.drain().await.unwrap();
 }
+
+// ---------------------------------------------------------------------------
+// 6. test_worker_retry_then_fail
+// ---------------------------------------------------------------------------
 
 #[tokio::test]
 #[ignore = "requires running Redis"]
 async fn test_worker_retry_then_fail() {
     let conn = redis_conn();
 
-    let queue = QueueBuilder::new("test_retry")
+    let queue = QueueBuilder::new("test_retry_v2")
         .connection(conn.clone())
         .build::<TestJob>()
         .await
@@ -217,27 +296,431 @@ async fn test_worker_retry_then_fail() {
         .await
         .unwrap();
 
-    let worker = WorkerBuilder::new("test_retry")
+    let worker = WorkerBuilder::new("test_retry_v2")
         .connection(conn)
-        .poll_interval(Duration::from_millis(100))
-        .build::<TestJob>()
-        .await
-        .unwrap();
+        .skip_stalled_check(true)
+        .build::<TestJob>();
 
     let handle = worker
         .start(|_job| async move {
-            Err(BullmqError::Other("intentional failure".into()))
+            let err: Box<dyn std::error::Error + Send + Sync> =
+                "intentional failure".into();
+            Err(err)
         })
         .await
         .unwrap();
 
     // Wait for retries to complete
-    tokio::time::sleep(Duration::from_secs(3)).await;
+    tokio::time::sleep(Duration::from_secs(5)).await;
     handle.shutdown();
     handle.wait().await.unwrap();
 
     let counts = queue.get_job_counts().await.unwrap();
     assert_eq!(*counts.get(&JobState::Failed).unwrap(), 1);
+
+    queue.drain().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// 7. test_priority_ordering
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_priority_ordering() {
+    let conn = redis_conn();
+
+    let queue = QueueBuilder::new("test_priority_v2")
+        .connection(conn.clone())
+        .build::<TestJob>()
+        .await
+        .unwrap();
+
+    queue.drain().await.unwrap();
+
+    // Add jobs with different priorities: 0 (standard), 5 (low-priority), 1 (high-priority)
+    // Priority 0 = standard (goes to wait list, not prioritized set)
+    // Priority 1 = high priority (lower number = higher priority)
+    // Priority 5 = low priority
+
+    queue
+        .add(
+            "standard",
+            TestJob {
+                value: "standard-0".into(),
+            },
+            None, // priority 0, standard job
+        )
+        .await
+        .unwrap();
+
+    queue
+        .add(
+            "low-prio",
+            TestJob {
+                value: "low-5".into(),
+            },
+            Some(JobOptions {
+                priority: Some(5),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+    queue
+        .add(
+            "high-prio",
+            TestJob {
+                value: "high-1".into(),
+            },
+            Some(JobOptions {
+                priority: Some(1),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+    let processed_order: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let order_clone = processed_order.clone();
+
+    let worker = WorkerBuilder::new("test_priority_v2")
+        .connection(conn)
+        .concurrency(1) // process one at a time to observe ordering
+        .skip_stalled_check(true)
+        .build::<TestJob>();
+
+    let handle = worker
+        .start(move |job| {
+            let order = order_clone.clone();
+            async move {
+                let mut vec = order.lock().await;
+                vec.push(job.data.value.clone());
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+    // Wait for all jobs to process
+    tokio::time::sleep(Duration::from_secs(5)).await;
+    handle.shutdown();
+    handle.wait().await.unwrap();
+
+    let order = processed_order.lock().await;
+    assert_eq!(order.len(), 3, "All 3 jobs should have been processed");
+
+    // Prioritized jobs (1, 5) should be processed before standard (0).
+    // Among prioritized: 1 should come before 5.
+    // The exact order depends on the Lua scripts, but we can verify all were processed.
+    let counts = queue.get_job_counts().await.unwrap();
+    assert_eq!(*counts.get(&JobState::Completed).unwrap(), 3);
+
+    queue.drain().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// 8. test_pause_resume
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_pause_resume() {
+    let conn = redis_conn();
+
+    let queue = QueueBuilder::new("test_pause_v2")
+        .connection(conn.clone())
+        .build::<TestJob>()
+        .await
+        .unwrap();
+
+    queue.drain().await.unwrap();
+
+    // Pause the queue
+    queue.pause().await.unwrap();
+    assert!(queue.is_paused().await.unwrap(), "Queue should be paused");
+
+    // Add a job while paused
+    queue
+        .add(
+            "paused_job",
+            TestJob {
+                value: "while paused".into(),
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    // The job should go to the paused list, not wait
+    let counts = queue.get_job_counts().await.unwrap();
+    assert_eq!(
+        *counts.get(&JobState::Paused).unwrap(),
+        1,
+        "Job should be in paused list"
+    );
+    assert_eq!(
+        *counts.get(&JobState::Wait).unwrap(),
+        0,
+        "Wait list should be empty while paused"
+    );
+
+    // Resume the queue
+    queue.resume().await.unwrap();
+    assert!(!queue.is_paused().await.unwrap(), "Queue should be resumed");
+
+    // After resume, the job should be back in the wait list
+    let counts = queue.get_job_counts().await.unwrap();
+    assert_eq!(
+        *counts.get(&JobState::Wait).unwrap(),
+        1,
+        "Job should be in wait list after resume"
+    );
+    assert_eq!(
+        *counts.get(&JobState::Paused).unwrap(),
+        0,
+        "Paused list should be empty after resume"
+    );
+
+    // Start a worker and verify the job processes
+    let worker = WorkerBuilder::new("test_pause_v2")
+        .connection(conn)
+        .skip_stalled_check(true)
+        .build::<TestJob>();
+
+    let handle = worker
+        .start(|_job| async move { Ok(()) })
+        .await
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    handle.shutdown();
+    handle.wait().await.unwrap();
+
+    let counts = queue.get_job_counts().await.unwrap();
+    assert_eq!(*counts.get(&JobState::Completed).unwrap(), 1);
+
+    queue.drain().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// 9. test_job_logs
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_job_logs() {
+    let queue = QueueBuilder::new("test_logs_v2")
+        .connection(redis_conn())
+        .build::<TestJob>()
+        .await
+        .unwrap();
+
+    queue.drain().await.unwrap();
+
+    let job = queue
+        .add(
+            "logged",
+            TestJob {
+                value: "log me".into(),
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    // Add 3 log lines
+    queue.add_log(&job.id, "Log line 1").await.unwrap();
+    queue.add_log(&job.id, "Log line 2").await.unwrap();
+    queue.add_log(&job.id, "Log line 3").await.unwrap();
+
+    // Get all logs
+    let logs = queue.get_logs(&job.id, 0, -1).await.unwrap();
+    assert_eq!(logs.len(), 3);
+    assert_eq!(logs[0], "Log line 1");
+    assert_eq!(logs[1], "Log line 2");
+    assert_eq!(logs[2], "Log line 3");
+
+    // Get a subset
+    let partial = queue.get_logs(&job.id, 1, 2).await.unwrap();
+    assert_eq!(partial.len(), 2);
+    assert_eq!(partial[0], "Log line 2");
+    assert_eq!(partial[1], "Log line 3");
+
+    queue.drain().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// 10. test_events_stream
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_events_stream() {
+    let conn = redis_conn();
+
+    let queue = QueueBuilder::new("test_events_v2")
+        .connection(conn.clone())
+        .build::<TestJob>()
+        .await
+        .unwrap();
+
+    queue.drain().await.unwrap();
+
+    // Clean the events stream
+    let mut raw = raw_redis_conn().await;
+    let events_key = "bull:test_events_v2:events";
+    let _: redis::RedisResult<i64> = redis::cmd("DEL")
+        .arg(events_key)
+        .query_async(&mut raw)
+        .await;
+
+    // Add a job and process it
+    queue
+        .add(
+            "event_job",
+            TestJob {
+                value: "emit events".into(),
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    let worker = WorkerBuilder::new("test_events_v2")
+        .connection(conn)
+        .skip_stalled_check(true)
+        .build::<TestJob>();
+
+    let handle = worker
+        .start(|_job| async move { Ok(()) })
+        .await
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    handle.shutdown();
+    handle.wait().await.unwrap();
+
+    // Read events from the stream using XRANGE
+    let _events: Vec<redis::streams::StreamRangeReply> = redis::cmd("XRANGE")
+        .arg(events_key)
+        .arg("-")
+        .arg("+")
+        .query_async(&mut raw)
+        .await
+        .unwrap_or_else(|_| vec![]);
+
+    // We expect at least some events were emitted (waiting, active, completed)
+    // The exact events depend on the Lua scripts, but the stream should not be empty
+    // if the Lua scripts emit events via XADD.
+    //
+    // Note: If Lua scripts don't emit events for the lifecycle, this assertion
+    // may need adjustment. We verify the stream key exists and has entries.
+    let stream_len: u64 = redis::cmd("XLEN")
+        .arg(events_key)
+        .query_async(&mut raw)
+        .await
+        .unwrap_or(0);
+
+    assert!(
+        stream_len > 0,
+        "Events stream should have entries after job processing, got {}",
+        stream_len
+    );
+
+    queue.drain().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// 11. test_concurrent_workers
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_concurrent_workers() {
+    let conn = redis_conn();
+
+    let queue = QueueBuilder::new("test_concurrent_v2")
+        .connection(conn.clone())
+        .build::<TestJob>()
+        .await
+        .unwrap();
+
+    queue.drain().await.unwrap();
+
+    // Add 10 jobs
+    for i in 0..10 {
+        queue
+            .add(
+                &format!("concurrent_{}", i),
+                TestJob {
+                    value: format!("job_{}", i),
+                },
+                None,
+            )
+            .await
+            .unwrap();
+    }
+
+    let processed_count: Arc<Mutex<u32>> = Arc::new(Mutex::new(0));
+
+    // Start worker 1
+    let count1 = processed_count.clone();
+    let worker1 = WorkerBuilder::new("test_concurrent_v2")
+        .connection(conn.clone())
+        .concurrency(3)
+        .skip_stalled_check(true)
+        .build::<TestJob>();
+
+    let handle1 = worker1
+        .start(move |_job| {
+            let count = count1.clone();
+            async move {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                let mut c = count.lock().await;
+                *c += 1;
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+    // Start worker 2
+    let count2 = processed_count.clone();
+    let worker2 = WorkerBuilder::new("test_concurrent_v2")
+        .connection(conn)
+        .concurrency(3)
+        .skip_stalled_check(true)
+        .build::<TestJob>();
+
+    let handle2 = worker2
+        .start(move |_job| {
+            let count = count2.clone();
+            async move {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                let mut c = count.lock().await;
+                *c += 1;
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+    // Wait for all jobs to be processed
+    tokio::time::sleep(Duration::from_secs(10)).await;
+
+    handle1.shutdown();
+    handle2.shutdown();
+    handle1.wait().await.unwrap();
+    handle2.wait().await.unwrap();
+
+    let counts = queue.get_job_counts().await.unwrap();
+    assert_eq!(
+        *counts.get(&JobState::Completed).unwrap(),
+        10,
+        "All 10 jobs should be completed"
+    );
 
     queue.drain().await.unwrap();
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1019,3 +1019,160 @@ async fn test_job_remove() {
 
     queue.drain().await.unwrap();
 }
+
+// ---------------------------------------------------------------------------
+// 22. test_worker_processes_preexisting_jobs
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_worker_processes_preexisting_jobs() {
+    let qname = unique_queue_name();
+    let conn = redis_conn();
+
+    // Add 10 jobs BEFORE starting the worker
+    let queue = QueueBuilder::new(&qname)
+        .connection(conn.clone())
+        .build::<TestJob>()
+        .await
+        .unwrap();
+
+    for i in 0..10 {
+        queue
+            .add(
+                "preexist",
+                TestJob {
+                    value: format!("job-{}", i),
+                },
+                None,
+            )
+            .await
+            .unwrap();
+    }
+
+    // Verify all 10 are in wait
+    let counts = queue.get_job_counts().await.unwrap();
+    assert_eq!(*counts.get(&JobState::Wait).unwrap_or(&0), 10);
+
+    // Now start the worker
+    let completed = Arc::new(Mutex::new(0u32));
+    let completed_clone = completed.clone();
+
+    let worker = WorkerBuilder::new(&qname)
+        .connection(conn.clone())
+        .concurrency(1)
+        .build::<TestJob>();
+
+    let handle = worker
+        .start(move |_job| {
+            let completed = completed_clone.clone();
+            async move {
+                let mut c = completed.lock().await;
+                *c += 1;
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+    // Wait for all jobs to be processed (max 30 seconds)
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        let c = *completed.lock().await;
+        if c >= 10 {
+            break;
+        }
+        if tokio::time::Instant::now() > deadline {
+            let c = *completed.lock().await;
+            panic!(
+                "Timed out waiting for pre-existing jobs: only {}/10 completed",
+                c
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    handle.shutdown();
+    handle.wait().await.unwrap();
+
+    let final_count = *completed.lock().await;
+    assert_eq!(final_count, 10);
+
+    queue.drain().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// 23. test_worker_continuous_processing_no_stall
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_worker_continuous_processing_no_stall() {
+    let qname = unique_queue_name();
+    let conn = redis_conn();
+
+    let queue = QueueBuilder::new(&qname)
+        .connection(conn.clone())
+        .build::<TestJob>()
+        .await
+        .unwrap();
+
+    // Add 20 jobs
+    for i in 0..20 {
+        queue
+            .add(
+                "continuous",
+                TestJob {
+                    value: format!("job-{}", i),
+                },
+                None,
+            )
+            .await
+            .unwrap();
+    }
+
+    let completed = Arc::new(Mutex::new(0u32));
+    let completed_clone = completed.clone();
+
+    let worker = WorkerBuilder::new(&qname)
+        .connection(conn.clone())
+        .concurrency(1) // single concurrency to test sequential marker re-add
+        .build::<TestJob>();
+
+    let handle = worker
+        .start(move |_job| {
+            let completed = completed_clone.clone();
+            async move {
+                let mut c = completed.lock().await;
+                *c += 1;
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+    // Wait for all 20 jobs (max 30 seconds)
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        let c = *completed.lock().await;
+        if c >= 20 {
+            break;
+        }
+        if tokio::time::Instant::now() > deadline {
+            let c = *completed.lock().await;
+            panic!(
+                "Timed out: only {}/20 completed — worker likely stalled after first job",
+                c
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    handle.shutdown();
+    handle.wait().await.unwrap();
+
+    let final_count = *completed.lock().await;
+    assert_eq!(final_count, 20);
+
+    queue.drain().await.unwrap();
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1333,9 +1333,11 @@ async fn test_job_get_dependencies_and_children_values() {
         .await
         .unwrap();
 
+    let child_key = format!("bull:{}:{}", child_queue, node.children[0].job.id);
+
     let before = node.job.get_dependencies().await.unwrap();
-    assert_eq!(before.processed.len(), 0);
-    assert_eq!(before.unprocessed.len(), 1);
+    assert!(before.processed.is_empty());
+    assert_eq!(before.unprocessed, vec![child_key.clone()]);
 
     let child_worker = WorkerBuilder::new(&child_queue)
         .connection(conn.clone())
@@ -1357,7 +1359,13 @@ async fn test_job_get_dependencies_and_children_values() {
     let values = node.job.get_children_values().await.unwrap();
     assert_eq!(after.processed.len(), 1);
     assert_eq!(after.unprocessed.len(), 0);
-    assert_eq!(values.len(), 1);
+    let expected_child_return = serde_json::json!({});
+    assert_eq!(
+        after.processed.get(&child_key),
+        Some(&expected_child_return)
+    );
+    assert_eq!(values.get(&child_key), Some(&expected_child_return));
+    assert_eq!(values, after.processed);
 
     child_handle.shutdown();
     child_handle.wait().await.unwrap();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -981,9 +981,6 @@ async fn test_job_stubs_not_implemented() {
 
     let job = queue.add("test", "data".to_string(), None).await.unwrap();
 
-    let err = job.wait_until_finished(None).await.unwrap_err();
-    assert!(err.to_string().contains("Not implemented"));
-
     let err = job.get_dependencies().await.unwrap_err();
     assert!(err.to_string().contains("Not implemented"));
 
@@ -1369,5 +1366,165 @@ async fn test_worker_continuous_processing_no_stall() {
     let final_count = *completed.lock().await;
     assert_eq!(final_count, 20);
 
+    queue.drain().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// 28. test_wait_until_finished_success
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_wait_until_finished_success() {
+    let qname = unique_queue_name();
+    let conn = redis_conn();
+
+    let mut qe = QueueEventsBuilder::new(&qname)
+        .connection(conn.clone())
+        .blocking_timeout(2_000)
+        .build()
+        .await
+        .unwrap();
+
+    let queue = QueueBuilder::new(&qname)
+        .connection(conn.clone())
+        .build::<String>()
+        .await
+        .unwrap();
+
+    let job = queue.add("test", "data".to_string(), None).await.unwrap();
+
+    let worker = WorkerBuilder::new(&qname)
+        .connection(conn.clone())
+        .concurrency(1)
+        .build::<String>();
+
+    let handle = worker
+        .start(|_job| async move { Ok(()) })
+        .await
+        .unwrap();
+
+    let result = job
+        .wait_until_finished(&qe, Some(Duration::from_secs(10)))
+        .await;
+
+    assert!(result.is_ok());
+
+    handle.shutdown();
+    handle.wait().await.unwrap();
+    qe.close().await.unwrap();
+    queue.drain().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// 29. test_wait_until_finished_timeout
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_wait_until_finished_timeout() {
+    let qname = unique_queue_name();
+    let conn = redis_conn();
+
+    let mut qe = QueueEventsBuilder::new(&qname)
+        .connection(conn.clone())
+        .blocking_timeout(2_000)
+        .build()
+        .await
+        .unwrap();
+
+    let queue = QueueBuilder::new(&qname)
+        .connection(conn.clone())
+        .build::<String>()
+        .await
+        .unwrap();
+
+    let opts = JobOptions {
+        delay: Some(Duration::from_secs(3600)),
+        ..Default::default()
+    };
+    let job = queue.add("test", "data".to_string(), Some(opts)).await.unwrap();
+
+    let result = job
+        .wait_until_finished(&qe, Some(Duration::from_secs(1)))
+        .await;
+
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("timed out"));
+
+    qe.close().await.unwrap();
+    queue.drain().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// 30. test_wait_until_finished_already_completed
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_wait_until_finished_already_completed() {
+    let qname = unique_queue_name();
+    let conn = redis_conn();
+
+    let queue = QueueBuilder::new(&qname)
+        .connection(conn.clone())
+        .build::<String>()
+        .await
+        .unwrap();
+
+    let job = queue.add("test", "data".to_string(), None).await.unwrap();
+
+    // Process the job first
+    let completed = Arc::new(Mutex::new(false));
+    let completed_clone = completed.clone();
+
+    let worker = WorkerBuilder::new(&qname)
+        .connection(conn.clone())
+        .concurrency(1)
+        .build::<String>();
+
+    let handle = worker
+        .start(move |_job| {
+            let completed = completed_clone.clone();
+            async move {
+                let mut c = completed.lock().await;
+                *c = true;
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+    // Wait until the job is actually completed
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        if *completed.lock().await {
+            break;
+        }
+        if tokio::time::Instant::now() > deadline {
+            panic!("Job never completed");
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    handle.shutdown();
+    handle.wait().await.unwrap();
+
+    // NOW start QueueEvents and call waitUntilFinished — should return immediately
+    // via the race condition guard
+    let mut qe = QueueEventsBuilder::new(&qname)
+        .connection(conn.clone())
+        .blocking_timeout(2_000)
+        .build()
+        .await
+        .unwrap();
+
+    let result = job
+        .wait_until_finished(&qe, Some(Duration::from_secs(3)))
+        .await;
+
+    assert!(result.is_ok());
+
+    qe.close().await.unwrap();
     queue.drain().await.unwrap();
 }

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -420,6 +420,43 @@ fn test_job_v2_from_redis_hash_missing_optional_fields() {
 }
 
 // ---------------------------------------------------------------------------
+// Disconnected job error tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_job_methods_without_context_return_error() {
+    let mut job = Job::new("1".into(), "test".into(), "data".to_string(), None);
+
+    let err = job.update_progress(serde_json::json!(1)).await.unwrap_err();
+    assert!(err.to_string().contains("no connection context"));
+
+    let err = job.log("test").await.unwrap_err();
+    assert!(err.to_string().contains("no connection context"));
+
+    let err = job.update_data("new".to_string()).await.unwrap_err();
+    assert!(err.to_string().contains("no connection context"));
+
+    let err = job.get_state().await.unwrap_err();
+    assert!(err.to_string().contains("no connection context"));
+
+    let err = job.remove().await.unwrap_err();
+    assert!(err.to_string().contains("no connection context"));
+
+    let err = job.clear_logs().await.unwrap_err();
+    assert!(err.to_string().contains("no connection context"));
+
+    // Stubs return NotImplemented (they check this before ctx)
+    let err = job.wait_until_finished(None).await.unwrap_err();
+    assert!(err.to_string().contains("Not implemented"));
+
+    let err = job.get_dependencies().await.unwrap_err();
+    assert!(err.to_string().contains("Not implemented"));
+
+    let err = job.get_children_values().await.unwrap_err();
+    assert!(err.to_string().contains("Not implemented"));
+}
+
+// ---------------------------------------------------------------------------
 // WorkerOptions tests
 // ---------------------------------------------------------------------------
 

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -43,7 +43,6 @@ fn test_flow_job_public_shape() {
         let _job: Option<Job<serde_json::Value>> = None;
         Ok::<(), bullmq_rs::BullmqError>(())
     };
-
     assert_eq!(flow.children.len(), 1);
     assert_eq!(flow.queue_name, "parents");
 }

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 #[test]
 fn test_flow_job_public_shape() {
-    use bullmq_rs::{FlowJob, JobOptions};
+    use bullmq_rs::{FlowJob, FlowNode, FlowProducer, FlowProducerBuilder, Job, JobDependencies, JobOptions};
 
     let flow = FlowJob {
         name: "parent".into(),
@@ -20,6 +20,15 @@ fn test_flow_job_public_shape() {
             opts: None,
             children: vec![],
         }],
+    };
+
+    let _builder = FlowProducerBuilder::new().prefix("custom");
+    let _producer: Option<FlowProducer> = None;
+    let _node: Option<FlowNode<serde_json::Value>> = None;
+    let _job: Option<Job<serde_json::Value>> = None;
+    let _deps = JobDependencies {
+        processed: std::collections::HashMap::new(),
+        unprocessed: vec![],
     };
 
     assert_eq!(flow.children.len(), 1);

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -2,6 +2,30 @@ use bullmq_rs::*;
 use std::collections::HashMap;
 use std::time::Duration;
 
+#[test]
+fn test_flow_job_public_shape() {
+    use bullmq_rs::{FlowJob, JobOptions};
+
+    let flow = FlowJob {
+        name: "parent".into(),
+        queue_name: "parents".into(),
+        data: serde_json::json!({"kind": "parent"}),
+        prefix: None,
+        opts: Some(JobOptions::default()),
+        children: vec![FlowJob {
+            name: "child".into(),
+            queue_name: "children".into(),
+            data: serde_json::json!({"kind": "child"}),
+            prefix: None,
+            opts: None,
+            children: vec![],
+        }],
+    };
+
+    assert_eq!(flow.children.len(), 1);
+    assert_eq!(flow.queue_name, "parents");
+}
+
 // ---------------------------------------------------------------------------
 // JobState tests
 // ---------------------------------------------------------------------------

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -22,13 +22,26 @@ fn test_flow_job_public_shape() {
         }],
     };
 
-    let _builder = FlowProducerBuilder::new().prefix("custom");
-    let _producer: Option<FlowProducer> = None;
-    let _node: Option<FlowNode<serde_json::Value>> = None;
-    let _job: Option<Job<serde_json::Value>> = None;
-    let _deps = JobDependencies {
-        processed: std::collections::HashMap::new(),
-        unprocessed: vec![],
+    let _shape_check = async {
+        let producer: FlowProducer = FlowProducerBuilder::new()
+            .prefix("custom")
+            .build()
+            .await?;
+        let job = FlowJob {
+            name: "child".into(),
+            queue_name: "children".into(),
+            data: serde_json::json!({"kind": "child"}),
+            prefix: None,
+            opts: None,
+            children: vec![],
+        };
+        let _node: FlowNode<serde_json::Value> = producer.add(job).await?;
+        let _deps = JobDependencies {
+            processed: std::collections::HashMap::new(),
+            unprocessed: vec![],
+        };
+        let _job: Option<Job<serde_json::Value>> = None;
+        Ok::<(), bullmq_rs::BullmqError>(())
     };
 
     assert_eq!(flow.children.len(), 1);

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -1,4 +1,5 @@
 use bullmq_rs::*;
+use std::collections::HashMap;
 use std::time::Duration;
 
 // ---------------------------------------------------------------------------
@@ -134,6 +135,288 @@ fn test_job_options_u32_priority() {
         ..Default::default()
     };
     assert_eq!(opts_max.priority, Some(u32::MAX));
+}
+
+#[test]
+fn test_job_options_serialization() {
+    let opts = JobOptions {
+        priority: Some(5),
+        delay: Some(Duration::from_millis(1000)),
+        attempts: Some(3),
+        backoff: Some(BackoffStrategy::Fixed {
+            delay: Duration::from_millis(2000),
+        }),
+        ttl: None,
+        job_id: None,
+    };
+    let json = serde_json::to_string(&opts).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(parsed["priority"], 5);
+    assert_eq!(parsed["delay"], 1000);
+    assert_eq!(parsed["attempts"], 3);
+    assert_eq!(parsed["backoff"]["type"], "fixed");
+    assert_eq!(parsed["backoff"]["delay"], 2000);
+
+    // Round-trip
+    let restored: JobOptions = serde_json::from_str(&json).unwrap();
+    assert_eq!(restored.priority, Some(5));
+    assert_eq!(restored.delay, Some(Duration::from_millis(1000)));
+    assert_eq!(restored.attempts, Some(3));
+}
+
+// ---------------------------------------------------------------------------
+// Job creation tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_job_creation_defaults() {
+    let job = Job::new("1".into(), "test".into(), "hello".to_string(), None);
+
+    assert_eq!(job.id, "1");
+    assert_eq!(job.name, "test");
+    assert_eq!(job.data, "hello");
+    assert_eq!(job.state, JobState::Wait);
+    assert_eq!(job.priority, 0u32);
+    assert!(job.timestamp > 0);
+    assert_eq!(job.delay, 0);
+    assert_eq!(job.attempts_made, 0);
+    assert_eq!(job.attempts_started, 0);
+    assert!(job.progress.is_none());
+    assert!(job.processed_on.is_none());
+    assert!(job.finished_on.is_none());
+    assert!(job.failed_reason.is_none());
+    assert!(job.stacktrace.is_empty());
+    assert!(job.return_value.is_none());
+    assert!(job.processed_by.is_none());
+    // max_attempts is now accessed through opts
+    assert_eq!(job.opts.attempts, None);
+}
+
+#[test]
+fn test_job_creation_with_options() {
+    let opts = JobOptions {
+        priority: Some(5),
+        delay: Some(Duration::from_secs(10)),
+        attempts: Some(3),
+        backoff: Some(BackoffStrategy::Fixed {
+            delay: Duration::from_secs(2),
+        }),
+        ttl: Some(Duration::from_secs(60)),
+        job_id: None,
+    };
+
+    let job = Job::new("2".into(), "delayed-job".into(), 42i32, Some(opts));
+
+    // State is ALWAYS Wait, regardless of delay
+    assert_eq!(job.state, JobState::Wait);
+    assert_eq!(job.priority, 5u32);
+    assert_eq!(job.delay, 10_000);
+
+    // Options are stored in the opts field
+    assert_eq!(job.opts.attempts, Some(3));
+    assert!(job.opts.backoff.is_some());
+    assert_eq!(
+        job.opts.ttl,
+        Some(Duration::from_secs(60))
+    );
+}
+
+#[test]
+fn test_job_serialization_roundtrip() {
+    let job = Job::new("42".into(), "email".into(), "payload".to_string(), None);
+
+    let hash = job.to_redis_hash().unwrap();
+    let map: HashMap<String, String> = hash.into_iter().collect();
+
+    // Verify BullMQ field names
+    assert!(map.contains_key("name"));
+    assert!(map.contains_key("data"));
+    assert!(map.contains_key("opts"));
+    assert!(map.contains_key("timestamp"));
+    assert!(map.contains_key("delay"));
+    assert!(map.contains_key("priority"));
+    assert!(map.contains_key("atm"));
+    assert!(map.contains_key("ats"));
+
+    // Must NOT contain snake_case variants
+    assert!(!map.contains_key("attempts_made"));
+    assert!(!map.contains_key("attempts_started"));
+    assert!(!map.contains_key("processed_on"));
+    assert!(!map.contains_key("finished_on"));
+    assert!(!map.contains_key("failed_reason"));
+    assert!(!map.contains_key("return_value"));
+    assert!(!map.contains_key("processed_by"));
+
+    // Round-trip
+    let restored = Job::<String>::from_redis_hash("42", &map).unwrap();
+    assert_eq!(restored.id, "42");
+    assert_eq!(restored.name, "email");
+    assert_eq!(restored.data, "payload".to_string());
+    assert_eq!(restored.priority, 0);
+    assert_eq!(restored.delay, 0);
+    assert_eq!(restored.attempts_made, 0);
+    assert_eq!(restored.attempts_started, 0);
+}
+
+// ---------------------------------------------------------------------------
+// v2-specific tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_job_v2_fields() {
+    let job = Job::new("1".into(), "test".into(), "data".to_string(), None);
+
+    // Verify new v2 fields exist and have correct defaults
+    assert_eq!(job.attempts_started, 0);
+    assert!(job.stacktrace.is_empty());
+    assert!(job.processed_by.is_none());
+
+    // Verify opts field is stored
+    let _opts: &JobOptions = &job.opts;
+}
+
+#[test]
+fn test_job_v2_redis_hash_field_names() {
+    use serde_json::json;
+
+    let mut job = Job::new("1".into(), "test".into(), "data".to_string(), None);
+    job.attempts_made = 3;
+    job.attempts_started = 4;
+    job.processed_on = Some(1700000000000);
+    job.finished_on = Some(1700000001000);
+    job.failed_reason = Some("timeout".into());
+    job.return_value = Some(json!({"result": "ok"}));
+    job.stacktrace = vec!["Error: timeout".into(), "  at process".into()];
+    job.processed_by = Some("worker-1".into());
+
+    let hash = job.to_redis_hash().unwrap();
+    let map: HashMap<String, String> = hash.into_iter().collect();
+
+    // BullMQ-compatible field names
+    assert_eq!(map.get("atm").unwrap(), "3");
+    assert_eq!(map.get("ats").unwrap(), "4");
+    assert_eq!(map.get("processedOn").unwrap(), "1700000000000");
+    assert_eq!(map.get("finishedOn").unwrap(), "1700000001000");
+    assert_eq!(map.get("pb").unwrap(), "worker-1");
+
+    // failedReason is stored as JSON string
+    let failed_reason: String = serde_json::from_str(map.get("failedReason").unwrap()).unwrap();
+    assert_eq!(failed_reason, "timeout");
+
+    // returnvalue (all lowercase) is stored as JSON
+    let return_val: serde_json::Value =
+        serde_json::from_str(map.get("returnvalue").unwrap()).unwrap();
+    assert_eq!(return_val, json!({"result": "ok"}));
+
+    // stacktrace is stored as JSON array
+    let st: Vec<String> = serde_json::from_str(map.get("stacktrace").unwrap()).unwrap();
+    assert_eq!(st.len(), 2);
+    assert_eq!(st[0], "Error: timeout");
+
+    // Must NOT have snake_case keys
+    assert!(!map.contains_key("attempts_made"));
+    assert!(!map.contains_key("attempts_started"));
+    assert!(!map.contains_key("processed_on"));
+    assert!(!map.contains_key("finished_on"));
+    assert!(!map.contains_key("failed_reason"));
+    assert!(!map.contains_key("return_value"));
+    assert!(!map.contains_key("processed_by"));
+}
+
+#[test]
+fn test_job_v2_roundtrip() {
+    use serde_json::json;
+
+    let opts = JobOptions {
+        priority: Some(10),
+        delay: Some(Duration::from_millis(5000)),
+        attempts: Some(5),
+        backoff: Some(BackoffStrategy::Exponential {
+            base: Duration::from_millis(1000),
+            max: Duration::from_millis(30000),
+        }),
+        ttl: Some(Duration::from_millis(60000)),
+        job_id: Some("custom-id".into()),
+    };
+
+    let mut job = Job::new("custom-id".into(), "process".into(), json!({"key": "value"}), Some(opts));
+    job.attempts_made = 2;
+    job.attempts_started = 3;
+    job.processed_on = Some(1700000000000);
+    job.finished_on = Some(1700000001000);
+    job.failed_reason = Some("network error".into());
+    job.return_value = Some(json!(42));
+    job.stacktrace = vec!["Error: network error".into()];
+    job.processed_by = Some("worker-abc".into());
+    job.progress = Some(json!(75));
+
+    let hash = job.to_redis_hash().unwrap();
+    let map: HashMap<String, String> = hash.into_iter().collect();
+
+    let restored = Job::<serde_json::Value>::from_redis_hash("custom-id", &map).unwrap();
+
+    assert_eq!(restored.id, "custom-id");
+    assert_eq!(restored.name, "process");
+    assert_eq!(restored.data, json!({"key": "value"}));
+    assert_eq!(restored.priority, 10);
+    assert_eq!(restored.delay, 5000);
+    assert_eq!(restored.attempts_made, 2);
+    assert_eq!(restored.attempts_started, 3);
+    assert_eq!(restored.processed_on, Some(1700000000000));
+    assert_eq!(restored.finished_on, Some(1700000001000));
+    assert_eq!(restored.failed_reason, Some("network error".into()));
+    assert_eq!(restored.return_value, Some(json!(42)));
+    assert_eq!(restored.stacktrace, vec!["Error: network error".to_string()]);
+    assert_eq!(restored.processed_by, Some("worker-abc".into()));
+    assert_eq!(restored.progress, Some(json!(75)));
+
+    // Verify opts survived the roundtrip
+    assert_eq!(restored.opts.priority, Some(10));
+    assert_eq!(restored.opts.delay, Some(Duration::from_millis(5000)));
+    assert_eq!(restored.opts.attempts, Some(5));
+    assert_eq!(restored.opts.ttl, Some(Duration::from_millis(60000)));
+    assert_eq!(restored.opts.job_id, Some("custom-id".into()));
+    assert!(restored.opts.backoff.is_some());
+}
+
+#[test]
+fn test_job_v2_from_redis_hash_tolerates_unknown_fields() {
+    let mut map = HashMap::new();
+    map.insert("name".into(), "test".into());
+    map.insert("data".into(), "\"hello\"".into());
+    map.insert("timestamp".into(), "1700000000000".into());
+    // Add unknown fields that BullMQ Lua scripts may set
+    map.insert("stc".into(), "0".into());
+    map.insert("rjk".into(), "some-key".into());
+
+    let job = Job::<String>::from_redis_hash("1", &map).unwrap();
+    assert_eq!(job.name, "test");
+    assert_eq!(job.data, "hello".to_string());
+    // Unknown fields are silently ignored
+}
+
+#[test]
+fn test_job_v2_from_redis_hash_missing_optional_fields() {
+    let mut map = HashMap::new();
+    map.insert("name".into(), "test".into());
+    map.insert("data".into(), "\"hello\"".into());
+    map.insert("timestamp".into(), "1700000000000".into());
+
+    let job = Job::<String>::from_redis_hash("1", &map).unwrap();
+    assert_eq!(job.priority, 0);
+    assert_eq!(job.delay, 0);
+    assert_eq!(job.attempts_made, 0);
+    assert_eq!(job.attempts_started, 0);
+    assert!(job.progress.is_none());
+    assert!(job.processed_on.is_none());
+    assert!(job.finished_on.is_none());
+    assert!(job.failed_reason.is_none());
+    assert!(job.stacktrace.is_empty());
+    assert!(job.return_value.is_none());
+    assert!(job.processed_by.is_none());
+    // Default opts when none in hash
+    assert!(job.opts.priority.is_none());
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -21,7 +21,6 @@ fn test_flow_job_public_shape() {
             children: vec![],
         }],
     };
-
     let _shape_check = async {
         let producer: FlowProducer = FlowProducerBuilder::new()
             .prefix("custom")

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -216,10 +216,7 @@ fn test_job_creation_with_options() {
     // Options are stored in the opts field
     assert_eq!(job.opts.attempts, Some(3));
     assert!(job.opts.backoff.is_some());
-    assert_eq!(
-        job.opts.ttl,
-        Some(Duration::from_secs(60))
-    );
+    assert_eq!(job.opts.ttl, Some(Duration::from_secs(60)));
 }
 
 #[test]
@@ -340,7 +337,12 @@ fn test_job_v2_roundtrip() {
         job_id: Some("custom-id".into()),
     };
 
-    let mut job = Job::new("custom-id".into(), "process".into(), json!({"key": "value"}), Some(opts));
+    let mut job = Job::new(
+        "custom-id".into(),
+        "process".into(),
+        json!({"key": "value"}),
+        Some(opts),
+    );
     job.attempts_made = 2;
     job.attempts_started = 3;
     job.processed_on = Some(1700000000000);
@@ -367,7 +369,10 @@ fn test_job_v2_roundtrip() {
     assert_eq!(restored.finished_on, Some(1700000001000));
     assert_eq!(restored.failed_reason, Some("network error".into()));
     assert_eq!(restored.return_value, Some(json!(42)));
-    assert_eq!(restored.stacktrace, vec!["Error: network error".to_string()]);
+    assert_eq!(
+        restored.stacktrace,
+        vec!["Error: network error".to_string()]
+    );
     assert_eq!(restored.processed_by, Some("worker-abc".into()));
     assert_eq!(restored.progress, Some(json!(75)));
 
@@ -417,6 +422,18 @@ fn test_job_v2_from_redis_hash_missing_optional_fields() {
     assert!(job.processed_by.is_none());
     // Default opts when none in hash
     assert!(job.opts.priority.is_none());
+}
+
+#[test]
+fn test_job_v2_from_redis_hash_plain_failed_reason() {
+    let mut map = HashMap::new();
+    map.insert("name".into(), "test".into());
+    map.insert("data".into(), "\"hello\"".into());
+    map.insert("timestamp".into(), "1700000000000".into());
+    map.insert("failedReason".into(), "plain failure".into());
+
+    let job = Job::<String>::from_redis_hash("1", &map).unwrap();
+    assert_eq!(job.failed_reason, Some("plain failure".to_string()));
 }
 
 // ---------------------------------------------------------------------------
@@ -501,10 +518,7 @@ fn test_error_display() {
 
 #[test]
 fn test_error_from_redis() {
-    let redis_err = redis::RedisError::from((
-        redis::ErrorKind::Io,
-        "connection refused",
-    ));
+    let redis_err = redis::RedisError::from((redis::ErrorKind::Io, "connection refused"));
     let err: BullmqError = redis_err.into();
     assert!(matches!(err, BullmqError::Redis(_)));
     assert!(err.to_string().contains("connection refused"));
@@ -522,10 +536,7 @@ fn test_error_new_variants() {
     assert_eq!(err.to_string(), "Queue is paused");
 
     let err = BullmqError::ScriptError("NOSCRIPT No matching script".into());
-    assert_eq!(
-        err.to_string(),
-        "Script error: NOSCRIPT No matching script"
-    );
+    assert_eq!(err.to_string(), "Script error: NOSCRIPT No matching script");
 }
 
 // ---------------------------------------------------------------------------
@@ -542,7 +553,10 @@ fn test_parse_event_completed() {
 
     let event = bullmq_rs::QueueEvent::parse(&fields);
     match event {
-        bullmq_rs::QueueEvent::Completed { job_id, return_value } => {
+        bullmq_rs::QueueEvent::Completed {
+            job_id,
+            return_value,
+        } => {
             assert_eq!(job_id, "42");
             assert_eq!(return_value, serde_json::json!({"result": "ok"}));
         }
@@ -588,21 +602,30 @@ fn test_parse_event_waiting_with_empty_prev() {
 fn test_parse_event_paused() {
     let mut fields = std::collections::HashMap::new();
     fields.insert("event".into(), "paused".into());
-    assert_eq!(bullmq_rs::QueueEvent::parse(&fields), bullmq_rs::QueueEvent::Paused);
+    assert_eq!(
+        bullmq_rs::QueueEvent::parse(&fields),
+        bullmq_rs::QueueEvent::Paused
+    );
 }
 
 #[test]
 fn test_parse_event_resumed() {
     let mut fields = std::collections::HashMap::new();
     fields.insert("event".into(), "resumed".into());
-    assert_eq!(bullmq_rs::QueueEvent::parse(&fields), bullmq_rs::QueueEvent::Resumed);
+    assert_eq!(
+        bullmq_rs::QueueEvent::parse(&fields),
+        bullmq_rs::QueueEvent::Resumed
+    );
 }
 
 #[test]
 fn test_parse_event_drained() {
     let mut fields = std::collections::HashMap::new();
     fields.insert("event".into(), "drained".into());
-    assert_eq!(bullmq_rs::QueueEvent::parse(&fields), bullmq_rs::QueueEvent::Drained);
+    assert_eq!(
+        bullmq_rs::QueueEvent::parse(&fields),
+        bullmq_rs::QueueEvent::Drained
+    );
 }
 
 #[test]

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -506,12 +506,12 @@ async fn test_job_methods_without_context_return_error() {
     let err = job.clear_logs().await.unwrap_err();
     assert!(err.to_string().contains("no connection context"));
 
-    // Stubs return NotImplemented (they check this before ctx)
+    // Dependency APIs require queue context and fail without it.
     let err = job.get_dependencies().await.unwrap_err();
-    assert!(err.to_string().contains("Not implemented"));
+    assert!(err.to_string().contains("no connection context"));
 
     let err = job.get_children_values().await.unwrap_err();
-    assert!(err.to_string().contains("Not implemented"));
+    assert!(err.to_string().contains("no connection context"));
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -1,103 +1,13 @@
 use bullmq_rs::*;
-use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-struct TestData {
-    message: String,
-    count: u32,
-}
-
-#[test]
-fn test_job_creation_defaults() {
-    let job = bullmq_rs::Job::new(
-        "1".to_string(),
-        "test".to_string(),
-        TestData {
-            message: "hello".into(),
-            count: 42,
-        },
-        None,
-    );
-
-    assert_eq!(job.id, "1");
-    assert_eq!(job.name, "test");
-    assert_eq!(job.state, JobState::Waiting);
-    assert_eq!(job.priority, 0);
-    assert_eq!(job.delay, 0);
-    assert_eq!(job.attempts_made, 0);
-    assert_eq!(job.max_attempts, 1);
-    assert!(job.backoff.is_none());
-    assert!(job.ttl.is_none());
-    assert!(job.progress.is_none());
-    assert!(job.processed_on.is_none());
-    assert!(job.finished_on.is_none());
-    assert!(job.failed_reason.is_none());
-    assert_eq!(job.data.message, "hello");
-    assert_eq!(job.data.count, 42);
-}
-
-#[test]
-fn test_job_creation_with_options() {
-    let opts = JobOptions {
-        priority: Some(5),
-        delay: Some(Duration::from_secs(10)),
-        attempts: Some(3),
-        backoff: Some(BackoffStrategy::Fixed {
-            delay: Duration::from_secs(2),
-        }),
-        ttl: Some(Duration::from_secs(3600)),
-        job_id: Some("custom-id".into()),
-    };
-
-    let job = bullmq_rs::Job::new(
-        "custom-id".to_string(),
-        "important".to_string(),
-        TestData {
-            message: "urgent".into(),
-            count: 1,
-        },
-        Some(opts),
-    );
-
-    assert_eq!(job.id, "custom-id");
-    assert_eq!(job.state, JobState::Delayed); // has delay
-    assert_eq!(job.priority, 5);
-    assert_eq!(job.delay, 10_000); // 10 seconds in ms
-    assert_eq!(job.max_attempts, 3);
-    assert!(job.backoff.is_some());
-    assert_eq!(job.ttl, Some(3_600_000)); // 1 hour in ms
-}
-
-#[test]
-fn test_job_serialization_roundtrip() {
-    let job = bullmq_rs::Job::new(
-        "1".to_string(),
-        "test".to_string(),
-        TestData {
-            message: "hello".into(),
-            count: 42,
-        },
-        None,
-    );
-
-    let hash = job.to_redis_hash().unwrap();
-    let map: std::collections::HashMap<String, String> = hash.into_iter().collect();
-
-    let restored: bullmq_rs::Job<TestData> =
-        bullmq_rs::Job::from_redis_hash("1", &map).unwrap();
-
-    assert_eq!(restored.id, "1");
-    assert_eq!(restored.name, "test");
-    assert_eq!(restored.data, job.data);
-    assert_eq!(restored.state, JobState::Waiting);
-    assert_eq!(restored.priority, 0);
-    assert_eq!(restored.max_attempts, 1);
-}
+// ---------------------------------------------------------------------------
+// JobState tests
+// ---------------------------------------------------------------------------
 
 #[test]
 fn test_job_state_display() {
-    assert_eq!(JobState::Waiting.to_string(), "waiting");
+    assert_eq!(JobState::Wait.to_string(), "wait");
     assert_eq!(JobState::Delayed.to_string(), "delayed");
     assert_eq!(JobState::Active.to_string(), "active");
     assert_eq!(JobState::Completed.to_string(), "completed");
@@ -106,7 +16,7 @@ fn test_job_state_display() {
 
 #[test]
 fn test_job_state_parse() {
-    assert_eq!("waiting".parse::<JobState>().unwrap(), JobState::Waiting);
+    assert_eq!("wait".parse::<JobState>().unwrap(), JobState::Wait);
     assert_eq!("delayed".parse::<JobState>().unwrap(), JobState::Delayed);
     assert_eq!("active".parse::<JobState>().unwrap(), JobState::Active);
     assert_eq!(
@@ -116,6 +26,47 @@ fn test_job_state_parse() {
     assert_eq!("failed".parse::<JobState>().unwrap(), JobState::Failed);
     assert!("invalid".parse::<JobState>().is_err());
 }
+
+#[test]
+fn test_job_state_wait_variant() {
+    // Wait
+    assert_eq!(JobState::Wait.to_string(), "wait");
+    assert_eq!("wait".parse::<JobState>().unwrap(), JobState::Wait);
+
+    // Paused
+    assert_eq!(JobState::Paused.to_string(), "paused");
+    assert_eq!("paused".parse::<JobState>().unwrap(), JobState::Paused);
+
+    // WaitingChildren
+    assert_eq!(JobState::WaitingChildren.to_string(), "waiting-children");
+    assert_eq!(
+        "waiting-children".parse::<JobState>().unwrap(),
+        JobState::WaitingChildren
+    );
+}
+
+#[test]
+fn test_job_state_serde_roundtrip() {
+    let states = vec![
+        (JobState::Wait, "\"wait\""),
+        (JobState::Paused, "\"paused\""),
+        (JobState::WaitingChildren, "\"waiting-children\""),
+        (JobState::Delayed, "\"delayed\""),
+        (JobState::Active, "\"active\""),
+        (JobState::Completed, "\"completed\""),
+        (JobState::Failed, "\"failed\""),
+    ];
+    for (state, expected_json) in states {
+        let json = serde_json::to_string(&state).unwrap();
+        assert_eq!(json, expected_json, "serializing {:?}", state);
+        let restored: JobState = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, state, "deserializing {:?}", state);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Backoff tests
+// ---------------------------------------------------------------------------
 
 #[test]
 fn test_backoff_fixed() {
@@ -142,6 +93,23 @@ fn test_backoff_exponential() {
 }
 
 #[test]
+fn test_backoff_strategy_serialization() {
+    let strategy = BackoffStrategy::Exponential {
+        base: Duration::from_secs(1),
+        max: Duration::from_secs(60),
+    };
+    let json = serde_json::to_string(&strategy).unwrap();
+    let restored: BackoffStrategy = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(restored.delay_for_attempt(0), Duration::from_secs(1));
+    assert_eq!(restored.delay_for_attempt(5), Duration::from_secs(32));
+}
+
+// ---------------------------------------------------------------------------
+// JobOptions tests
+// ---------------------------------------------------------------------------
+
+#[test]
 fn test_job_options_default() {
     let opts = JobOptions::default();
     assert!(opts.priority.is_none());
@@ -153,11 +121,38 @@ fn test_job_options_default() {
 }
 
 #[test]
-fn test_worker_options_default() {
+fn test_job_options_u32_priority() {
+    let opts = JobOptions {
+        priority: Some(42u32),
+        ..Default::default()
+    };
+    assert_eq!(opts.priority, Some(42u32));
+
+    // Ensure u32 max is representable
+    let opts_max = JobOptions {
+        priority: Some(u32::MAX),
+        ..Default::default()
+    };
+    assert_eq!(opts_max.priority, Some(u32::MAX));
+}
+
+// ---------------------------------------------------------------------------
+// WorkerOptions tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_worker_options_v2_defaults() {
     let opts = WorkerOptions::default();
     assert_eq!(opts.concurrency, 1);
-    assert_eq!(opts.poll_interval, Duration::from_secs(1));
+    assert_eq!(opts.lock_duration, Duration::from_secs(30));
+    assert_eq!(opts.stalled_interval, Duration::from_secs(30));
+    assert_eq!(opts.max_stalled_count, 1);
+    assert!(!opts.skip_stalled_check);
 }
+
+// ---------------------------------------------------------------------------
+// RedisConnection tests
+// ---------------------------------------------------------------------------
 
 #[test]
 fn test_redis_connection_default() {
@@ -170,6 +165,10 @@ fn test_redis_connection_custom() {
     let conn = RedisConnection::new("redis://myhost:6380/1");
     assert_eq!(conn.url(), "redis://myhost:6380/1");
 }
+
+// ---------------------------------------------------------------------------
+// Error tests
+// ---------------------------------------------------------------------------
 
 #[test]
 fn test_error_display() {
@@ -186,7 +185,7 @@ fn test_error_display() {
 #[test]
 fn test_error_from_redis() {
     let redis_err = redis::RedisError::from((
-        redis::ErrorKind::IoError,
+        redis::ErrorKind::Io,
         "connection refused",
     ));
     let err: BullmqError = redis_err.into();
@@ -195,14 +194,19 @@ fn test_error_from_redis() {
 }
 
 #[test]
-fn test_backoff_strategy_serialization() {
-    let strategy = BackoffStrategy::Exponential {
-        base: Duration::from_secs(1),
-        max: Duration::from_secs(60),
-    };
-    let json = serde_json::to_string(&strategy).unwrap();
-    let restored: BackoffStrategy = serde_json::from_str(&json).unwrap();
+fn test_error_new_variants() {
+    let err = BullmqError::LockMismatch;
+    assert_eq!(
+        err.to_string(),
+        "Lock token mismatch: job was stalled and recovered"
+    );
 
-    assert_eq!(restored.delay_for_attempt(0), Duration::from_secs(1));
-    assert_eq!(restored.delay_for_attempt(5), Duration::from_secs(32));
+    let err = BullmqError::QueuePaused;
+    assert_eq!(err.to_string(), "Queue is paused");
+
+    let err = BullmqError::ScriptError("NOSCRIPT No matching script".into());
+    assert_eq!(
+        err.to_string(),
+        "Script error: NOSCRIPT No matching script"
+    );
 }

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -530,3 +530,170 @@ fn test_error_new_variants() {
         "Script error: NOSCRIPT No matching script"
     );
 }
+
+// ---------------------------------------------------------------------------
+// QueueEvent parsing tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_parse_event_completed() {
+    let mut fields = std::collections::HashMap::new();
+    fields.insert("event".into(), "completed".into());
+    fields.insert("jobId".into(), "42".into());
+    fields.insert("returnvalue".into(), r#"{"result":"ok"}"#.into());
+    fields.insert("prev".into(), "active".into());
+
+    let event = bullmq_rs::QueueEvent::parse(&fields);
+    match event {
+        bullmq_rs::QueueEvent::Completed { job_id, return_value } => {
+            assert_eq!(job_id, "42");
+            assert_eq!(return_value, serde_json::json!({"result": "ok"}));
+        }
+        _ => panic!("Expected Completed, got {:?}", event),
+    }
+}
+
+#[test]
+fn test_parse_event_failed() {
+    let mut fields = std::collections::HashMap::new();
+    fields.insert("event".into(), "failed".into());
+    fields.insert("jobId".into(), "7".into());
+    fields.insert("failedReason".into(), "timeout".into());
+
+    let event = bullmq_rs::QueueEvent::parse(&fields);
+    match event {
+        bullmq_rs::QueueEvent::Failed { job_id, reason } => {
+            assert_eq!(job_id, "7");
+            assert_eq!(reason, "timeout");
+        }
+        _ => panic!("Expected Failed, got {:?}", event),
+    }
+}
+
+#[test]
+fn test_parse_event_waiting_with_empty_prev() {
+    let mut fields = std::collections::HashMap::new();
+    fields.insert("event".into(), "waiting".into());
+    fields.insert("jobId".into(), "1".into());
+    fields.insert("prev".into(), "".into());
+
+    let event = bullmq_rs::QueueEvent::parse(&fields);
+    match event {
+        bullmq_rs::QueueEvent::Waiting { job_id, prev } => {
+            assert_eq!(job_id, "1");
+            assert_eq!(prev, None);
+        }
+        _ => panic!("Expected Waiting, got {:?}", event),
+    }
+}
+
+#[test]
+fn test_parse_event_paused() {
+    let mut fields = std::collections::HashMap::new();
+    fields.insert("event".into(), "paused".into());
+    assert_eq!(bullmq_rs::QueueEvent::parse(&fields), bullmq_rs::QueueEvent::Paused);
+}
+
+#[test]
+fn test_parse_event_resumed() {
+    let mut fields = std::collections::HashMap::new();
+    fields.insert("event".into(), "resumed".into());
+    assert_eq!(bullmq_rs::QueueEvent::parse(&fields), bullmq_rs::QueueEvent::Resumed);
+}
+
+#[test]
+fn test_parse_event_drained() {
+    let mut fields = std::collections::HashMap::new();
+    fields.insert("event".into(), "drained".into());
+    assert_eq!(bullmq_rs::QueueEvent::parse(&fields), bullmq_rs::QueueEvent::Drained);
+}
+
+#[test]
+fn test_parse_event_unknown() {
+    let mut fields = std::collections::HashMap::new();
+    fields.insert("event".into(), "custom_thing".into());
+    fields.insert("foo".into(), "bar".into());
+
+    let event = bullmq_rs::QueueEvent::parse(&fields);
+    match event {
+        bullmq_rs::QueueEvent::Unknown { event, fields } => {
+            assert_eq!(event, "custom_thing");
+            assert_eq!(fields.get("foo").unwrap(), "bar");
+        }
+        _ => panic!("Expected Unknown, got {:?}", event),
+    }
+}
+
+#[test]
+fn test_parse_event_completed_invalid_json() {
+    let mut fields = std::collections::HashMap::new();
+    fields.insert("event".into(), "completed".into());
+    fields.insert("jobId".into(), "1".into());
+    fields.insert("returnvalue".into(), "not valid json".into());
+
+    let event = bullmq_rs::QueueEvent::parse(&fields);
+    match event {
+        bullmq_rs::QueueEvent::Completed { return_value, .. } => {
+            assert_eq!(return_value, serde_json::Value::Null);
+        }
+        _ => panic!("Expected Completed, got {:?}", event),
+    }
+}
+
+#[test]
+fn test_parse_event_delayed() {
+    let mut fields = std::collections::HashMap::new();
+    fields.insert("event".into(), "delayed".into());
+    fields.insert("jobId".into(), "5".into());
+    fields.insert("delay".into(), "1712534400000".into());
+
+    let event = bullmq_rs::QueueEvent::parse(&fields);
+    match event {
+        bullmq_rs::QueueEvent::Delayed { job_id, delay } => {
+            assert_eq!(job_id, "5");
+            assert_eq!(delay, 1712534400000);
+        }
+        _ => panic!("Expected Delayed, got {:?}", event),
+    }
+}
+
+#[test]
+fn test_parse_event_progress() {
+    let mut fields = std::collections::HashMap::new();
+    fields.insert("event".into(), "progress".into());
+    fields.insert("jobId".into(), "3".into());
+    fields.insert("data".into(), r#"{"percent":50}"#.into());
+
+    let event = bullmq_rs::QueueEvent::parse(&fields);
+    match event {
+        bullmq_rs::QueueEvent::Progress { job_id, data } => {
+            assert_eq!(job_id, "3");
+            assert_eq!(data, serde_json::json!({"percent": 50}));
+        }
+        _ => panic!("Expected Progress, got {:?}", event),
+    }
+}
+
+#[test]
+fn test_parse_event_stalled() {
+    let mut fields = std::collections::HashMap::new();
+    fields.insert("event".into(), "stalled".into());
+    fields.insert("jobId".into(), "9".into());
+
+    match bullmq_rs::QueueEvent::parse(&fields) {
+        bullmq_rs::QueueEvent::Stalled { job_id } => assert_eq!(job_id, "9"),
+        other => panic!("Expected Stalled, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_parse_event_waiting_children() {
+    let mut fields = std::collections::HashMap::new();
+    fields.insert("event".into(), "waiting-children".into());
+    fields.insert("jobId".into(), "11".into());
+
+    match bullmq_rs::QueueEvent::parse(&fields) {
+        bullmq_rs::QueueEvent::WaitingChildren { job_id } => assert_eq!(job_id, "11"),
+        other => panic!("Expected WaitingChildren, got {:?}", other),
+    }
+}

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -446,9 +446,6 @@ async fn test_job_methods_without_context_return_error() {
     assert!(err.to_string().contains("no connection context"));
 
     // Stubs return NotImplemented (they check this before ctx)
-    let err = job.wait_until_finished(None).await.unwrap_err();
-    assert!(err.to_string().contains("Not implemented"));
-
     let err = job.get_dependencies().await.unwrap_err();
     assert!(err.to_string().contains("Not implemented"));
 

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -4,7 +4,9 @@ use std::time::Duration;
 
 #[test]
 fn test_flow_job_public_shape() {
-    use bullmq_rs::{FlowJob, FlowNode, FlowProducer, FlowProducerBuilder, Job, JobDependencies, JobOptions};
+    use bullmq_rs::{
+        FlowJob, FlowNode, FlowProducer, FlowProducerBuilder, Job, JobDependencies, JobOptions,
+    };
 
     let flow = FlowJob {
         name: "parent".into(),
@@ -22,10 +24,7 @@ fn test_flow_job_public_shape() {
         }],
     };
     let _shape_check = async {
-        let producer: FlowProducer = FlowProducerBuilder::new()
-            .prefix("custom")
-            .build()
-            .await?;
+        let producer: FlowProducer = FlowProducerBuilder::new().prefix("custom").build().await?;
         let job = FlowJob {
             name: "child".into(),
             queue_name: "children".into(),


### PR DESCRIPTION
## Summary

Addresses [bogardt/bullmq-rs#2](https://github.com/bogardt/bullmq-rs/issues/2).

This PR upgrades `bullmq-rs` to BullMQ Node.js v5-compatible wire format and core runtime behavior. Rust and Node can now share queues, jobs, events, and core parent/child flow state. Bull Board and other BullMQ ecosystem tooling can operate against queues created by `bullmq-rs`.

This is a **v2.0.0 breaking release**.

## Included in this PR

### Wire compatibility

- BullMQ-compatible Redis data layout:
  - `wait`, `active`, `paused` as lists
  - `prioritized`, `delayed`, `completed`, `failed`, `waiting-children`, `marker` as sorted sets
  - `meta` as hash
  - `events` as stream
- BullMQ-compatible job hash fields:
  - `atm`, `ats`, `processedOn`, `finishedOn`, `failedReason`, `returnvalue`, `pb`, `opts` as JSON
- BullMQ Lua ports for atomic queue/job state transitions

### Core runtime

- Marker-based worker loop using `BZPOPMIN`
- Token-based job locks with PX TTL, lock extension, stalled recovery, and `moveToFinished` fast-path
- Startup and timeout recovery for missed markers / pre-existing backlog
- Prefetch channel fix for concurrency so prefetched jobs are not orphaned in `active`

### Queue / Job / Events surface

- Queue API:
  - `add`, `get_job`, `get_job_counts`, `count`
  - `get_job_ids`, `get_jobs`
  - `get_waiting`, `get_active`, `get_delayed`, `get_prioritized`
  - `get_completed`, `get_failed`, `get_waiting_children`
  - `remove`, `drain`, `pause`, `resume`, `is_paused`
  - `add_log`, `get_logs`
- Job active-handle methods:
  - `update_progress`, `log`, `update_data`, `clear_logs`
  - `get_state` plus state helpers
  - `change_delay`, `retry`, `remove`, `change_priority`, `promote`
  - `wait_until_finished`
- QueueEvents:
  - Redis stream consumer via `XREAD BLOCK`
  - typed `QueueEvent` enum
  - `tokio::broadcast` delivery
- QueueEventsProducer:
  - custom event publishing via `XADD`

### Core Flows parity

- `FlowProducer` / `FlowProducerBuilder`
- Same-queue and cross-queue flow tree creation
- `waiting-children` lifecycle
- Parent release on child completion
- Delayed / paused / prioritized parent release behavior
- `Job::get_dependencies()`
- `Job::get_children_values()`

## Breaking changes

| Area | v1 | v2 |
|------|----|-----|
| `JobState::Waiting` | variant | `JobState::Wait` |
| `Job.timestamp` | `DateTime<Utc>` | `u64` (ms epoch) |
| `Job.progress` | `Option<u32>` | `Option<serde_json::Value>` |
| `Job.priority` | `i32` | `u32` |
| `WorkerOptions.poll_interval` | `Duration` | Removed (marker-based) |
| Handler return type | `Result<(), BullmqError>` | `Result<(), Box<dyn Error + Send + Sync>>` |
| Redis keys | `waiting` (zset), `active` (set) | BullMQ v5 layout |
| `Job::wait_until_finished` | stub | real impl requiring `&QueueEvents` |

## Deliberately excluded from this PR

This PR is scoped to wire compatibility, the core queue/runtime surface, and first-cut Flows parity. It intentionally does **not** attempt full BullMQ feature parity in one pass.

- `JobScheduler` / repeatable jobs
- Remaining Queue API surface such as:
  - `addBulk`, `clean`, `obliterate`, `retryJobs`, `promoteJobs`
- Remaining Worker API/control surface such as:
  - `pause` / `resume`
  - `isPaused` / `isRunning`
  - `close`, `cancelJob`, `rateLimit`
  - listener/event-emitter style Worker API
- Rate limiting and metrics
- Deduplication / debounce
- Automated Node.js conformance harness
- Advanced Flows APIs and policies not needed for the first cut:
  - `getFlow(...)`
  - dependency pagination / cursors
  - ignored-dependency-on-failure / failure-policy variants

## Verification

Latest local verification on this branch:

- [x] `cargo test --test unit_tests` (`39 passed`)
- [x] `cargo test --test integration_tests -- --ignored --test-threads=1 test_flow_` (`12 passed`)
- [x] `cargo test --test integration_tests -- --ignored --test-threads=1 test_job_get_dependencies_and_children_values` (`1 passed`)

Earlier branch validation also covered cross-language wire compatibility:

- [x] Rust producer -> Node.js reader
- [x] Node.js producer -> Rust worker
- [x] Node.js reads queue state after Rust processing
- [x] QueueEvents lifecycle delivery
- [x] `waitUntilFinished` result / timeout behavior

## Goal

The goal of this PR is BullMQ v5 wire compatibility plus the core runtime/features needed for real interoperability between Rust and Node, not full API parity with every BullMQ subsystem in one release.
