### PR TITLE
ci: wire cross-language compat tests against BullMQ Node.js

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,63 @@ jobs:
       - name: Run integration tests
         run: cargo test --test integration_tests -- --ignored --test-threads=1
 
+  compat:
+    name: Wire compat (BullMQ Node.js)
+    runs-on: ubuntu-latest
+
+    services:
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+
+    env:
+      REDIS_URL: redis://127.0.0.1:6379
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: tests/compat/package-lock.json
+
+      - name: Install BullMQ Node.js
+        working-directory: tests/compat
+        run: npm ci
+
+      - name: Build compat examples
+        run: cargo build --examples
+
+      - name: "Rust -> Node: produce jobs with bullmq-rs"
+        run: cargo run --example compat_producer
+
+      - name: "Rust -> Node: read jobs with BullMQ Node.js"
+        working-directory: tests/compat
+        run: node rust_producer_node_reader.js
+
+      - name: "Node -> Rust: produce job with BullMQ Node.js"
+        working-directory: tests/compat
+        run: node node_producer.js
+
+      - name: "Node -> Rust: process job with bullmq-rs"
+        run: cargo run --example compat_worker
+
+      - name: "Node -> Rust: verify completion with BullMQ Node.js"
+        working-directory: tests/compat
+        run: node node_verify_completed.js
+
   docs:
     name: Docs build
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+node_modules/
 .env
 ./redis-logs
 .wolf/

--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,0 +1,12 @@
+ci: wire cross-language compat tests against BullMQ Node.js
+
+Add a `compat` CI job that exercises both wire-format directions
+against bullmq@5.8 on a Redis 7 service container:
+- Rust -> Node: compat_producer example adds plain/delayed/prioritized
+  jobs, Node reader asserts counts, data and opts round-trip.
+- Node -> Rust: Node producer adds a job, compat_worker example
+  processes it, Node verifier asserts completion state is readable.
+
+Each direction uses its own queue (env-overridable) so runs do not
+interfere. Also fix needless-borrow clippy errors in integration
+tests flagged by current stable clippy so the lint job stays green.

--- a/examples/compat_producer.rs
+++ b/examples/compat_producer.rs
@@ -1,0 +1,89 @@
+//! Compat fixture: adds jobs for BullMQ Node.js to read.
+//!
+//! See tests/compat/README.md for the full cross-language flow.
+
+use bullmq_rs::{JobOptions, JobState, QueueBuilder, RedisConnection};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct Email {
+    to: String,
+    subject: String,
+    body: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let redis_url = std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".into());
+    let queue_name =
+        std::env::var("COMPAT_R2N_QUEUE").unwrap_or_else(|_| "compat-rust-to-node".into());
+
+    let conn = RedisConnection::new(&redis_url);
+    let queue = QueueBuilder::new(&queue_name)
+        .connection(conn)
+        .build::<Email>()
+        .await?;
+
+    let plain = queue
+        .add(
+            "welcome",
+            Email {
+                to: "user@example.com".into(),
+                subject: "Welcome!".into(),
+                body: "Produced by bullmq-rs".into(),
+            },
+            None,
+        )
+        .await?;
+    println!("Added plain job {}", plain.id);
+
+    let delayed = queue
+        .add(
+            "reminder",
+            Email {
+                to: "user@example.com".into(),
+                subject: "Delayed".into(),
+                body: "Produced by bullmq-rs (delayed)".into(),
+            },
+            Some(JobOptions {
+                delay: Some(Duration::from_secs(3600)),
+                ..Default::default()
+            }),
+        )
+        .await?;
+    println!("Added delayed job {}", delayed.id);
+
+    let prioritized = queue
+        .add(
+            "urgent",
+            Email {
+                to: "vip@example.com".into(),
+                subject: "Priority".into(),
+                body: "Produced by bullmq-rs (priority 5)".into(),
+            },
+            Some(JobOptions {
+                priority: Some(5u32),
+                ..Default::default()
+            }),
+        )
+        .await?;
+    println!("Added prioritized job {}", prioritized.id);
+
+    let counts = queue.get_job_counts().await?;
+    let wait = *counts.get(&JobState::Wait).unwrap_or(&0);
+    let delayed_count = *counts.get(&JobState::Delayed).unwrap_or(&0);
+    let prioritized_count = *counts.get(&JobState::Prioritized).unwrap_or(&0);
+    println!(
+        "Counts: wait={} delayed={} prioritized={}",
+        wait, delayed_count, prioritized_count
+    );
+
+    if wait < 1 || delayed_count < 1 || prioritized_count < 1 {
+        eprintln!("FAILED: expected at least one job in each of wait/delayed/prioritized");
+        std::process::exit(1);
+    }
+
+    println!("SUCCESS: jobs produced on queue '{}'", queue_name);
+    Ok(())
+}

--- a/examples/compat_worker.rs
+++ b/examples/compat_worker.rs
@@ -1,0 +1,87 @@
+//! Compat fixture: processes jobs added by BullMQ Node.js and exits.
+//!
+//! See tests/compat/README.md for the full cross-language flow.
+
+use bullmq_rs::{JobState, QueueBuilder, RedisConnection, WorkerBuilder};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct Email {
+    to: String,
+    subject: String,
+    body: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let redis_url = std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".into());
+    let queue_name =
+        std::env::var("COMPAT_N2R_QUEUE").unwrap_or_else(|_| "compat-node-to-rust".into());
+
+    let conn = RedisConnection::new(&redis_url);
+
+    let queue = QueueBuilder::new(&queue_name)
+        .connection(conn.clone())
+        .build::<Email>()
+        .await?;
+
+    let worker = WorkerBuilder::new(&queue_name)
+        .connection(conn)
+        .concurrency(1)
+        .lock_duration(Duration::from_secs(30))
+        .build::<Email>();
+
+    let handle = worker
+        .start(|job| async move {
+            println!(
+                "Processing job {} (name={}): to={}, subject={}",
+                job.id, job.name, job.data.to, job.data.subject
+            );
+            if job.name != "welcome" {
+                return Err(format!("unexpected job name '{}'", job.name).into());
+            }
+            if job.data.to.is_empty() || job.data.subject.is_empty() || job.data.body.is_empty() {
+                return Err("job data fields missing after Node->Rust round-trip".into());
+            }
+            Ok(())
+        })
+        .await?;
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    let completed;
+    loop {
+        let counts = queue.get_job_counts().await?;
+        let current = *counts.get(&JobState::Completed).unwrap_or(&0);
+        let failed = *counts.get(&JobState::Failed).unwrap_or(&0);
+        if failed > 0 {
+            eprintln!("FAILED: {} job(s) failed during processing", failed);
+            handle.shutdown();
+            handle.wait().await?;
+            std::process::exit(1);
+        }
+        if current >= 1 {
+            completed = current;
+            break;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            eprintln!(
+                "FAILED: no job completed within 30s (queue '{}')",
+                queue_name
+            );
+            handle.shutdown();
+            handle.wait().await?;
+            std::process::exit(1);
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+
+    handle.shutdown();
+    handle.wait().await?;
+
+    println!(
+        "SUCCESS: {} Node-produced job(s) processed by bullmq-rs on queue '{}'",
+        completed, queue_name
+    );
+    Ok(())
+}

--- a/tests/compat/README.md
+++ b/tests/compat/README.md
@@ -1,21 +1,33 @@
 # Cross-Language Compatibility Tests
 
-These tests verify that bullmq-rs v2 produces Redis data that BullMQ Node.js can read and vice versa.
+These tests verify that bullmq-rs v2 produces Redis data that BullMQ Node.js can read and vice versa. They run in CI (see the `compat` job in `.github/workflows/ci.yml`) and can also be run locally.
 
 ## Prerequisites
 
-- Redis running on localhost:6379 (or set REDIS_URL)
+- Redis running on localhost:6379 (or set `REDIS_URL`)
 - Node.js 18+
-- `npm install` in this directory
+- `npm ci` in this directory
 
 ## Running
 
 ```bash
-# Rust adds job, Node.js verifies it
-cargo run --example basic_queue  # add some jobs first
+# Rust adds jobs (plain, delayed, prioritized), Node.js verifies them
+cargo run --example compat_producer
 node rust_producer_node_reader.js
 
-# Node.js adds job, Rust reads it
+# Node.js adds a job, Rust processes it, Node.js verifies completion
 node node_producer.js
-cargo run --example basic_worker  # process the job
+cargo run --example compat_worker
+node node_verify_completed.js
 ```
+
+## Queues
+
+Each direction uses its own queue so runs do not interfere:
+
+| Direction   | Default queue        | Override env var   |
+| ----------- | -------------------- | ------------------ |
+| Rust → Node | `compat-rust-to-node` | `COMPAT_R2N_QUEUE` |
+| Node → Rust | `compat-node-to-rust` | `COMPAT_N2R_QUEUE` |
+
+When re-running locally against a non-fresh Redis, flush the compat queues first (e.g. `redis-cli --scan --pattern 'bull:compat-*' | xargs redis-cli del`).

--- a/tests/compat/node_producer.js
+++ b/tests/compat/node_producer.js
@@ -1,15 +1,16 @@
 /**
  * Adds a job using BullMQ Node.js for bullmq-rs to process.
  *
- * After running this, start a Rust worker to process the job:
- *   cargo run --example basic_worker
+ * After running this, process the job with:
+ *   cargo run --example compat_worker
  */
 const { Queue } = require('bullmq');
 
 const REDIS_URL = process.env.REDIS_URL || 'redis://127.0.0.1:6379';
+const QUEUE_NAME = process.env.COMPAT_N2R_QUEUE || 'compat-node-to-rust';
 
 async function main() {
-  const queue = new Queue('emails', {
+  const queue = new Queue(QUEUE_NAME, {
     connection: { url: REDIS_URL },
   });
 
@@ -20,8 +21,8 @@ async function main() {
       body: 'This job was created by BullMQ Node.js',
     });
 
-    console.log(`Added job ${job.id} via BullMQ Node.js`);
-    console.log('Now run: cargo run --example basic_worker');
+    console.log(`Added job ${job.id} via BullMQ Node.js on queue '${QUEUE_NAME}'`);
+    console.log('Now run: cargo run --example compat_worker');
   } finally {
     await queue.close();
   }

--- a/tests/compat/node_verify_completed.js
+++ b/tests/compat/node_verify_completed.js
@@ -1,0 +1,42 @@
+/**
+ * Verifies from BullMQ Node.js that the job produced by node_producer.js
+ * was completed by the bullmq-rs worker (compat_worker example).
+ */
+const { Queue } = require('bullmq');
+
+const REDIS_URL = process.env.REDIS_URL || 'redis://127.0.0.1:6379';
+const QUEUE_NAME = process.env.COMPAT_N2R_QUEUE || 'compat-node-to-rust';
+
+function fail(message) {
+  console.error(`FAILED: ${message}`);
+  process.exit(1);
+}
+
+async function main() {
+  const queue = new Queue(QUEUE_NAME, {
+    connection: { url: REDIS_URL },
+  });
+
+  try {
+    const counts = await queue.getJobCounts();
+    console.log('Job counts:', counts);
+
+    if (counts.failed > 0) fail(`${counts.failed} job(s) failed`);
+    if (counts.completed < 1) fail('expected at least 1 completed job');
+
+    const jobs = await queue.getJobs(['completed'], 0, 10);
+    for (const job of jobs) {
+      console.log(`  Completed job ${job.id}: name=${job.name}, finishedOn=${job.finishedOn}`);
+      if (!job.finishedOn) fail(`completed job ${job.id} has no finishedOn timestamp`);
+    }
+
+    console.log('SUCCESS: Rust-completed job state readable by BullMQ Node.js');
+  } finally {
+    await queue.close();
+  }
+}
+
+main().catch((err) => {
+  console.error('FAILED:', err.message);
+  process.exit(1);
+});

--- a/tests/compat/package-lock.json
+++ b/tests/compat/package-lock.json
@@ -1,0 +1,355 @@
+{
+  "name": "compat",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "bullmq": "^5.8.0",
+        "ioredis": "^5.0.0"
+      }
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.10.0.tgz",
+      "integrity": "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==",
+      "license": "MIT"
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
+      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
+      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
+      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
+      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
+      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
+      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/bullmq": {
+      "version": "5.78.0",
+      "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-5.78.0.tgz",
+      "integrity": "sha512-tT9jJmbobk9ueEfFc22egLmgwCcMGgOjZ5Y1cvgczBPv1JUmC7iHQVbQtqku2YBE5dE9uzdVpxIrBvL/YAjGwA==",
+      "license": "MIT",
+      "dependencies": {
+        "cron-parser": "4.9.0",
+        "ioredis": "5.10.1",
+        "msgpackr": "2.0.2",
+        "node-abort-controller": "3.1.1",
+        "semver": "7.8.0",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "peerDependencies": {
+        "redis": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "redis": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bullmq/node_modules/@ioredis/commands": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.1.tgz",
+      "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==",
+      "license": "MIT"
+    },
+    "node_modules/bullmq/node_modules/ioredis": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
+      "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "1.5.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
+      "integrity": "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cron-parser": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
+      "integrity": "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "luxon": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ioredis": {
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.11.1.tgz",
+      "integrity": "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "1.10.0",
+        "cluster-key-slot": "1.1.1",
+        "debug": "4.4.3",
+        "denque": "2.1.0",
+        "redis-errors": "1.2.0",
+        "redis-parser": "3.0.0",
+        "standard-as-callback": "2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/msgpackr": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.2.tgz",
+      "integrity": "sha512-c5hYOXFbP79Slh6Dzd2wzk+jnV7mX1UxfMYtilnY1NmalXPqG8DGb5cYCMBrW4AsH3zekBBZd4QrKz9NhtvYLQ==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.4"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
+      "integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
+      }
+    },
+    "node_modules/node-abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
+      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
+      "license": "MIT"
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    }
+  }
+}

--- a/tests/compat/rust_producer_node_reader.js
+++ b/tests/compat/rust_producer_node_reader.js
@@ -1,15 +1,21 @@
 /**
  * Verifies that jobs added by bullmq-rs can be read by BullMQ Node.js.
  *
- * Run `cargo run --example basic_queue` first to populate the queue,
+ * Run `cargo run --example compat_producer` first to populate the queue,
  * then run this script.
  */
 const { Queue } = require('bullmq');
 
 const REDIS_URL = process.env.REDIS_URL || 'redis://127.0.0.1:6379';
+const QUEUE_NAME = process.env.COMPAT_R2N_QUEUE || 'compat-rust-to-node';
+
+function fail(message) {
+  console.error(`FAILED: ${message}`);
+  process.exit(1);
+}
 
 async function main() {
-  const queue = new Queue('emails', {
+  const queue = new Queue(QUEUE_NAME, {
     connection: { url: REDIS_URL },
   });
 
@@ -17,25 +23,34 @@ async function main() {
     const counts = await queue.getJobCounts();
     console.log('Job counts:', counts);
 
-    if (counts.waiting === 0 && counts.delayed === 0) {
-      console.log('No jobs found. Run `cargo run --example basic_queue` first.');
-      process.exit(1);
-    }
+    if (counts.waiting < 1) fail('expected at least 1 waiting job');
+    if (counts.delayed < 1) fail('expected at least 1 delayed job');
+    if (counts.prioritized < 1) fail('expected at least 1 prioritized job');
 
-    // Try to read a waiting job
-    const jobs = await queue.getJobs(['waiting', 'delayed'], 0, 10);
+    const jobs = await queue.getJobs(['waiting', 'delayed', 'prioritized'], 0, 10);
     console.log(`Found ${jobs.length} jobs`);
 
+    const byName = {};
     for (const job of jobs) {
-      console.log(`  Job ${job.id}: name=${job.name}, data=${JSON.stringify(job.data)}`);
-      // Verify we can read the data without WRONGTYPE errors
-      if (!job.data) {
-        console.error(`  ERROR: Job ${job.id} has no data`);
-        process.exit(1);
+      console.log(`  Job ${job.id}: name=${job.name}, data=${JSON.stringify(job.data)}, opts=${JSON.stringify(job.opts)}`);
+      if (!job.data || !job.data.to || !job.data.subject || !job.data.body) {
+        fail(`job ${job.id} data not readable or missing fields`);
       }
+      byName[job.name] = job;
     }
 
-    console.log('SUCCESS: All jobs readable by BullMQ Node.js');
+    if (!byName.welcome) fail("missing plain job 'welcome'");
+    if (!byName.reminder) fail("missing delayed job 'reminder'");
+    if (!byName.urgent) fail("missing prioritized job 'urgent'");
+
+    if (!byName.reminder.opts || !byName.reminder.opts.delay) {
+      fail("delayed job 'reminder' has no delay in opts");
+    }
+    if (!byName.urgent.opts || byName.urgent.opts.priority !== 5) {
+      fail(`prioritized job 'urgent' has priority ${byName.urgent.opts && byName.urgent.opts.priority}, expected 5`);
+    }
+
+    console.log('SUCCESS: all bullmq-rs jobs readable by BullMQ Node.js');
   } finally {
     await queue.close();
   }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1074,7 +1074,7 @@ async fn test_job_clear_logs() {
 #[tokio::test]
 #[ignore = "requires running Redis"]
 async fn test_job_get_state() {
-    let queue = QueueBuilder::new(&unique_queue_name())
+    let queue = QueueBuilder::new(unique_queue_name())
         .connection(redis_conn())
         .build::<String>()
         .await
@@ -1096,7 +1096,7 @@ async fn test_job_get_state() {
 #[tokio::test]
 #[ignore = "requires running Redis"]
 async fn test_job_get_state_delayed() {
-    let queue = QueueBuilder::new(&unique_queue_name())
+    let queue = QueueBuilder::new(unique_queue_name())
         .connection(redis_conn())
         .build::<String>()
         .await
@@ -1236,7 +1236,7 @@ async fn test_job_change_priority() {
     let conn = RedisConnection::new(
         std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string()),
     );
-    let queue = QueueBuilder::new(&unique_queue_name())
+    let queue = QueueBuilder::new(unique_queue_name())
         .connection(conn)
         .build::<String>()
         .await
@@ -1274,7 +1274,7 @@ async fn test_job_promote() {
     let conn = RedisConnection::new(
         std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string()),
     );
-    let queue = QueueBuilder::new(&unique_queue_name())
+    let queue = QueueBuilder::new(unique_queue_name())
         .connection(conn)
         .build::<String>()
         .await
@@ -1387,7 +1387,7 @@ async fn test_job_remove() {
     let conn = RedisConnection::new(
         std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string()),
     );
-    let queue = QueueBuilder::new(&unique_queue_name())
+    let queue = QueueBuilder::new(unique_queue_name())
         .connection(conn)
         .build::<String>()
         .await


### PR DESCRIPTION
Add a `compat` CI job that exercises both wire-format directions against bullmq@5.8 on a Redis 7 service container:
- Rust -> Node: compat_producer example adds plain/delayed/prioritized jobs, Node reader asserts counts, data and opts round-trip.
- Node -> Rust: Node producer adds a job, compat_worker example processes it, Node verifier asserts completion state is readable.

Each direction uses its own queue (env-overridable) so runs do not interfere. Also fix needless-borrow clippy errors in integration tests flagged by current stable clippy so the lint job stays green.