### PR TITLE
feat: add JobScheduler (repeatable jobs) and worker advanced controls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +68,9 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 name = "bullmq-rs"
 version = "2.0.0"
 dependencies = [
+ "chrono",
+ "chrono-tz",
+ "croner",
  "redis",
  "serde",
  "serde_json",
@@ -81,10 +93,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cc"
+version = "1.2.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
 
 [[package]]
 name = "combine"
@@ -107,6 +152,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "croner"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c344b0690c1ad1c7176fe18eb173e0c927008fdaaa256e40dfd43ddd149c0843"
+dependencies = [
+ "chrono",
 ]
 
 [[package]]
@@ -168,6 +228,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "foldhash"
@@ -257,6 +323,30 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "icu_collections"
@@ -529,6 +619,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -697,6 +805,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,6 +819,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -1024,10 +1144,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 uuid = { version = "1", features = ["v4"] }
 tracing = "0.1"
+croner = "2"
+chrono = "0.4.45"
+chrono-tz = "0.10.4"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/lua/addJobScheduler-11.lua
+++ b/lua/addJobScheduler-11.lua
@@ -1,0 +1,211 @@
+--[[
+  Adds a job scheduler, i.e. a job factory that creates jobs based on a given schedule (repeat options).
+
+    Input:
+      KEYS[1]  'repeat' key
+      KEYS[2]  'delayed' key
+      KEYS[3]  'wait' key
+      KEYS[4]  'paused' key
+      KEYS[5]  'meta' key
+      KEYS[6]  'prioritized' key
+      KEYS[7]  'marker' key
+      KEYS[8]  'id' key
+      KEYS[9]  'events' key
+      KEYS[10] 'pc' priority counter
+      KEYS[11] 'active' key
+
+      ARGV[1] next milliseconds
+      ARGV[2] JSON scheduler options
+            name, tz?, pattern?, endDate?, every?, startDate?, limit?, offset?
+      ARGV[3] jobs scheduler id
+      ARGV[4] Json stringified template data
+      ARGV[5] JSON template opts
+      ARGV[6] JSON delayed job opts
+      ARGV[7] timestamp
+      ARGV[8] prefix key
+      ARGV[9] producer key
+
+      Output:
+        repeatableKey  - OK
+
+  Ported from BullMQ (msgpack ARGV adapted to JSON per repo convention;
+  what gets stored in Redis is byte-identical to upstream).
+]]
+local rcall = redis.call
+local repeatKey = KEYS[1]
+local delayedKey = KEYS[2]
+local waitKey = KEYS[3]
+local pausedKey = KEYS[4]
+local metaKey = KEYS[5]
+local prioritizedKey = KEYS[6]
+local eventsKey = KEYS[9]
+
+local nextMillis = ARGV[1]
+local jobSchedulerId = ARGV[3]
+local templateOpts = cjson.decode(ARGV[5])
+local now = tonumber(ARGV[7])
+local prefixKey = ARGV[8]
+local jobOpts = cjson.decode(ARGV[6])
+
+--@include "getOrSetMaxEvents"
+--@include "isQueuePaused"
+--@include "addBaseMarkerIfNeeded"
+--@include "getTargetQueueList"
+--@include "addJobInTargetList"
+--@include "getPriorityScore"
+--@include "addJobWithPriority"
+--@include "getDelayedScore"
+--@include "addDelayMarkerIfNeeded"
+--@include "addDelayedJob"
+--@include "storeJob"
+--@include "storeAndEnqueueJob"
+--@include "addJobFromScheduler"
+--@include "removeJobKeys"
+--@include "removeDeduplicationKeyIfNeededOnRemoval"
+--@include "destructureJobKey"
+--@include "removeParentDependencyKey"
+--@include "removeJob"
+--@include "storeJobScheduler"
+--@include "getJobSchedulerEveryNextMillis"
+
+-- If we are overriding a repeatable job we must delete the delayed job for
+-- the next iteration.
+local schedulerKey = repeatKey .. ":" .. jobSchedulerId
+local maxEvents = getOrSetMaxEvents(metaKey)
+
+local templateData = ARGV[4]
+
+local prevMillis = rcall("ZSCORE", repeatKey, jobSchedulerId)
+if prevMillis then
+    prevMillis = tonumber(prevMillis)
+end
+local schedulerOpts = cjson.decode(ARGV[2])
+
+local every = schedulerOpts['every']
+
+-- For backwards compatibility we also check the offset from the job itself.
+-- could be removed in future major versions.
+local jobOffset = jobOpts['repeat'] and jobOpts['repeat']['offset'] or 0
+local offset = schedulerOpts['offset'] or jobOffset or 0
+local newOffset = offset
+
+local updatedEvery = false
+if every then
+    -- if we changed the 'every' value we need to reset millis to nil
+    local millis = prevMillis
+    if prevMillis then
+        local prevEvery = tonumber(rcall("HGET", schedulerKey, "every"))
+        if prevEvery ~= every then
+            millis = nil
+            updatedEvery = true
+        end
+    end
+
+    local startDate = schedulerOpts['startDate']
+    nextMillis, newOffset = getJobSchedulerEveryNextMillis(millis, every, now, offset, startDate)
+end
+
+local function removeJobFromScheduler(prefixKey, delayedKey, prioritizedKey, waitKey, pausedKey, jobId, metaKey,
+    eventsKey)
+    if rcall("ZSCORE", delayedKey, jobId) then
+        removeJob(jobId, true, prefixKey, true --[[remove debounce key]] )
+        rcall("ZREM", delayedKey, jobId)
+        return true
+    elseif rcall("ZSCORE", prioritizedKey, jobId) then
+        removeJob(jobId, true, prefixKey, true --[[remove debounce key]] )
+        rcall("ZREM", prioritizedKey, jobId)
+        return true
+    else
+        local pausedOrWaitKey = waitKey
+        if isQueuePaused(metaKey) then
+            pausedOrWaitKey = pausedKey
+        end
+
+        if rcall("LREM", pausedOrWaitKey, 1, jobId) > 0 then
+            removeJob(jobId, true, prefixKey, true --[[remove debounce key]] )
+            return true
+        end
+    end
+
+    return false
+end
+
+local removedPrevJob = false
+if prevMillis then
+    local currentJobId = "repeat:" .. jobSchedulerId .. ":" .. prevMillis
+    local currentJobKey = schedulerKey .. ":" .. prevMillis
+
+    -- In theory it should always exist the currentJobKey if there is a prevMillis unless something has
+    -- gone really wrong.
+    if rcall("EXISTS", currentJobKey) == 1 then
+        removedPrevJob = removeJobFromScheduler(prefixKey, delayedKey, prioritizedKey, waitKey, pausedKey, currentJobId,
+            metaKey, eventsKey)
+    end
+end
+
+if removedPrevJob then
+    -- The jobs has been removed and we want to replace it, so lets use the same millis.
+    if every and not updatedEvery then
+        nextMillis = prevMillis
+    end
+else
+    -- Special case where no job was removed, and we need to add the next iteration.
+    schedulerOpts['offset'] = newOffset
+end
+
+-- Check for job ID collision with existing jobs (in any state)
+local jobId = "repeat:" .. jobSchedulerId .. ":" .. nextMillis
+local jobKey = prefixKey .. jobId
+
+-- If there's already a job with this ID, in a state
+-- that is not updatable (active, completed, failed) we must
+-- handle the collision
+local hasCollision = false
+if rcall("EXISTS", jobKey) == 1 then
+    if every then
+        -- For 'every' case: try next time slot to avoid collision
+        local nextSlotMillis = nextMillis + every
+        local nextSlotJobId = "repeat:" .. jobSchedulerId .. ":" .. nextSlotMillis
+        local nextSlotJobKey = prefixKey .. nextSlotJobId
+
+        if rcall("EXISTS", nextSlotJobKey) == 0 then
+            -- Next slot is free, use it
+            nextMillis = nextSlotMillis
+            jobId = nextSlotJobId
+        else
+            -- Next slot also has a job, return error code
+            return -11 -- SchedulerJobSlotsBusy
+        end
+    else
+        hasCollision = true
+    end
+end
+
+local delay = nextMillis - now
+
+-- Fast Clamp delay to minimum of 0
+if delay < 0 then
+    delay = 0
+end
+
+local nextJobKey = schedulerKey .. ":" .. nextMillis
+
+if not hasCollision or removedPrevJob then
+    -- jobId already calculated above during collision check
+
+    storeJobScheduler(jobSchedulerId, schedulerKey, repeatKey, nextMillis, schedulerOpts, templateData, templateOpts)
+
+    rcall("INCR", KEYS[8])
+
+    addJobFromScheduler(nextJobKey, jobId, jobOpts, waitKey, pausedKey, KEYS[11], metaKey, prioritizedKey, KEYS[10],
+        delayedKey, KEYS[7], eventsKey, schedulerOpts['name'], maxEvents, now, templateData, jobSchedulerId, delay)
+elseif hasCollision then
+    -- For 'pattern' case: return error code
+    return -10 -- SchedulerJobIdCollision
+end
+
+if ARGV[9] ~= "" then
+    rcall("HSET", ARGV[9], "nrjid", jobId)
+end
+
+return {jobId .. "", delay}

--- a/lua/extendLocks-1.lua
+++ b/lua/extendLocks-1.lua
@@ -1,0 +1,50 @@
+--[[
+  Extend locks for multiple jobs and remove them from the stalled set if successful.
+  Return the list of job IDs for which the operation failed.
+
+  KEYS[1] = stalled key
+
+  ARGV[1] = baseKey
+  ARGV[2] = tokens (JSON array)
+  ARGV[3] = jobIds (JSON array)
+  ARGV[4] = lockDuration (ms)
+
+  Output:
+    An array of failed job IDs. If empty, all succeeded.
+
+  Ported from BullMQ (msgpack ARGV adapted to JSON per repo convention).
+]]
+local rcall = redis.call
+
+local stalledKey = KEYS[1]
+local baseKey = ARGV[1]
+local tokens = cjson.decode(ARGV[2])
+local jobIds = cjson.decode(ARGV[3])
+local lockDuration = ARGV[4]
+
+local jobCount = #jobIds
+local failedJobs = {}
+
+for i = 1, jobCount, 1 do
+    local lockKey = baseKey .. jobIds[i] .. ':lock'
+    local jobId = jobIds[i]
+    local token = tokens[i]
+
+    local currentToken = rcall("GET", lockKey)
+    if currentToken then
+        if currentToken == token then
+            local setResult = rcall("SET", lockKey, token, "PX", lockDuration)
+            if setResult then
+                rcall("SREM", stalledKey, jobId)
+            else
+                table.insert(failedJobs, jobId)
+            end
+        else
+            table.insert(failedJobs, jobId)
+        end
+    else
+        table.insert(failedJobs, jobId)
+    end
+end
+
+return failedJobs

--- a/lua/getJobScheduler-1.lua
+++ b/lua/getJobScheduler-1.lua
@@ -1,0 +1,20 @@
+--[[
+  Get job scheduler record.
+
+  Input:
+    KEYS[1] 'repeat' key
+
+    ARGV[1] id
+
+  Ported from BullMQ.
+]]
+local rcall = redis.call
+local jobSchedulerKey = KEYS[1] .. ":" .. ARGV[1]
+
+local score = rcall("ZSCORE", KEYS[1], ARGV[1])
+
+if score then
+  return {rcall("HGETALL", jobSchedulerKey), score} -- get job data
+end
+
+return {nil, nil}

--- a/lua/includes/addDelayedJob.lua
+++ b/lua/includes/addDelayedJob.lua
@@ -1,0 +1,18 @@
+--[[
+  Adds an already-stored job to the delayed zset and emits the
+  'delayed' event.
+
+  Ported from BullMQ.
+]]
+local function addDelayedJob(jobId, delayedKey, eventsKey, timestamp,
+  maxEvents, markerKey, delay)
+
+  local score, delayedTimestamp = getDelayedScore(delayedKey, timestamp, tonumber(delay))
+
+  rcall("ZADD", delayedKey, score, jobId)
+  rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*", "event", "delayed",
+    "jobId", jobId, "delay", delayedTimestamp)
+
+  -- mark that a delayed job is available
+  addDelayMarkerIfNeeded(markerKey, delayedKey)
+end

--- a/lua/includes/addJobFromScheduler.lua
+++ b/lua/includes/addJobFromScheduler.lua
@@ -1,0 +1,17 @@
+--[[
+  Store and enqueue the next iteration job produced by a job scheduler.
+
+  Ported from BullMQ.
+]]
+local function addJobFromScheduler(jobKey, jobId, opts, waitKey, pausedKey, activeKey, metaKey,
+  prioritizedKey, priorityCounter, delayedKey, markerKey, eventsKey, name, maxEvents, timestamp,
+  data, jobSchedulerId, repeatDelay)
+
+  opts['delay'] = repeatDelay
+  opts['jobId'] = jobId
+
+  storeAndEnqueueJob(eventsKey, jobKey, jobId, name, data, opts,
+      timestamp, nil, nil, jobSchedulerId, maxEvents,
+      waitKey, pausedKey, activeKey, metaKey, prioritizedKey,
+      priorityCounter, delayedKey, markerKey)
+end

--- a/lua/includes/getJobSchedulerEveryNextMillis.lua
+++ b/lua/includes/getJobSchedulerEveryNextMillis.lua
@@ -1,0 +1,44 @@
+--[[
+  Compute the next iteration timestamp and slot offset for an "every"
+  job scheduler.
+
+  Ported from BullMQ.
+]]
+local function getJobSchedulerEveryNextMillis(prevMillis, every, now, offset, startDate)
+    local nextMillis
+    if not prevMillis then
+        if startDate then
+            -- Assuming startDate is passed as milliseconds from JavaScript
+            nextMillis = tonumber(startDate)
+            nextMillis = nextMillis > now and nextMillis or now
+        else
+            nextMillis = now
+            -- For the first iteration with no startDate and an explicit
+            -- offset, align nextMillis to the next offset slot strictly
+            -- after now. Without this the user-supplied offset is
+            -- recorded but ignored, and the first job fires at now
+            -- instead of the next aligned timestamp (issue #3705).
+            if offset and offset > 0 then
+                local aligned = math.floor(nextMillis / every) * every + offset
+                if aligned <= nextMillis then
+                    aligned = aligned + every
+                end
+                nextMillis = aligned
+            end
+        end
+    else
+        nextMillis = prevMillis + every
+        -- check if we may have missed some iterations
+        if nextMillis < now then
+            nextMillis = math.floor(now / every) * every + every + (offset or 0)
+        end
+    end
+
+    if not offset or offset == 0 then
+        local timeSlot = math.floor(nextMillis / every) * every;
+        offset = nextMillis - timeSlot;
+    end
+
+    -- Return a tuple nextMillis, offset
+    return math.floor(nextMillis), math.floor(offset)
+end

--- a/lua/includes/isQueuePaused.lua
+++ b/lua/includes/isQueuePaused.lua
@@ -1,0 +1,7 @@
+--[[
+  Function to check for the meta.paused key to decide if we are paused or not
+  (since an empty list and !EXISTS are not really the same).
+]]
+local function isQueuePaused(queueMetaKey)
+  return rcall("HEXISTS", queueMetaKey, "paused") == 1
+end

--- a/lua/includes/storeAndEnqueueJob.lua
+++ b/lua/includes/storeAndEnqueueJob.lua
@@ -1,0 +1,36 @@
+--[[
+  Shared helper to store a job and enqueue it into the appropriate list/set.
+  Handles delayed, prioritized, and standard (LIFO/FIFO) jobs.
+  Emits the appropriate event after enqueuing ("delayed" or "waiting").
+
+  Returns delay, priority from storeJob.
+
+  Ported from BullMQ.
+]]
+local function storeAndEnqueueJob(eventsKey, jobIdKey, jobId, name, data, opts,
+    timestamp, parentKey, parentData, repeatJobKey, maxEvents,
+    waitKey, pausedKey, activeKey, metaKey, prioritizedKey,
+    priorityCounterKey, delayedKey, markerKey)
+
+  local delay, priority = storeJob(eventsKey, jobIdKey, jobId, name, data,
+      opts, timestamp, parentKey, parentData, repeatJobKey)
+
+  if delay ~= 0 and delayedKey then
+    addDelayedJob(jobId, delayedKey, eventsKey, timestamp, maxEvents, markerKey, delay)
+  else
+    local target, isPausedOrMaxed = getTargetQueueList(metaKey, activeKey, waitKey, pausedKey)
+
+    if priority > 0 then
+      addJobWithPriority(markerKey, prioritizedKey, priority, jobId,
+          priorityCounterKey, isPausedOrMaxed)
+    else
+      local pushCmd = opts['lifo'] and 'RPUSH' or 'LPUSH'
+      addJobInTargetList(target, markerKey, pushCmd, isPausedOrMaxed, jobId)
+    end
+
+    rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*", "event", "waiting",
+        "jobId", jobId)
+  end
+
+  return delay, priority
+end

--- a/lua/includes/storeJob.lua
+++ b/lua/includes/storeJob.lua
@@ -3,7 +3,8 @@
 
   Ported from BullMQ (stripped: parent/dependency, repeat).
 ]]
-local function storeJob(eventsKey, jobIdKey, jobId, name, data, opts, timestamp, parentKey, parentData)
+local function storeJob(eventsKey, jobIdKey, jobId, name, data, opts, timestamp, parentKey, parentData,
+                        repeatJobKey)
   local jsonOpts = cjson.encode(opts)
   local delay = opts['delay'] or 0
   local priority = opts['priority'] or 0
@@ -19,6 +20,10 @@ local function storeJob(eventsKey, jobIdKey, jobId, name, data, opts, timestamp,
 
   if parentData ~= nil and parentData ~= "" then
     rcall("HSET", jobIdKey, "parent", parentData)
+  end
+
+  if repeatJobKey then
+    rcall("HSET", jobIdKey, "rjk", repeatJobKey)
   end
 
   if debounceId then

--- a/lua/includes/storeJobScheduler.lua
+++ b/lua/includes/storeJobScheduler.lua
@@ -1,0 +1,69 @@
+--[[
+  Function to store a job scheduler.
+
+  Ported from BullMQ. templateOpts is a decoded Lua table; it is stored
+  re-encoded with cjson exactly like upstream does.
+]]
+local function storeJobScheduler(schedulerId, schedulerKey, repeatKey, nextMillis, opts,
+  templateData, templateOpts)
+  rcall("ZADD", repeatKey, nextMillis, schedulerId)
+
+  local optionalValues = {}
+  if opts['tz'] then
+    table.insert(optionalValues, "tz")
+    table.insert(optionalValues, opts['tz'])
+  end
+
+  if opts['limit'] then
+    table.insert(optionalValues, "limit")
+    table.insert(optionalValues, opts['limit'])
+  end
+
+  if opts['pattern'] then
+    table.insert(optionalValues, "pattern")
+    table.insert(optionalValues, opts['pattern'])
+  end
+
+  if opts['startDate'] then
+    table.insert(optionalValues, "startDate")
+    table.insert(optionalValues, opts['startDate'])
+  end
+
+  if opts['endDate'] then
+    table.insert(optionalValues, "endDate")
+    table.insert(optionalValues, opts['endDate'])
+  end
+
+  if opts['every'] then
+    table.insert(optionalValues, "every")
+    table.insert(optionalValues, opts['every'])
+  end
+
+  if opts['offset'] then
+    table.insert(optionalValues, "offset")
+    table.insert(optionalValues, opts['offset'])
+  else
+    local offset = rcall("HGET", schedulerKey, "offset")
+    if offset then
+      table.insert(optionalValues, "offset")
+      table.insert(optionalValues, tonumber(offset))
+    end
+  end
+
+  local jsonTemplateOpts = cjson.encode(templateOpts)
+  if jsonTemplateOpts and jsonTemplateOpts ~= '{}' then
+    table.insert(optionalValues, "opts")
+    table.insert(optionalValues, jsonTemplateOpts)
+  end
+
+  if templateData and templateData ~= '{}' then
+    table.insert(optionalValues, "data")
+    table.insert(optionalValues, templateData)
+  end
+
+  table.insert(optionalValues, "ic")
+  table.insert(optionalValues, rcall("HGET", schedulerKey, "ic") or 1)
+
+  rcall("DEL", schedulerKey) -- remove all attributes and then re-insert new ones
+  rcall("HMSET", schedulerKey, "name", opts['name'], unpack(optionalValues))
+end

--- a/lua/removeJobScheduler-3.lua
+++ b/lua/removeJobScheduler-3.lua
@@ -1,0 +1,43 @@
+--[[
+  Removes a job scheduler and its next scheduled job.
+  Input:
+    KEYS[1] job schedulers key
+    KEYS[2] delayed jobs key
+    KEYS[3] events key
+
+    ARGV[1] job scheduler id
+    ARGV[2] prefix key
+
+  Output:
+    0 - OK
+    1 - Missing repeat job
+
+  Events:
+    'removed'
+
+  Ported from BullMQ.
+]]
+local rcall = redis.call
+
+--@include "removeJobKeys"
+
+local jobSchedulerId = ARGV[1]
+local prefix = ARGV[2]
+
+local millis = rcall("ZSCORE", KEYS[1], jobSchedulerId)
+
+if millis then
+  -- Delete next programmed job.
+  local delayedJobId = "repeat:" .. jobSchedulerId .. ":" .. millis
+  if(rcall("ZREM", KEYS[2], delayedJobId) == 1) then
+    removeJobKeys(prefix .. delayedJobId)
+    rcall("XADD", KEYS[3], "*", "event", "removed", "jobId", delayedJobId, "prev", "delayed")
+  end
+end
+
+if(rcall("ZREM", KEYS[1], jobSchedulerId) == 1) then
+  rcall("DEL", KEYS[1] .. ":" .. jobSchedulerId)
+  return 0
+end
+
+return 1

--- a/lua/updateJobScheduler-12.lua
+++ b/lua/updateJobScheduler-12.lua
@@ -1,0 +1,138 @@
+--[[
+  Updates a job scheduler and adds next delayed job
+
+  Input:
+    KEYS[1]  'repeat' key
+    KEYS[2]  'delayed'
+    KEYS[3]  'wait' key
+    KEYS[4]  'paused' key
+    KEYS[5]  'meta'
+    KEYS[6]  'prioritized' key
+    KEYS[7]  'marker',
+    KEYS[8]  'id'
+    KEYS[9]  events stream key
+    KEYS[10] 'pc' priority counter
+    KEYS[11] producer key
+    KEYS[12] 'active' key
+
+    ARGV[1] next milliseconds
+    ARGV[2] jobs scheduler id
+    ARGV[3] Json stringified delayed data
+    ARGV[4] JSON delayed job opts
+    ARGV[5] timestamp
+    ARGV[6] prefix key
+    ARGV[7] producer id
+
+    Output:
+      next delayed job id  - OK
+
+  Ported from BullMQ (msgpack ARGV adapted to JSON per repo convention).
+]]
+local rcall = redis.call
+local repeatKey = KEYS[1]
+local delayedKey = KEYS[2]
+local waitKey = KEYS[3]
+local pausedKey = KEYS[4]
+local metaKey = KEYS[5]
+local prioritizedKey = KEYS[6]
+local nextMillis = tonumber(ARGV[1])
+local jobSchedulerId = ARGV[2]
+local timestamp = tonumber(ARGV[5])
+local prefixKey = ARGV[6]
+local producerId = ARGV[7]
+local jobOpts = cjson.decode(ARGV[4])
+
+--@include "getOrSetMaxEvents"
+--@include "addBaseMarkerIfNeeded"
+--@include "getTargetQueueList"
+--@include "addJobInTargetList"
+--@include "getPriorityScore"
+--@include "addJobWithPriority"
+--@include "getDelayedScore"
+--@include "addDelayMarkerIfNeeded"
+--@include "addDelayedJob"
+--@include "storeJob"
+--@include "storeAndEnqueueJob"
+--@include "addJobFromScheduler"
+--@include "getJobSchedulerEveryNextMillis"
+
+local prevMillis = rcall("ZSCORE", repeatKey, jobSchedulerId)
+
+-- Validate that scheduler exists.
+-- If it does not exist we should not iterate anymore.
+if prevMillis then
+    prevMillis = tonumber(prevMillis)
+
+    local schedulerKey = repeatKey .. ":" .. jobSchedulerId
+    local schedulerAttributes = rcall("HMGET", schedulerKey, "name", "data", "every", "startDate", "offset")
+
+    local every = tonumber(schedulerAttributes[3])
+    local now = tonumber(timestamp)
+
+    -- If every is not found in scheduler attributes, try to get it from job options
+    if not every and jobOpts['repeat'] and jobOpts['repeat']['every'] then
+        every = tonumber(jobOpts['repeat']['every'])
+    end
+
+    if every then
+        local startDate = schedulerAttributes[4]
+        local jobOptsOffset = jobOpts['repeat'] and jobOpts['repeat']['offset'] or 0
+        local offset = schedulerAttributes[5] or jobOptsOffset or 0
+        local newOffset
+
+        nextMillis, newOffset = getJobSchedulerEveryNextMillis(prevMillis, every, now, offset, startDate)
+
+        if not offset then
+            rcall("HSET", schedulerKey, "offset", newOffset)
+            jobOpts['repeat']['offset'] = newOffset
+        end
+    end
+
+    local nextDelayedJobId = "repeat:" .. jobSchedulerId .. ":" .. nextMillis
+    local nextDelayedJobKey = schedulerKey .. ":" .. nextMillis
+
+    local currentDelayedJobId = "repeat:" .. jobSchedulerId .. ":" .. prevMillis
+
+    if producerId == currentDelayedJobId then
+        local eventsKey = KEYS[9]
+        local maxEvents = getOrSetMaxEvents(metaKey)
+
+        if rcall("EXISTS", nextDelayedJobKey) ~= 1 then
+
+            rcall("ZADD", repeatKey, nextMillis, jobSchedulerId)
+            rcall("HINCRBY", schedulerKey, "ic", 1)
+
+            rcall("INCR", KEYS[8])
+
+            -- TODO: remove this workaround in next breaking change,
+            -- all job-schedulers must save job data
+            local templateData = schedulerAttributes[2] or ARGV[3]
+
+            if templateData and templateData ~= '{}' then
+                rcall("HSET", schedulerKey, "data", templateData)
+            end
+
+            local delay = nextMillis - now
+
+            -- Fast Clamp delay to minimum of 0
+            if delay < 0 then
+                delay = 0
+            end
+
+            jobOpts["delay"] = delay
+
+            addJobFromScheduler(nextDelayedJobKey, nextDelayedJobId, jobOpts, waitKey, pausedKey, KEYS[12], metaKey,
+                prioritizedKey, KEYS[10], delayedKey, KEYS[7], eventsKey, schedulerAttributes[1], maxEvents, ARGV[5],
+                templateData or '{}', jobSchedulerId, delay)
+
+            -- TODO: remove this workaround in next breaking change
+            if KEYS[11] ~= "" then
+                rcall("HSET", KEYS[11], "nrjid", nextDelayedJobId)
+            end
+
+            return nextDelayedJobId .. "" -- convert to string
+        else
+            rcall("XADD", eventsKey, "MAXLEN", "~", maxEvents, "*", "event", "duplicated", "jobId", nextDelayedJobId)
+        end
+    end
+end

--- a/src/job.rs
+++ b/src/job.rs
@@ -82,6 +82,8 @@ pub struct Job<T> {
     pub return_value: Option<serde_json::Value>,
     /// Identifier of the worker that processed this job. Maps to "pb" in the Redis hash.
     pub processed_by: Option<String>,
+    /// Id of the job scheduler that produced this job. Maps to "rjk" in the Redis hash.
+    pub repeat_job_key: Option<String>,
     /// Connection context injected by Queue/Worker. None for manually-created jobs.
     #[serde(skip)]
     pub(crate) ctx: Option<Arc<JobContext>>,
@@ -118,6 +120,7 @@ impl<T: Serialize + DeserializeOwned> Job<T> {
             stacktrace: Vec::new(),
             return_value: None,
             processed_by: None,
+            repeat_job_key: None,
             ctx: None,
             lock_token: None,
         }
@@ -169,6 +172,9 @@ impl<T: Serialize + DeserializeOwned> Job<T> {
         }
         if let Some(ref pb) = self.processed_by {
             fields.push(("pb".into(), pb.clone()));
+        }
+        if let Some(ref rjk) = self.repeat_job_key {
+            fields.push(("rjk".into(), rjk.clone()));
         }
 
         Ok(fields)
@@ -246,6 +252,7 @@ impl<T: Serialize + DeserializeOwned> Job<T> {
             .transpose()?
             .unwrap_or_default();
         let processed_by = map.get("pb").cloned();
+        let repeat_job_key = map.get("rjk").cloned();
 
         // Determine state: prefer explicit "state" field, otherwise infer Wait.
         let state: JobState = match map.get("state") {
@@ -271,6 +278,7 @@ impl<T: Serialize + DeserializeOwned> Job<T> {
             stacktrace,
             return_value,
             processed_by,
+            repeat_job_key,
             ctx: None,
             lock_token: None,
         })
@@ -623,6 +631,61 @@ impl<T: Serialize + DeserializeOwned> Job<T> {
             self.priority,
         )
         .await
+    }
+
+    /// Move this active job to the completed set.
+    ///
+    /// Only valid for jobs holding a lock token, i.e. jobs obtained via
+    /// [`crate::Queue::get_next_job`] (or inside a worker handler). The
+    /// `return_value` is stored in the `returnvalue` hash field.
+    pub async fn move_to_completed(&mut self, return_value: serde_json::Value) -> BullmqResult<()> {
+        self.move_to_finished_state(&serde_json::to_string(&return_value)?, "completed")
+            .await?;
+        self.return_value = Some(return_value);
+        self.state = JobState::Completed;
+        Ok(())
+    }
+
+    /// Move this active job to the failed set with the given reason.
+    ///
+    /// Only valid for jobs holding a lock token, i.e. jobs obtained via
+    /// [`crate::Queue::get_next_job`] (or inside a worker handler).
+    pub async fn move_to_failed(&mut self, reason: &str) -> BullmqResult<()> {
+        self.move_to_finished_state(reason, "failed").await?;
+        self.failed_reason = Some(reason.to_string());
+        self.state = JobState::Failed;
+        Ok(())
+    }
+
+    async fn move_to_finished_state(&self, result_data: &str, target: &str) -> BullmqResult<()> {
+        let token = self.lock_token.as_deref().ok_or_else(|| {
+            BullmqError::Other(
+                "moving to a finished state requires a lock token (use Queue::get_next_job)".into(),
+            )
+        })?;
+
+        let ctx = self.ctx()?;
+        let mut conn = ctx.conn.clone();
+
+        crate::scripts::commands::move_to_finished::move_to_finished(
+            &ctx.scripts,
+            &mut conn,
+            &ctx.prefix,
+            &ctx.queue_name,
+            &self.id,
+            token,
+            now_ms(),
+            result_data,
+            target,
+            10_000,
+            false,
+            30_000,
+            self.attempts_made + 1,
+            None,
+            None,
+        )
+        .await?;
+        Ok(())
     }
 
     /// Wait until this job is finished (completed or failed).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,7 @@ pub mod flow_producer;
 pub mod types;
 
 pub mod job;
+pub(crate) mod repeat;
 pub(crate) mod scripts;
 
 pub mod queue;
@@ -78,7 +79,8 @@ pub use queue::{Queue, QueueBuilder};
 pub use queue_events::{QueueEvent, QueueEvents, QueueEventsBuilder};
 pub use queue_events_producer::{QueueEventsProducer, QueueEventsProducerBuilder};
 pub use types::{
-    BackoffStrategy, DeduplicationOptions, JobDependencies, JobOptions, JobState, Metrics,
-    MetricsMeta, MetricsOptions, RateLimiterOptions, WorkerOptions,
+    BackoffStrategy, DeduplicationOptions, JobDependencies, JobOptions, JobScheduler,
+    JobSchedulerTemplate, JobState, Metrics, MetricsMeta, MetricsOptions, RateLimiterOptions,
+    RepeatOptions, WorkerOptions,
 };
 pub use worker::{Worker, WorkerBuilder, WorkerHandle};

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -11,11 +11,15 @@ use crate::connection::RedisConnection;
 use crate::error::{BullmqError, BullmqResult};
 use crate::job::{cleanup_job, Job, JobContext};
 use crate::scripts::commands::{
-    add_delayed_job, add_log, add_prioritized_job, add_standard_job, clean_jobs_in_set,
-    get_metrics, move_jobs_to_wait, obliterate, pause,
+    add_delayed_job, add_job_scheduler, add_log, add_prioritized_job, add_standard_job,
+    clean_jobs_in_set, extend_locks, get_job_scheduler, get_metrics, move_jobs_to_wait,
+    move_to_active, obliterate, pause, remove_job_scheduler,
 };
 use crate::scripts::ScriptLoader;
-use crate::types::{JobOptions, JobState, Metrics, DEFAULT_MAX_EVENTS};
+use crate::types::{
+    JobOptions, JobScheduler, JobSchedulerTemplate, JobState, Metrics, RepeatOptions,
+    DEFAULT_MAX_EVENTS,
+};
 
 fn now_ms() -> u64 {
     std::time::SystemTime::now()
@@ -929,6 +933,273 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + 'static> Queue<T> {
         .await
     }
 
+    /// Create or update a job scheduler (repeatable job) and schedule its
+    /// next iteration.
+    ///
+    /// Mirrors Node BullMQ `Queue.upsertJobScheduler`. Exactly one of
+    /// [`RepeatOptions::pattern`] or [`RepeatOptions::every`] must be set.
+    /// When upserting over an existing scheduler, the pending iteration job
+    /// is replaced (no orphan is left behind). After each iteration finishes,
+    /// workers automatically schedule the following one until `limit` or
+    /// `end_date` is reached, or the scheduler is removed.
+    ///
+    /// Returns the first iteration job, whose id has the shape
+    /// `repeat:<scheduler_id>:<next_millis>`. Errors when the iteration
+    /// `limit` or `end_date` is already exhausted (Node returns `undefined`
+    /// in those cases).
+    pub async fn upsert_job_scheduler(
+        &self,
+        scheduler_id: &str,
+        repeat_opts: RepeatOptions,
+        template: JobSchedulerTemplate<T>,
+    ) -> BullmqResult<Job<T>> {
+        if repeat_opts.pattern.is_some() && repeat_opts.every.is_some() {
+            return Err(BullmqError::Other(
+                "Both .pattern and .every options are defined for this repeatable job".into(),
+            ));
+        }
+        if repeat_opts.pattern.is_none() && repeat_opts.every.is_none() {
+            return Err(BullmqError::Other(
+                "Either .pattern or .every options must be defined for this repeatable job".into(),
+            ));
+        }
+        if repeat_opts.immediately && repeat_opts.start_date.is_some() {
+            return Err(BullmqError::Other(
+                "Both .immediately and .startDate options are defined for this repeatable job"
+                    .into(),
+            ));
+        }
+
+        let iteration_count = repeat_opts.count.map(|c| c + 1).unwrap_or(1);
+        if let Some(limit) = repeat_opts.limit {
+            if iteration_count > limit {
+                return Err(BullmqError::Other(format!(
+                    "Job scheduler {} reached its iteration limit",
+                    scheduler_id
+                )));
+            }
+        }
+
+        let mut now = now_ms();
+        if let Some(end_date) = repeat_opts.end_date {
+            if now > end_date {
+                return Err(BullmqError::Other(format!(
+                    "Job scheduler {} is past its end date",
+                    scheduler_id
+                )));
+            }
+        }
+
+        let template_opts = template.opts.unwrap_or_default();
+        let prev_millis = template_opts.prev_millis.unwrap_or(0);
+        if prev_millis > now {
+            now = prev_millis;
+        }
+
+        let next_millis = match &repeat_opts.pattern {
+            Some(pattern) => crate::repeat::next_pattern_millis(now, &repeat_opts, pattern)?
+                .ok_or_else(|| {
+                    BullmqError::Other(format!("No next occurrence for cron pattern '{}'", pattern))
+                })?
+                .max(now),
+            // The Lua script computes nextMillis itself in 'every' mode.
+            None => 0,
+        };
+
+        let job_name = template
+            .name
+            .clone()
+            .unwrap_or_else(|| scheduler_id.to_string());
+        let template_data_json = match &template.data {
+            Some(data) => serde_json::to_string(data)?,
+            None => "{}".to_string(),
+        };
+
+        let merged_opts = crate::repeat::build_iteration_opts(
+            &template_opts,
+            &repeat_opts,
+            scheduler_id,
+            iteration_count,
+            if repeat_opts.pattern.is_some() {
+                Some(next_millis)
+            } else {
+                None
+            },
+        );
+
+        let scheduler_opts_json = scheduler_opts_json(&job_name, &repeat_opts)?;
+        let template_opts_json = serde_json::to_string(&template_opts)?;
+        let delayed_opts_json = serde_json::to_string(&merged_opts)?;
+
+        let mut conn = self.conn.clone();
+        let result = add_job_scheduler::add_job_scheduler(
+            &self.scripts,
+            &mut conn,
+            &self.prefix,
+            &self.name,
+            scheduler_id,
+            next_millis,
+            &scheduler_opts_json,
+            &template_data_json,
+            &template_opts_json,
+            &delayed_opts_json,
+            now_ms(),
+            None,
+        )
+        .await?;
+
+        let data: T = match template.data {
+            Some(data) => data,
+            None => serde_json::from_str("{}").map_err(|_| {
+                BullmqError::Other(
+                    "JobSchedulerTemplate.data is required for this payload type".into(),
+                )
+            })?,
+        };
+
+        let mut opts = merged_opts;
+        opts.job_id = Some(result.job_id.clone());
+        opts.delay = Some(std::time::Duration::from_millis(result.delay));
+
+        let mut job = Job::new(result.job_id, job_name, data, Some(opts));
+        job.state = if result.delay > 0 {
+            JobState::Delayed
+        } else {
+            JobState::Wait
+        };
+        job.repeat_job_key = Some(scheduler_id.to_string());
+        job.ctx = Some(self.job_context());
+        Ok(job)
+    }
+
+    /// Get a job scheduler's metadata, or `None` when it does not exist.
+    pub async fn get_job_scheduler(&self, id: &str) -> BullmqResult<Option<JobScheduler>> {
+        let mut conn = self.conn.clone();
+        let Some((map, next)) = get_job_scheduler::get_job_scheduler(
+            &self.scripts,
+            &mut conn,
+            &self.prefix,
+            &self.name,
+            id,
+        )
+        .await?
+        else {
+            return Ok(None);
+        };
+        if map.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(scheduler_from_hash(id, &map, Some(next))))
+    }
+
+    /// List job schedulers from the repeat sorted set, ordered by next
+    /// iteration timestamp (ascending). `start` and `end` are zero-based
+    /// inclusive indexes (`0, -1` returns all).
+    pub async fn get_job_schedulers(
+        &self,
+        start: i64,
+        end: i64,
+    ) -> BullmqResult<Vec<JobScheduler>> {
+        let mut conn = self.conn.clone();
+        let entries: Vec<(String, f64)> = redis::cmd("ZRANGE")
+            .arg(self.key("repeat"))
+            .arg(start)
+            .arg(end)
+            .arg("WITHSCORES")
+            .query_async(&mut conn)
+            .await?;
+
+        let mut schedulers = Vec::with_capacity(entries.len());
+        for (id, score) in entries {
+            let map: HashMap<String, String> =
+                conn.hgetall(self.key(&format!("repeat:{}", id))).await?;
+            schedulers.push(scheduler_from_hash(&id, &map, Some(score as u64)));
+        }
+        Ok(schedulers)
+    }
+
+    /// Remove a job scheduler, its metadata, and its pending iteration job.
+    ///
+    /// Returns `true` when the scheduler existed and was removed.
+    pub async fn remove_job_scheduler(&self, id: &str) -> BullmqResult<bool> {
+        let mut conn = self.conn.clone();
+        remove_job_scheduler::remove_job_scheduler(
+            &self.scripts,
+            &mut conn,
+            &self.prefix,
+            &self.name,
+            id,
+        )
+        .await
+    }
+
+    /// Manually fetch the next job from the queue, moving it to active and
+    /// acquiring a lock with the given `token` (mirrors `worker.getNextJob`
+    /// in Node BullMQ, without blocking).
+    ///
+    /// The lock is held for 30 seconds. The caller is responsible for:
+    /// - extending the lock while processing (see
+    ///   [`Queue::extend_job_locks`]), and
+    /// - finishing the job via [`Job::move_to_completed`] /
+    ///   [`Job::move_to_failed`].
+    ///
+    /// If the job is neither finished nor its lock extended, it will be
+    /// recovered by a worker's stalled-job checker after the lock expires.
+    pub async fn get_next_job(&self, token: &str) -> BullmqResult<Option<Job<T>>> {
+        let mut conn = self.conn.clone();
+        let result = move_to_active::move_to_active(
+            &self.scripts,
+            &mut conn,
+            &self.prefix,
+            &self.name,
+            token,
+            30_000,
+            now_ms(),
+            DEFAULT_MAX_EVENTS,
+            None,
+        )
+        .await?;
+
+        let Some(job_id) = result.job_id else {
+            return Ok(None);
+        };
+        let mut job = Job::from_redis_hash(&job_id, &result.job_data)?;
+        job.state = JobState::Active;
+        job.lock_token = Some(token.to_string());
+        job.ctx = Some(self.job_context());
+        Ok(Some(job))
+    }
+
+    /// Extend the locks of multiple jobs in one round trip (mirrors
+    /// `scripts.extendLocks` in Node BullMQ). `job_ids` and `tokens` are
+    /// matched by index and must have the same length.
+    ///
+    /// Returns the ids of the jobs whose lock could NOT be extended (missing
+    /// lock or token mismatch); an empty vector means all succeeded.
+    pub async fn extend_job_locks(
+        &self,
+        job_ids: &[String],
+        tokens: &[String],
+        duration: std::time::Duration,
+    ) -> BullmqResult<Vec<String>> {
+        if job_ids.len() != tokens.len() {
+            return Err(BullmqError::Other(
+                "extend_job_locks requires job_ids and tokens of the same length".into(),
+            ));
+        }
+        let mut conn = self.conn.clone();
+        extend_locks::extend_locks(
+            &self.scripts,
+            &mut conn,
+            &self.prefix,
+            &self.name,
+            job_ids,
+            tokens,
+            duration.as_millis() as u64,
+        )
+        .await
+    }
+
     /// Get the queue name.
     pub fn name(&self) -> &str {
         &self.name
@@ -937,6 +1208,67 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + 'static> Queue<T> {
     /// Build a Redis key with the queue prefix.
     pub(crate) fn key(&self, suffix: &str) -> String {
         format!("{}:{}:{}", self.prefix, self.name, suffix)
+    }
+}
+
+/// Serialize the scheduler options stored in the `repeat:<id>` hash,
+/// matching the fields Node passes to the addJobScheduler script.
+fn scheduler_opts_json(name: &str, repeat: &RepeatOptions) -> BullmqResult<String> {
+    let mut map = serde_json::Map::new();
+    map.insert("name".into(), serde_json::Value::from(name));
+    if let Some(start_date) = repeat.start_date {
+        map.insert("startDate".into(), serde_json::Value::from(start_date));
+    }
+    if let Some(end_date) = repeat.end_date {
+        map.insert("endDate".into(), serde_json::Value::from(end_date));
+    }
+    if let Some(ref tz) = repeat.tz {
+        map.insert("tz".into(), serde_json::Value::from(tz.clone()));
+    }
+    if let Some(ref pattern) = repeat.pattern {
+        map.insert("pattern".into(), serde_json::Value::from(pattern.clone()));
+    }
+    if let Some(every) = repeat.every {
+        map.insert(
+            "every".into(),
+            serde_json::Value::from(every.as_millis() as u64),
+        );
+    }
+    if let Some(limit) = repeat.limit {
+        map.insert("limit".into(), serde_json::Value::from(limit));
+    }
+    // Node only forwards an explicit offset in 'every' mode.
+    if repeat.every.is_some() {
+        if let Some(offset) = repeat.offset {
+            map.insert("offset".into(), serde_json::Value::from(offset));
+        }
+    }
+    Ok(serde_json::to_string(&serde_json::Value::Object(map))?)
+}
+
+fn hash_num(map: &HashMap<String, String>, field: &str) -> Option<u64> {
+    map.get(field)
+        .and_then(|s| s.parse::<f64>().ok())
+        .map(|f| f as u64)
+}
+
+/// Build a [`JobScheduler`] from the `repeat:<id>` hash fields, mirroring
+/// Node's `transformSchedulerData`.
+fn scheduler_from_hash(id: &str, map: &HashMap<String, String>, next: Option<u64>) -> JobScheduler {
+    JobScheduler {
+        id: id.to_string(),
+        name: map.get("name").cloned().unwrap_or_default(),
+        next,
+        iteration_count: hash_num(map, "ic"),
+        limit: hash_num(map, "limit"),
+        start_date: hash_num(map, "startDate"),
+        end_date: hash_num(map, "endDate"),
+        tz: map.get("tz").cloned(),
+        pattern: map.get("pattern").cloned(),
+        every: hash_num(map, "every"),
+        offset: hash_num(map, "offset"),
+        template_data: map.get("data").and_then(|s| serde_json::from_str(s).ok()),
+        template_opts: map.get("opts").and_then(|s| serde_json::from_str(s).ok()),
     }
 }
 

--- a/src/repeat.rs
+++ b/src/repeat.rs
@@ -1,0 +1,165 @@
+use std::time::Duration;
+
+use chrono::TimeZone;
+
+use crate::error::{BullmqError, BullmqResult};
+use crate::types::{JobOptions, RepeatOptions};
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+/// Compute the next iteration timestamp for a cron `pattern`, mirroring
+/// BullMQ Node's `defaultRepeatStrategy`: the search starts at
+/// `max(millis, startDate)`, `immediately` short-circuits to now, and a
+/// result past `endDate` yields `None`.
+pub(crate) fn next_pattern_millis(
+    millis: u64,
+    opts: &RepeatOptions,
+    pattern: &str,
+) -> BullmqResult<Option<u64>> {
+    if opts.immediately {
+        return Ok(Some(now_ms()));
+    }
+
+    let current = millis.max(opts.start_date.unwrap_or(0)) as i64;
+    let cron = croner::Cron::new(pattern)
+        .with_seconds_optional()
+        .parse()
+        .map_err(|e| BullmqError::Other(format!("Invalid cron pattern '{}': {}", pattern, e)))?;
+
+    let next = match &opts.tz {
+        Some(tz_name) => {
+            let tz: chrono_tz::Tz = tz_name
+                .parse()
+                .map_err(|_| BullmqError::Other(format!("Invalid timezone: {}", tz_name)))?;
+            let current_dt = tz
+                .timestamp_millis_opt(current)
+                .single()
+                .ok_or_else(|| BullmqError::Other("Invalid current timestamp".into()))?;
+            cron.find_next_occurrence(&current_dt, false)
+                .ok()
+                .map(|d| d.timestamp_millis() as u64)
+        }
+        None => {
+            let current_dt = chrono::Local
+                .timestamp_millis_opt(current)
+                .single()
+                .ok_or_else(|| BullmqError::Other("Invalid current timestamp".into()))?;
+            cron.find_next_occurrence(&current_dt, false)
+                .ok()
+                .map(|d| d.timestamp_millis() as u64)
+        }
+    };
+
+    match (next, opts.end_date) {
+        (Some(n), Some(end)) if n > end => Ok(None),
+        _ => Ok(next),
+    }
+}
+
+/// Build the merged options stored on a scheduler-produced job, mirroring
+/// Node's `JobScheduler.getNextJobOpts`. In 'every' mode (`pattern_next_millis`
+/// is `None`) the job id, delay, and prevMillis are computed by the Lua script
+/// and therefore left unset here.
+pub(crate) fn build_iteration_opts(
+    base_opts: &JobOptions,
+    repeat_opts: &RepeatOptions,
+    scheduler_id: &str,
+    iteration_count: u64,
+    pattern_next_millis: Option<u64>,
+) -> JobOptions {
+    let mut merged = base_opts.clone();
+
+    let mut next_repeat = repeat_opts.clone();
+    next_repeat.immediately = false;
+    next_repeat.count = Some(iteration_count);
+    if next_repeat.every.is_none() {
+        next_repeat.offset = None;
+    }
+    merged.repeat = Some(next_repeat);
+    merged.repeat_job_key = Some(scheduler_id.to_string());
+
+    let now = now_ms();
+    merged.timestamp = Some(now);
+
+    match pattern_next_millis {
+        Some(next) => {
+            merged.job_id = Some(format!("repeat:{}:{}", scheduler_id, next));
+            merged.prev_millis = Some(next);
+            merged.delay = Some(Duration::from_millis(next.saturating_sub(now)));
+        }
+        None => {
+            merged.job_id = None;
+            merged.prev_millis = None;
+            merged.delay = None;
+        }
+    }
+
+    merged
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_next_pattern_millis_every_minute() {
+        let now = 1_700_000_000_000u64;
+        let opts = RepeatOptions::default();
+        let next = next_pattern_millis(now, &opts, "* * * * *")
+            .unwrap()
+            .unwrap();
+        assert!(next > now);
+        assert_eq!(next % 60_000, 0);
+        assert!(next - now <= 60_000);
+    }
+
+    #[test]
+    fn test_next_pattern_millis_respects_start_date() {
+        let now = 1_700_000_000_000u64;
+        let start = now + 3_600_000;
+        let opts = RepeatOptions {
+            start_date: Some(start),
+            ..Default::default()
+        };
+        let next = next_pattern_millis(now, &opts, "* * * * *")
+            .unwrap()
+            .unwrap();
+        assert!(next >= start);
+    }
+
+    #[test]
+    fn test_next_pattern_millis_respects_end_date() {
+        let now = 1_700_000_000_000u64;
+        let opts = RepeatOptions {
+            end_date: Some(now + 1),
+            ..Default::default()
+        };
+        assert!(next_pattern_millis(now, &opts, "* * * * *")
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn test_next_pattern_millis_with_tz() {
+        let now = 1_700_000_000_000u64;
+        let opts = RepeatOptions {
+            tz: Some("Europe/Paris".into()),
+            ..Default::default()
+        };
+        let next = next_pattern_millis(now, &opts, "0 12 * * *")
+            .unwrap()
+            .unwrap();
+        assert!(next > now);
+    }
+
+    #[test]
+    fn test_next_pattern_millis_invalid_pattern() {
+        let opts = RepeatOptions::default();
+        assert!(next_pattern_millis(0, &opts, "not a cron").is_err());
+    }
+}

--- a/src/scripts/commands/add_job_scheduler.rs
+++ b/src/scripts/commands/add_job_scheduler.rs
@@ -1,0 +1,99 @@
+use redis::aio::ConnectionManager;
+
+use crate::error::{BullmqError, BullmqResult};
+use crate::scripts::ScriptLoader;
+
+use super::key;
+
+/// Result of an addJobScheduler call: the id and delay of the next iteration job.
+#[derive(Debug)]
+pub(crate) struct AddJobSchedulerResult {
+    pub job_id: String,
+    pub delay: u64,
+}
+
+/// Upsert a job scheduler and create its next iteration job.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn add_job_scheduler(
+    loader: &ScriptLoader,
+    conn: &mut ConnectionManager,
+    prefix: &str,
+    queue_name: &str,
+    scheduler_id: &str,
+    next_millis: u64,
+    scheduler_opts_json: &str,
+    template_data_json: &str,
+    template_opts_json: &str,
+    delayed_opts_json: &str,
+    timestamp: u64,
+    producer_id: Option<&str>,
+) -> BullmqResult<AddJobSchedulerResult> {
+    let keys = vec![
+        key(prefix, queue_name, "repeat"),
+        key(prefix, queue_name, "delayed"),
+        key(prefix, queue_name, "wait"),
+        key(prefix, queue_name, "paused"),
+        key(prefix, queue_name, "meta"),
+        key(prefix, queue_name, "prioritized"),
+        key(prefix, queue_name, "marker"),
+        key(prefix, queue_name, "id"),
+        key(prefix, queue_name, "events"),
+        key(prefix, queue_name, "pc"),
+        key(prefix, queue_name, "active"),
+    ];
+    let producer_key = producer_id
+        .map(|p| key(prefix, queue_name, p))
+        .unwrap_or_default();
+    let args: Vec<Vec<u8>> = vec![
+        next_millis.to_string().into_bytes(),
+        scheduler_opts_json.as_bytes().to_vec(),
+        scheduler_id.as_bytes().to_vec(),
+        template_data_json.as_bytes().to_vec(),
+        template_opts_json.as_bytes().to_vec(),
+        delayed_opts_json.as_bytes().to_vec(),
+        timestamp.to_string().into_bytes(),
+        format!("{}:{}:", prefix, queue_name).into_bytes(),
+        producer_key.into_bytes(),
+    ];
+
+    let result = loader.invoke("addJobScheduler", conn, &keys, &args).await?;
+
+    match result {
+        redis::Value::Int(code) if code < 0 => Err(BullmqError::ScriptError(match code {
+            -10 => format!(
+                "addJobScheduler: job id collision for scheduler {}",
+                scheduler_id
+            ),
+            -11 => format!(
+                "addJobScheduler: job slots busy for scheduler {}",
+                scheduler_id
+            ),
+            _ => format!("addJobScheduler returned unexpected code: {}", code),
+        })),
+        redis::Value::Array(items) if items.len() >= 2 => {
+            let job_id = match &items[0] {
+                redis::Value::BulkString(b) => String::from_utf8_lossy(b).to_string(),
+                redis::Value::SimpleString(s) => s.clone(),
+                other => {
+                    return Err(BullmqError::ScriptError(format!(
+                        "addJobScheduler returned unexpected job id: {:?}",
+                        other
+                    )))
+                }
+            };
+            let delay = match &items[1] {
+                redis::Value::Int(d) => (*d).max(0) as u64,
+                redis::Value::BulkString(b) => String::from_utf8_lossy(b)
+                    .parse::<f64>()
+                    .unwrap_or(0.0)
+                    .max(0.0) as u64,
+                _ => 0,
+            };
+            Ok(AddJobSchedulerResult { job_id, delay })
+        }
+        other => Err(BullmqError::ScriptError(format!(
+            "addJobScheduler returned unexpected value: {:?}",
+            other
+        ))),
+    }
+}

--- a/src/scripts/commands/extend_locks.rs
+++ b/src/scripts/commands/extend_locks.rs
@@ -1,0 +1,42 @@
+use redis::aio::ConnectionManager;
+
+use crate::error::BullmqResult;
+use crate::scripts::ScriptLoader;
+
+use super::key;
+
+/// Extend the locks of multiple jobs in one round trip.
+///
+/// Returns the ids of the jobs whose lock could NOT be extended (missing lock
+/// or token mismatch).
+pub(crate) async fn extend_locks(
+    loader: &ScriptLoader,
+    conn: &mut ConnectionManager,
+    prefix: &str,
+    queue_name: &str,
+    job_ids: &[String],
+    tokens: &[String],
+    duration_ms: u64,
+) -> BullmqResult<Vec<String>> {
+    let keys = vec![key(prefix, queue_name, "stalled")];
+    let args: Vec<Vec<u8>> = vec![
+        format!("{}:{}:", prefix, queue_name).into_bytes(),
+        serde_json::to_vec(tokens)?,
+        serde_json::to_vec(job_ids)?,
+        duration_ms.to_string().into_bytes(),
+    ];
+
+    let result = loader.invoke("extendLocks", conn, &keys, &args).await?;
+
+    let mut failed = Vec::new();
+    if let redis::Value::Array(items) = result {
+        for item in items {
+            match item {
+                redis::Value::BulkString(b) => failed.push(String::from_utf8_lossy(&b).to_string()),
+                redis::Value::SimpleString(s) => failed.push(s),
+                _ => {}
+            }
+        }
+    }
+    Ok(failed)
+}

--- a/src/scripts/commands/get_job_scheduler.rs
+++ b/src/scripts/commands/get_job_scheduler.rs
@@ -1,0 +1,57 @@
+use std::collections::HashMap;
+
+use redis::aio::ConnectionManager;
+
+use crate::error::BullmqResult;
+use crate::scripts::ScriptLoader;
+
+use super::key;
+
+fn value_to_string(value: &redis::Value) -> Option<String> {
+    match value {
+        redis::Value::BulkString(b) => Some(String::from_utf8_lossy(b).to_string()),
+        redis::Value::SimpleString(s) => Some(s.clone()),
+        _ => None,
+    }
+}
+
+/// Get a job scheduler's metadata hash and next iteration timestamp (the
+/// repeat zset score). Returns `None` when the scheduler does not exist.
+pub(crate) async fn get_job_scheduler(
+    loader: &ScriptLoader,
+    conn: &mut ConnectionManager,
+    prefix: &str,
+    queue_name: &str,
+    scheduler_id: &str,
+) -> BullmqResult<Option<(HashMap<String, String>, u64)>> {
+    let keys = vec![key(prefix, queue_name, "repeat")];
+    let args: Vec<Vec<u8>> = vec![scheduler_id.as_bytes().to_vec()];
+
+    let result = loader.invoke("getJobScheduler", conn, &keys, &args).await?;
+
+    let redis::Value::Array(items) = result else {
+        return Ok(None);
+    };
+    if items.len() < 2 {
+        return Ok(None);
+    }
+
+    let mut map = HashMap::new();
+    if let redis::Value::Array(pairs) = &items[0] {
+        let mut i = 0;
+        while i + 1 < pairs.len() {
+            if let (Some(k), Some(v)) = (value_to_string(&pairs[i]), value_to_string(&pairs[i + 1]))
+            {
+                map.insert(k, v);
+            }
+            i += 2;
+        }
+    }
+
+    let score = value_to_string(&items[1])
+        .and_then(|s| s.parse::<f64>().ok())
+        .map(|f| f as u64)
+        .unwrap_or(0);
+
+    Ok(Some((map, score)))
+}

--- a/src/scripts/commands/mod.rs
+++ b/src/scripts/commands/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod add_delayed_job;
+pub(crate) mod add_job_scheduler;
 pub(crate) mod add_log;
 pub(crate) mod add_parent_job;
 pub(crate) mod add_prioritized_job;
@@ -6,6 +7,8 @@ pub(crate) mod add_standard_job;
 pub(crate) mod change_priority;
 pub(crate) mod clean_jobs_in_set;
 pub(crate) mod extend_lock;
+pub(crate) mod extend_locks;
+pub(crate) mod get_job_scheduler;
 pub(crate) mod get_metrics;
 pub(crate) mod move_jobs_to_wait;
 pub(crate) mod move_stalled_jobs_to_wait;
@@ -15,7 +18,9 @@ pub(crate) mod move_to_finished;
 pub(crate) mod obliterate;
 pub(crate) mod pause;
 pub(crate) mod promote;
+pub(crate) mod remove_job_scheduler;
 pub(crate) mod retry_job;
+pub(crate) mod update_job_scheduler;
 
 /// Build a Redis key: `{prefix}:{queue_name}:{suffix}`.
 pub(crate) fn key(prefix: &str, queue_name: &str, suffix: &str) -> String {

--- a/src/scripts/commands/remove_job_scheduler.rs
+++ b/src/scripts/commands/remove_job_scheduler.rs
@@ -1,0 +1,33 @@
+use redis::aio::ConnectionManager;
+
+use crate::error::BullmqResult;
+use crate::scripts::ScriptLoader;
+
+use super::key;
+
+/// Remove a job scheduler, its metadata hash, and its pending iteration job.
+///
+/// Returns `true` when the scheduler existed and was removed.
+pub(crate) async fn remove_job_scheduler(
+    loader: &ScriptLoader,
+    conn: &mut ConnectionManager,
+    prefix: &str,
+    queue_name: &str,
+    scheduler_id: &str,
+) -> BullmqResult<bool> {
+    let keys = vec![
+        key(prefix, queue_name, "repeat"),
+        key(prefix, queue_name, "delayed"),
+        key(prefix, queue_name, "events"),
+    ];
+    let args: Vec<Vec<u8>> = vec![
+        scheduler_id.as_bytes().to_vec(),
+        format!("{}:{}:", prefix, queue_name).into_bytes(),
+    ];
+
+    let result = loader
+        .invoke("removeJobScheduler", conn, &keys, &args)
+        .await?;
+
+    Ok(matches!(result, redis::Value::Int(0)))
+}

--- a/src/scripts/commands/update_job_scheduler.rs
+++ b/src/scripts/commands/update_job_scheduler.rs
@@ -1,0 +1,58 @@
+use redis::aio::ConnectionManager;
+
+use crate::error::BullmqResult;
+use crate::scripts::ScriptLoader;
+
+use super::key;
+
+/// Schedule the next iteration of a job scheduler after the current iteration
+/// finished. Returns the id of the created delayed job, or `None` when the
+/// scheduler no longer exists, the producer is stale, or the next iteration
+/// already exists.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn update_job_scheduler(
+    loader: &ScriptLoader,
+    conn: &mut ConnectionManager,
+    prefix: &str,
+    queue_name: &str,
+    scheduler_id: &str,
+    next_millis: u64,
+    template_data_json: &str,
+    delayed_opts_json: &str,
+    timestamp: u64,
+    producer_id: &str,
+) -> BullmqResult<Option<String>> {
+    let keys = vec![
+        key(prefix, queue_name, "repeat"),
+        key(prefix, queue_name, "delayed"),
+        key(prefix, queue_name, "wait"),
+        key(prefix, queue_name, "paused"),
+        key(prefix, queue_name, "meta"),
+        key(prefix, queue_name, "prioritized"),
+        key(prefix, queue_name, "marker"),
+        key(prefix, queue_name, "id"),
+        key(prefix, queue_name, "events"),
+        key(prefix, queue_name, "pc"),
+        key(prefix, queue_name, producer_id),
+        key(prefix, queue_name, "active"),
+    ];
+    let args: Vec<Vec<u8>> = vec![
+        next_millis.to_string().into_bytes(),
+        scheduler_id.as_bytes().to_vec(),
+        template_data_json.as_bytes().to_vec(),
+        delayed_opts_json.as_bytes().to_vec(),
+        timestamp.to_string().into_bytes(),
+        format!("{}:{}:", prefix, queue_name).into_bytes(),
+        producer_id.as_bytes().to_vec(),
+    ];
+
+    let result = loader
+        .invoke("updateJobScheduler", conn, &keys, &args)
+        .await?;
+
+    match result {
+        redis::Value::BulkString(b) => Ok(Some(String::from_utf8_lossy(&b).to_string())),
+        redis::Value::SimpleString(s) => Ok(Some(s)),
+        _ => Ok(None),
+    }
+}

--- a/src/scripts/mod.rs
+++ b/src/scripts/mod.rs
@@ -66,6 +66,11 @@ impl ScriptLoader {
         register!("cleanJobsInSet", "cleanJobsInSet-3.lua");
         register!("obliterate", "obliterate-2.lua");
         register!("getMetrics", "getMetrics-2.lua");
+        register!("addJobScheduler", "addJobScheduler-11.lua");
+        register!("updateJobScheduler", "updateJobScheduler-12.lua");
+        register!("getJobScheduler", "getJobScheduler-1.lua");
+        register!("removeJobScheduler", "removeJobScheduler-3.lua");
+        register!("extendLocks", "extendLocks-1.lua");
 
         Self { scripts }
     }
@@ -127,6 +132,15 @@ impl ScriptLoader {
         inc!("removeZSetJobs", "removeZSetJobs.lua");
         inc!("cleanList", "cleanList.lua");
         inc!("cleanSet", "cleanSet.lua");
+        inc!("isQueuePaused", "isQueuePaused.lua");
+        inc!("addDelayedJob", "addDelayedJob.lua");
+        inc!("storeAndEnqueueJob", "storeAndEnqueueJob.lua");
+        inc!("addJobFromScheduler", "addJobFromScheduler.lua");
+        inc!("storeJobScheduler", "storeJobScheduler.lua");
+        inc!(
+            "getJobSchedulerEveryNextMillis",
+            "getJobSchedulerEveryNextMillis.lua"
+        );
         m
     }
 
@@ -219,6 +233,11 @@ mod tests {
         assert!(loader.scripts.contains_key("cleanJobsInSet"));
         assert!(loader.scripts.contains_key("obliterate"));
         assert!(loader.scripts.contains_key("getMetrics"));
-        assert_eq!(loader.scripts.len(), 18);
+        assert!(loader.scripts.contains_key("addJobScheduler"));
+        assert!(loader.scripts.contains_key("updateJobScheduler"));
+        assert!(loader.scripts.contains_key("getJobScheduler"));
+        assert!(loader.scripts.contains_key("removeJobScheduler"));
+        assert!(loader.scripts.contains_key("extendLocks"));
+        assert_eq!(loader.scripts.len(), 23);
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -90,6 +90,127 @@ pub struct JobOptions {
     /// Deduplication options. Serialized as `de` to match the BullMQ wire format.
     #[serde(rename = "de", skip_serializing_if = "Option::is_none", default)]
     pub deduplication: Option<DeduplicationOptions>,
+    /// Repeat options carried by every job produced by a job scheduler.
+    /// Managed by [`crate::Queue::upsert_job_scheduler`]; not meant to be set
+    /// directly on regular jobs.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub repeat: Option<RepeatOptions>,
+    /// Iteration timestamp (ms) this scheduler-produced job was created for.
+    /// Managed by the job scheduler.
+    #[serde(
+        rename = "prevMillis",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
+    pub prev_millis: Option<u64>,
+    /// Id of the job scheduler that produced this job. Managed by the job
+    /// scheduler (also stored as the `rjk` hash field).
+    #[serde(
+        rename = "repeatJobKey",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
+    pub repeat_job_key: Option<String>,
+    /// Creation timestamp (ms) recorded in the serialized options by the job
+    /// scheduler, mirroring BullMQ Node's merged options.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub timestamp: Option<u64>,
+}
+
+/// Repeat options for a job scheduler (repeatable job).
+///
+/// Exactly one of [`pattern`](Self::pattern) (cron) or [`every`](Self::every)
+/// must be set. Serializes to JSON matching the BullMQ Node.js `repeat`
+/// options format.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RepeatOptions {
+    /// Cron pattern (cron-parser syntax: 5 fields, or 6 fields with leading
+    /// seconds), e.g. `"* * * * *"` for every minute.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub pattern: Option<String>,
+    /// Fixed interval between iterations.
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        with = "option_duration_millis",
+        default
+    )]
+    pub every: Option<Duration>,
+    /// Maximum total number of iterations.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub limit: Option<u64>,
+    /// Earliest time (ms since Unix epoch) for the first iteration.
+    #[serde(rename = "startDate", skip_serializing_if = "Option::is_none", default)]
+    pub start_date: Option<u64>,
+    /// Time (ms since Unix epoch) after which no more iterations are produced.
+    #[serde(rename = "endDate", skip_serializing_if = "Option::is_none", default)]
+    pub end_date: Option<u64>,
+    /// IANA timezone used to evaluate the cron `pattern` (e.g. "Europe/Paris").
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub tz: Option<String>,
+    /// Produce the first iteration immediately instead of waiting for the next
+    /// cron match. Only valid with `pattern`, and incompatible with
+    /// `start_date`. Never serialized, mirroring BullMQ Node.
+    #[serde(skip, default)]
+    pub immediately: bool,
+    /// Offset in milliseconds within `every` slots. Managed by the scheduler.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub offset: Option<u64>,
+    /// Iteration counter. Managed by the scheduler.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub count: Option<u64>,
+}
+
+/// Job template applied to every job produced by a job scheduler.
+#[derive(Debug, Clone)]
+pub struct JobSchedulerTemplate<T> {
+    /// Name of the produced jobs. Defaults to the scheduler id.
+    pub name: Option<String>,
+    /// Data payload of the produced jobs.
+    pub data: Option<T>,
+    /// Options applied to the produced jobs.
+    pub opts: Option<JobOptions>,
+}
+
+impl<T> Default for JobSchedulerTemplate<T> {
+    fn default() -> Self {
+        Self {
+            name: None,
+            data: None,
+            opts: None,
+        }
+    }
+}
+
+/// Metadata of a job scheduler as returned by
+/// [`crate::Queue::get_job_scheduler`].
+#[derive(Debug, Clone, Default)]
+pub struct JobScheduler {
+    /// Scheduler id (the `key` in BullMQ Node).
+    pub id: String,
+    /// Name of the produced jobs.
+    pub name: String,
+    /// Timestamp (ms) of the next scheduled iteration.
+    pub next: Option<u64>,
+    /// Number of iterations produced so far.
+    pub iteration_count: Option<u64>,
+    /// Maximum total number of iterations.
+    pub limit: Option<u64>,
+    /// Earliest time (ms since Unix epoch) for the first iteration.
+    pub start_date: Option<u64>,
+    /// Time (ms since Unix epoch) after which no more iterations are produced.
+    pub end_date: Option<u64>,
+    /// IANA timezone used to evaluate the cron pattern.
+    pub tz: Option<String>,
+    /// Cron pattern.
+    pub pattern: Option<String>,
+    /// Fixed interval between iterations (ms).
+    pub every: Option<u64>,
+    /// Offset in milliseconds within `every` slots.
+    pub offset: Option<u64>,
+    /// Template data payload of the produced jobs.
+    pub template_data: Option<serde_json::Value>,
+    /// Template options of the produced jobs.
+    pub template_opts: Option<JobOptions>,
 }
 
 /// Job deduplication options.

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::marker::PhantomData;
 use std::sync::Arc;
@@ -22,12 +22,16 @@ type ActiveCallback = Arc<dyn Fn(&Job<serde_json::Value>) + Send + Sync>;
 type ErrorCallback = Arc<dyn Fn(&BullmqError) + Send + Sync>;
 use crate::scripts::commands::{
     extend_lock, move_stalled_jobs_to_wait, move_to_active, move_to_delayed, move_to_finished,
+    update_job_scheduler,
 };
 use crate::scripts::ScriptLoader;
 use crate::types::{MetricsOptions, RateLimiterOptions, WorkerOptions, DEFAULT_MAX_EVENTS};
 
 const MARKER_BLOCK_TIMEOUT: Duration = Duration::from_secs(5);
 const BLOCKING_CONN_RESPONSE_TIMEOUT: Duration = Duration::from_secs(6);
+
+/// Registry of cancellation signals for in-flight jobs, keyed by job id.
+type Cancellations = Arc<std::sync::Mutex<HashMap<String, tokio::sync::oneshot::Sender<()>>>>;
 
 /// A worker that processes jobs from a queue.
 ///
@@ -79,6 +83,7 @@ pub struct WorkerHandle {
     semaphore: Arc<Semaphore>,
     concurrency: usize,
     prefetched: Arc<std::sync::atomic::AtomicUsize>,
+    cancellations: Cancellations,
     join_handle: tokio::task::JoinHandle<()>,
 }
 
@@ -124,6 +129,31 @@ impl WorkerHandle {
     /// A paused worker is still considered running.
     pub fn is_running(&self) -> bool {
         !*self.shutdown_tx.borrow() && !self.join_handle.is_finished()
+    }
+
+    /// Cancel an in-flight job by aborting its processing future.
+    ///
+    /// Returns `true` when the job was being processed by this worker and the
+    /// cancellation signal was delivered, `false` otherwise (unknown job id or
+    /// already finished).
+    ///
+    /// Unlike Node BullMQ — where cancellation is cooperative via an
+    /// `AbortSignal` passed to the processor — the handler future is dropped
+    /// at its next await point and gets no chance to clean up. The job is NOT
+    /// moved to a finished state: it stays in the active list with its lock,
+    /// the lock then expires (this worker stops extending it), and the
+    /// stalled-job checker eventually requeues or fails it according to
+    /// `max_stalled_count`.
+    pub fn cancel_job(&self, job_id: &str) -> bool {
+        let sender = self
+            .cancellations
+            .lock()
+            .expect("cancellations mutex poisoned")
+            .remove(job_id);
+        match sender {
+            Some(tx) => tx.send(()).is_ok(),
+            None => false,
+        }
     }
 
     /// Signal the worker to stop after finishing current jobs.
@@ -174,6 +204,9 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
         // Shared state for active job tracking (used by lock extender).
         let active_jobs: Arc<Mutex<HashSet<String>>> = Arc::new(Mutex::new(HashSet::new()));
 
+        // Cancellation signals for in-flight jobs (used by cancel_job).
+        let cancellations: Cancellations = Arc::new(std::sync::Mutex::new(HashMap::new()));
+
         // Shutdown channel.
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
@@ -207,6 +240,7 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
 
         let semaphore_handle = semaphore.clone();
         let prefetched_handle = prefetched.clone();
+        let cancellations_handle = cancellations.clone();
 
         let join_handle = tokio::spawn({
             let scripts = scripts.clone();
@@ -214,6 +248,7 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
             let prefix = prefix.clone();
             let token = token.clone();
             let active_jobs = active_jobs.clone();
+            let cancellations = cancellations.clone();
             let shutdown_rx_main = shutdown_rx.clone();
             let paused_rx_main = paused_rx.clone();
             let prefetched = prefetched.clone();
@@ -637,6 +672,7 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                             let task_lock_duration = lock_duration_ms;
                             let task_paused_rx = paused_rx.clone();
                             let task_prefetched = prefetched.clone();
+                            let task_cancellations = cancellations.clone();
 
                             tokio::spawn(async move {
                                 let _permit = permit;
@@ -655,9 +691,35 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                                     }
                                 }
 
-                                // Run the user handler.
-                                match handler(job.clone()).await {
-                                    Ok(()) => {
+                                // Run the user handler, racing it against a
+                                // cancellation signal (see WorkerHandle::cancel_job).
+                                let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel::<()>();
+                                task_cancellations
+                                    .lock()
+                                    .expect("cancellations mutex poisoned")
+                                    .insert(job_id.clone(), cancel_tx);
+
+                                let handler_outcome = tokio::select! {
+                                    res = handler(job.clone()) => Some(res),
+                                    _ = cancel_rx => None,
+                                };
+
+                                task_cancellations
+                                    .lock()
+                                    .expect("cancellations mutex poisoned")
+                                    .remove(&job_id);
+
+                                match handler_outcome {
+                                    None => {
+                                        // Cancelled: drop the job without finishing it.
+                                        // Its lock expires once removed from active_jobs
+                                        // below, and the stalled checker requeues it.
+                                        tracing::warn!(
+                                            "Job {} cancelled, it will be recovered by the stalled checker",
+                                            job_id
+                                        );
+                                    }
+                                    Some(Ok(())) => {
                                         // Success: call moveToFinished(completed).
                                         // Skip fetchNext while paused so the pause settles
                                         // instead of prefetching more work.
@@ -723,6 +785,24 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                                             }
                                         }
 
+                                        if job.repeat_job_key.is_some() {
+                                            if let Err(e) = schedule_next_repeatable_job(
+                                                &scripts,
+                                                &mut task_conn,
+                                                &task_prefix,
+                                                &task_name,
+                                                &job,
+                                            )
+                                            .await
+                                            {
+                                                tracing::warn!(
+                                                    "Failed to schedule next repeatable iteration for job {}: {}",
+                                                    job_id,
+                                                    e
+                                                );
+                                            }
+                                        }
+
                                         // Invoke on_completed callback.
                                         if let Some(ref cb) = on_completed {
                                             if let Ok(val_job) = convert_job_to_value(&job) {
@@ -732,7 +812,7 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
 
                                         tracing::debug!("Job {} completed", job_id);
                                     }
-                                    Err(err) => {
+                                    Some(Err(err)) => {
                                         let new_attempts = job.attempts_made + 1;
                                         let max_attempts = job.opts.attempts.unwrap_or(1);
 
@@ -836,6 +916,24 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                                                 }
                                             }
 
+                                            if job.repeat_job_key.is_some() {
+                                                if let Err(e) = schedule_next_repeatable_job(
+                                                    &scripts,
+                                                    &mut task_conn,
+                                                    &task_prefix,
+                                                    &task_name,
+                                                    &job,
+                                                )
+                                                .await
+                                                {
+                                                    tracing::warn!(
+                                                        "Failed to schedule next repeatable iteration for job {}: {}",
+                                                        job_id,
+                                                        e
+                                                    );
+                                                }
+                                            }
+
                                             // Invoke on_failed callback.
                                             if let Some(ref cb) = on_failed {
                                                 if let Ok(val_job) = convert_job_to_value(&job) {
@@ -887,9 +985,97 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
             semaphore: semaphore_handle,
             concurrency,
             prefetched: prefetched_handle,
+            cancellations: cancellations_handle,
             join_handle,
         })
     }
+}
+
+/// Schedule the next iteration of a job scheduler after one of its jobs
+/// finished, mirroring Node BullMQ's `JobScheduler.upsertJobScheduler` with
+/// `override: false` and `producerId` set to the finished job's id (the Lua
+/// script is a no-op when the scheduler was removed, the producer is stale,
+/// or the next iteration already exists).
+async fn schedule_next_repeatable_job<T: Serialize>(
+    scripts: &ScriptLoader,
+    conn: &mut redis::aio::ConnectionManager,
+    prefix: &str,
+    queue_name: &str,
+    job: &Job<T>,
+) -> BullmqResult<()> {
+    let Some(scheduler_id) = job.repeat_job_key.as_deref() else {
+        return Ok(());
+    };
+
+    // Only v5 job schedulers (storeJobScheduler) write the 'ic' field; this
+    // filters out legacy repeatable keys, which are not supported here.
+    let scheduler_key = format!("{}:{}:repeat:{}", prefix, queue_name, scheduler_id);
+    let is_scheduler: bool = redis::cmd("HEXISTS")
+        .arg(&scheduler_key)
+        .arg("ic")
+        .query_async(conn)
+        .await?;
+    if !is_scheduler {
+        return Ok(());
+    }
+
+    let Some(repeat) = job.opts.repeat.clone() else {
+        return Ok(());
+    };
+
+    let iteration_count = repeat.count.map(|c| c + 1).unwrap_or(1);
+    if let Some(limit) = repeat.limit {
+        if iteration_count > limit {
+            return Ok(());
+        }
+    }
+
+    let mut now = now_ms();
+    if let Some(end_date) = repeat.end_date {
+        if now > end_date {
+            return Ok(());
+        }
+    }
+    let prev_millis = job.opts.prev_millis.unwrap_or(0);
+    if prev_millis > now {
+        now = prev_millis;
+    }
+
+    let next_millis = match &repeat.pattern {
+        Some(pattern) => match crate::repeat::next_pattern_millis(now, &repeat, pattern)? {
+            Some(next) => next.max(now),
+            None => return Ok(()),
+        },
+        // The Lua script computes nextMillis itself in 'every' mode.
+        None if repeat.every.is_some() => 0,
+        None => return Ok(()),
+    };
+
+    let merged_opts = crate::repeat::build_iteration_opts(
+        &job.opts,
+        &repeat,
+        scheduler_id,
+        iteration_count,
+        repeat.pattern.as_ref().map(|_| next_millis),
+    );
+
+    let template_data = serde_json::to_string(&job.data)?;
+    let delayed_opts = serde_json::to_string(&merged_opts)?;
+
+    update_job_scheduler::update_job_scheduler(
+        scripts,
+        conn,
+        prefix,
+        queue_name,
+        scheduler_id,
+        next_millis,
+        &template_data,
+        &delayed_opts,
+        now_ms(),
+        &job.id,
+    )
+    .await?;
+    Ok(())
 }
 
 fn is_bzpopmin_timeout(error: &redis::RedisError) -> bool {
@@ -918,6 +1104,7 @@ fn convert_job_to_value<T: Serialize>(job: &Job<T>) -> BullmqResult<Job<serde_js
         stacktrace: job.stacktrace.clone(),
         return_value: job.return_value.clone(),
         processed_by: job.processed_by.clone(),
+        repeat_job_key: job.repeat_job_key.clone(),
         ctx: None,
         lock_token: None,
     })

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -4465,3 +4465,703 @@ async fn test_worker_on_active_callback() {
 
     queue.drain().await.unwrap();
 }
+
+// ---------------------------------------------------------------------------
+// Job scheduler (repeatable jobs)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_job_scheduler_every_iterations() {
+    let conn = redis_conn();
+    let qname = unique_queue_name();
+
+    let queue = QueueBuilder::new(&qname)
+        .connection(conn.clone())
+        .build::<TestJob>()
+        .await
+        .unwrap();
+
+    let job = queue
+        .upsert_job_scheduler(
+            "every-sched",
+            RepeatOptions {
+                every: Some(Duration::from_millis(1000)),
+                ..Default::default()
+            },
+            JobSchedulerTemplate {
+                name: Some("tick".into()),
+                data: Some(TestJob {
+                    value: "tick-data".into(),
+                }),
+                opts: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        job.id.starts_with("repeat:every-sched:"),
+        "iteration job id should have the repeat:<id>:<millis> shape, got {}",
+        job.id
+    );
+    assert_eq!(job.name, "tick");
+
+    // The first iteration job must exist with the scheduler id in 'rjk'.
+    let mut raw = raw_redis_conn().await;
+    let rjk: String = redis::cmd("HGET")
+        .arg(format!("bull:{}:{}", qname, job.id))
+        .arg("rjk")
+        .query_async(&mut raw)
+        .await
+        .unwrap();
+    assert_eq!(rjk, "every-sched");
+
+    let processed = Arc::new(AtomicU64::new(0));
+    let processed_cb = processed.clone();
+    let worker = WorkerBuilder::new(&qname)
+        .connection(conn)
+        .skip_stalled_check(true)
+        .build::<TestJob>();
+    let handle = worker
+        .start(move |job| {
+            let processed = processed_cb.clone();
+            async move {
+                assert_eq!(job.data.value, "tick-data");
+                processed.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+    // Wait for at least 2 iterations to complete (auto-rescheduled).
+    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    while processed.load(Ordering::SeqCst) < 2 && std::time::Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(
+        processed.load(Ordering::SeqCst) >= 2,
+        "at least 2 iterations should have been processed, got {}",
+        processed.load(Ordering::SeqCst)
+    );
+
+    // The next iteration must be pending in the delayed set.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let mut next_pending = false;
+    while std::time::Instant::now() < deadline {
+        let delayed: Vec<String> = redis::cmd("ZRANGE")
+            .arg(format!("bull:{}:delayed", qname))
+            .arg(0)
+            .arg(-1)
+            .query_async(&mut raw)
+            .await
+            .unwrap();
+        if delayed
+            .iter()
+            .any(|id| id.starts_with("repeat:every-sched:"))
+        {
+            next_pending = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(next_pending, "next iteration should be auto-scheduled");
+
+    handle.shutdown();
+    handle.wait().await.unwrap();
+
+    queue.remove_job_scheduler("every-sched").await.unwrap();
+    queue.drain().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_job_scheduler_cron_pattern() {
+    let conn = redis_conn();
+    let qname = unique_queue_name();
+
+    let queue = QueueBuilder::new(&qname)
+        .connection(conn)
+        .build::<TestJob>()
+        .await
+        .unwrap();
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64;
+
+    let job = queue
+        .upsert_job_scheduler(
+            "cron-sched",
+            RepeatOptions {
+                pattern: Some("* * * * *".into()),
+                ..Default::default()
+            },
+            JobSchedulerTemplate {
+                name: Some("cron-tick".into()),
+                data: Some(TestJob {
+                    value: "cron".into(),
+                }),
+                opts: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let mut raw = raw_redis_conn().await;
+
+    // Scheduler hash stores the pattern.
+    let pattern: String = redis::cmd("HGET")
+        .arg(format!("bull:{}:repeat:cron-sched", qname))
+        .arg("pattern")
+        .query_async(&mut raw)
+        .await
+        .unwrap();
+    assert_eq!(pattern, "* * * * *");
+
+    // The next job is delayed to the next minute boundary.
+    let next_millis: u64 = job.id.rsplit(':').next().unwrap().parse().unwrap();
+    assert_eq!(
+        next_millis % 60_000,
+        0,
+        "next millis should be on a minute boundary"
+    );
+    assert!(next_millis > now && next_millis <= now + 60_000);
+
+    let delayed: Vec<String> = redis::cmd("ZRANGE")
+        .arg(format!("bull:{}:delayed", qname))
+        .arg(0)
+        .arg(-1)
+        .query_async(&mut raw)
+        .await
+        .unwrap();
+    assert!(delayed.contains(&job.id), "iteration job should be delayed");
+
+    queue.remove_job_scheduler("cron-sched").await.unwrap();
+    queue.drain().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_get_job_scheduler_metadata() {
+    let conn = redis_conn();
+    let qname = unique_queue_name();
+
+    let queue = QueueBuilder::new(&qname)
+        .connection(conn)
+        .build::<TestJob>()
+        .await
+        .unwrap();
+
+    queue
+        .upsert_job_scheduler(
+            "meta-sched",
+            RepeatOptions {
+                every: Some(Duration::from_secs(5)),
+                limit: Some(10),
+                ..Default::default()
+            },
+            JobSchedulerTemplate {
+                name: Some("meta-tick".into()),
+                data: Some(TestJob {
+                    value: "meta".into(),
+                }),
+                opts: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let scheduler = queue
+        .get_job_scheduler("meta-sched")
+        .await
+        .unwrap()
+        .expect("scheduler should exist");
+    assert_eq!(scheduler.id, "meta-sched");
+    assert_eq!(scheduler.name, "meta-tick");
+    assert_eq!(scheduler.every, Some(5000));
+    assert_eq!(scheduler.limit, Some(10));
+    assert_eq!(scheduler.iteration_count, Some(1));
+    assert!(scheduler.next.is_some());
+    assert!(scheduler.pattern.is_none());
+    let template_data = scheduler.template_data.expect("template data stored");
+    assert_eq!(template_data["value"], "meta");
+
+    let schedulers = queue.get_job_schedulers(0, -1).await.unwrap();
+    assert_eq!(schedulers.len(), 1);
+    assert_eq!(schedulers[0].id, "meta-sched");
+    assert_eq!(schedulers[0].every, Some(5000));
+
+    assert!(queue.get_job_scheduler("missing").await.unwrap().is_none());
+
+    queue.remove_job_scheduler("meta-sched").await.unwrap();
+    queue.drain().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_remove_job_scheduler() {
+    let conn = redis_conn();
+    let qname = unique_queue_name();
+
+    let queue = QueueBuilder::new(&qname)
+        .connection(conn)
+        .build::<TestJob>()
+        .await
+        .unwrap();
+
+    let job = queue
+        .upsert_job_scheduler(
+            "rm-sched",
+            RepeatOptions {
+                pattern: Some("* * * * *".into()),
+                ..Default::default()
+            },
+            JobSchedulerTemplate {
+                name: Some("rm-tick".into()),
+                data: Some(TestJob { value: "rm".into() }),
+                opts: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(queue.remove_job_scheduler("rm-sched").await.unwrap());
+
+    let mut raw = raw_redis_conn().await;
+    let zscore: Option<f64> = redis::cmd("ZSCORE")
+        .arg(format!("bull:{}:repeat", qname))
+        .arg("rm-sched")
+        .query_async(&mut raw)
+        .await
+        .unwrap();
+    assert!(zscore.is_none(), "repeat zset entry should be removed");
+
+    let hash_exists: bool = redis::cmd("EXISTS")
+        .arg(format!("bull:{}:repeat:rm-sched", qname))
+        .query_async(&mut raw)
+        .await
+        .unwrap();
+    assert!(!hash_exists, "scheduler hash should be removed");
+
+    let delayed_count: u64 = redis::cmd("ZCARD")
+        .arg(format!("bull:{}:delayed", qname))
+        .query_async(&mut raw)
+        .await
+        .unwrap();
+    assert_eq!(delayed_count, 0, "pending delayed job should be removed");
+
+    let job_exists: bool = redis::cmd("EXISTS")
+        .arg(format!("bull:{}:{}", qname, job.id))
+        .query_async(&mut raw)
+        .await
+        .unwrap();
+    assert!(!job_exists, "pending iteration job hash should be removed");
+
+    assert!(
+        !queue.remove_job_scheduler("rm-sched").await.unwrap(),
+        "removing a missing scheduler should return false"
+    );
+
+    queue.drain().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_job_scheduler_limit_stops_iterations() {
+    let conn = redis_conn();
+    let qname = unique_queue_name();
+
+    let queue = QueueBuilder::new(&qname)
+        .connection(conn.clone())
+        .build::<TestJob>()
+        .await
+        .unwrap();
+
+    queue
+        .upsert_job_scheduler(
+            "limit-sched",
+            RepeatOptions {
+                every: Some(Duration::from_millis(500)),
+                limit: Some(2),
+                ..Default::default()
+            },
+            JobSchedulerTemplate {
+                name: Some("limited".into()),
+                data: Some(TestJob {
+                    value: "limited".into(),
+                }),
+                opts: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let processed = Arc::new(AtomicU64::new(0));
+    let processed_cb = processed.clone();
+    let worker = WorkerBuilder::new(&qname)
+        .connection(conn)
+        .skip_stalled_check(true)
+        .build::<TestJob>();
+    let handle = worker
+        .start(move |_job| {
+            let processed = processed_cb.clone();
+            async move {
+                processed.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    while processed.load(Ordering::SeqCst) < 2 && std::time::Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    // Give the scheduler a chance to (wrongly) produce more iterations.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    handle.shutdown();
+    handle.wait().await.unwrap();
+
+    assert_eq!(
+        processed.load(Ordering::SeqCst),
+        2,
+        "scheduler with limit=2 must stop after 2 iterations"
+    );
+
+    let mut raw = raw_redis_conn().await;
+    let delayed_count: u64 = redis::cmd("ZCARD")
+        .arg(format!("bull:{}:delayed", qname))
+        .query_async(&mut raw)
+        .await
+        .unwrap();
+    assert_eq!(delayed_count, 0, "no further iteration should be pending");
+
+    queue.remove_job_scheduler("limit-sched").await.unwrap();
+    queue.drain().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_job_scheduler_upsert_override_replaces_pending_job() {
+    let conn = redis_conn();
+    let qname = unique_queue_name();
+
+    let queue = QueueBuilder::new(&qname)
+        .connection(conn)
+        .build::<TestJob>()
+        .await
+        .unwrap();
+
+    let first = queue
+        .upsert_job_scheduler(
+            "override-sched",
+            RepeatOptions {
+                pattern: Some("* * * * *".into()),
+                ..Default::default()
+            },
+            JobSchedulerTemplate {
+                name: Some("v1".into()),
+                data: Some(TestJob { value: "v1".into() }),
+                opts: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let second = queue
+        .upsert_job_scheduler(
+            "override-sched",
+            RepeatOptions {
+                pattern: Some("* * * * *".into()),
+                ..Default::default()
+            },
+            JobSchedulerTemplate {
+                name: Some("v2".into()),
+                data: Some(TestJob { value: "v2".into() }),
+                opts: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let mut raw = raw_redis_conn().await;
+    let delayed: Vec<String> = redis::cmd("ZRANGE")
+        .arg(format!("bull:{}:delayed", qname))
+        .arg(0)
+        .arg(-1)
+        .query_async(&mut raw)
+        .await
+        .unwrap();
+    assert_eq!(
+        delayed.len(),
+        1,
+        "override must replace the pending delayed job, not orphan it (got {:?})",
+        delayed
+    );
+    assert_eq!(delayed[0], second.id);
+    if first.id != second.id {
+        let orphan_exists: bool = redis::cmd("EXISTS")
+            .arg(format!("bull:{}:{}", qname, first.id))
+            .query_async(&mut raw)
+            .await
+            .unwrap();
+        assert!(!orphan_exists, "the first pending job must be deleted");
+    }
+
+    let scheduler = queue
+        .get_job_scheduler("override-sched")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(scheduler.name, "v2");
+
+    queue.remove_job_scheduler("override-sched").await.unwrap();
+    queue.drain().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// Worker advanced controls
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_extend_job_locks() {
+    let conn = redis_conn();
+    let qname = unique_queue_name();
+
+    let queue = QueueBuilder::new(&qname)
+        .connection(conn)
+        .build::<TestJob>()
+        .await
+        .unwrap();
+
+    let job = queue
+        .add(
+            "lockme",
+            TestJob {
+                value: "lock".into(),
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    let token = "test-lock-token";
+    let fetched = queue
+        .get_next_job(token)
+        .await
+        .unwrap()
+        .expect("job should be fetched");
+    assert_eq!(fetched.id, job.id);
+
+    // Wrong token: the job id must be reported as failed.
+    let failed = queue
+        .extend_job_locks(
+            std::slice::from_ref(&job.id),
+            &["wrong-token".to_string()],
+            Duration::from_secs(60),
+        )
+        .await
+        .unwrap();
+    assert_eq!(failed, vec![job.id.clone()]);
+
+    // Correct token: lock TTL is refreshed.
+    let failed = queue
+        .extend_job_locks(
+            std::slice::from_ref(&job.id),
+            &[token.to_string()],
+            Duration::from_secs(60),
+        )
+        .await
+        .unwrap();
+    assert!(failed.is_empty());
+
+    let mut raw = raw_redis_conn().await;
+    let pttl: i64 = redis::cmd("PTTL")
+        .arg(format!("bull:{}:{}:lock", qname, job.id))
+        .query_async(&mut raw)
+        .await
+        .unwrap();
+    assert!(
+        pttl > 30_000 && pttl <= 60_000,
+        "lock PTTL should be refreshed to ~60s, got {}",
+        pttl
+    );
+
+    queue.drain().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_cancel_job_aborts_handler() {
+    let conn = redis_conn();
+    let qname = unique_queue_name();
+
+    let queue = QueueBuilder::new(&qname)
+        .connection(conn.clone())
+        .build::<TestJob>()
+        .await
+        .unwrap();
+
+    let job = queue
+        .add(
+            "long",
+            TestJob {
+                value: "long".into(),
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    let started = Arc::new(AtomicU64::new(0));
+    let completed = Arc::new(AtomicU64::new(0));
+    let started_cb = started.clone();
+    let completed_cb = completed.clone();
+
+    let worker = WorkerBuilder::new(&qname)
+        .connection(conn)
+        .skip_stalled_check(true)
+        .build::<TestJob>();
+    let handle = worker
+        .start(move |_job| {
+            let started = started_cb.clone();
+            let completed = completed_cb.clone();
+            async move {
+                started.fetch_add(1, Ordering::SeqCst);
+                tokio::time::sleep(Duration::from_secs(10)).await;
+                completed.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+    // Wait for the handler to start, then cancel after ~500ms.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while started.load(Ordering::SeqCst) == 0 && std::time::Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert_eq!(
+        started.load(Ordering::SeqCst),
+        1,
+        "handler should have started"
+    );
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    assert!(
+        handle.cancel_job(&job.id),
+        "cancel_job should signal the in-flight job"
+    );
+    assert!(
+        !handle.cancel_job(&job.id),
+        "second cancel of the same job should return false"
+    );
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    assert_eq!(
+        completed.load(Ordering::SeqCst),
+        0,
+        "the handler future must have been aborted"
+    );
+
+    // The job is neither completed nor failed: it stays in the active list
+    // (with its lock left to expire) until a stalled checker recovers it.
+    // Waiting for stalled recovery is too slow for this test, so only the
+    // not-finished + still-active state is asserted.
+    let mut raw = raw_redis_conn().await;
+    let completed_count: u64 = redis::cmd("ZCARD")
+        .arg(format!("bull:{}:completed", qname))
+        .query_async(&mut raw)
+        .await
+        .unwrap();
+    assert_eq!(completed_count, 0);
+    let active: Vec<String> = redis::cmd("LRANGE")
+        .arg(format!("bull:{}:active", qname))
+        .arg(0)
+        .arg(-1)
+        .query_async(&mut raw)
+        .await
+        .unwrap();
+    assert!(
+        active.contains(&job.id),
+        "cancelled job should still be in active"
+    );
+
+    handle.shutdown();
+    handle.wait().await.unwrap();
+
+    queue.drain().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_queue_get_next_job() {
+    let conn = redis_conn();
+    let qname = unique_queue_name();
+
+    let queue = QueueBuilder::new(&qname)
+        .connection(conn)
+        .build::<TestJob>()
+        .await
+        .unwrap();
+
+    let job = queue
+        .add(
+            "manual",
+            TestJob {
+                value: "manual".into(),
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    let token = "manual-token";
+    let fetched = queue
+        .get_next_job(token)
+        .await
+        .unwrap()
+        .expect("a job should be returned");
+    assert_eq!(fetched.id, job.id);
+    assert_eq!(fetched.name, "manual");
+    assert_eq!(fetched.data.value, "manual");
+    assert_eq!(fetched.state, JobState::Active);
+
+    let mut raw = raw_redis_conn().await;
+    let active: Vec<String> = redis::cmd("LRANGE")
+        .arg(format!("bull:{}:active", qname))
+        .arg(0)
+        .arg(-1)
+        .query_async(&mut raw)
+        .await
+        .unwrap();
+    assert!(
+        active.contains(&job.id),
+        "fetched job should be in the active list"
+    );
+
+    assert!(
+        queue.get_next_job(token).await.unwrap().is_none(),
+        "no more jobs should be available"
+    );
+
+    // Complete the fetched job manually.
+    let mut fetched = fetched;
+    fetched
+        .move_to_completed(serde_json::json!({"ok": true}))
+        .await
+        .unwrap();
+    let completed_count: u64 = redis::cmd("ZCARD")
+        .arg(format!("bull:{}:completed", qname))
+        .query_async(&mut raw)
+        .await
+        .unwrap();
+    assert_eq!(completed_count, 1);
+
+    queue.drain().await.unwrap();
+}

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -192,6 +192,7 @@ fn test_job_options_serialization() {
         ttl: None,
         job_id: None,
         deduplication: None,
+        ..Default::default()
     };
     let json = serde_json::to_string(&opts).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -249,6 +250,7 @@ fn test_job_creation_with_options() {
         ttl: Some(Duration::from_secs(60)),
         job_id: None,
         deduplication: None,
+        ..Default::default()
     };
 
     let job = Job::new("2".into(), "delayed-job".into(), 42i32, Some(opts));
@@ -381,6 +383,7 @@ fn test_job_v2_roundtrip() {
         ttl: Some(Duration::from_millis(60000)),
         job_id: Some("custom-id".into()),
         deduplication: None,
+        ..Default::default()
     };
 
     let mut job = Job::new(


### PR DESCRIPTION
Port the BullMQ v5.78 job scheduler to close the last parity gap, plus the remaining worker control APIs.

JobScheduler:
- New Queue API: upsert_job_scheduler, get_job_scheduler, get_job_schedulers, remove_job_scheduler, with new public types RepeatOptions (pattern XOR every, limit, start/end date, tz, immediately, offset), JobSchedulerTemplate and JobScheduler.
- Lua ports of addJobScheduler-11, updateJobScheduler-12, getJobScheduler-1, removeJobScheduler-3 and their includes (storeJobScheduler, getJobSchedulerEveryNextMillis, addJobFromScheduler, storeAndEnqueueJob, addDelayedJob, isQueuePaused). msgpack ARGV boundaries are adapted to JSON (cjson) per repo convention; everything stored in Redis (scheduler hash, job hashes, opts JSON with repeat/prevMillis/repeatJobKey fields, rjk field) stays wire-identical to Node since upstream also re-encodes those values with cjson before storing.
- Cron patterns are evaluated with the croner crate (chrono/chrono-tz for timezones), mirroring Node's defaultRepeatStrategy semantics (currentDate = max(now, startDate), immediately => now, results clamped to now, endDate cutoff).
- Workers schedule the next iteration via updateJobScheduler-12 with producerId = the finished job id whenever a job carrying rjk completes or permanently fails; the script's producer/EXISTS guards make this idempotent. Node schedules at fetch time instead; the resulting Redis state is the same, but a crash mid-processing delays the next iteration until stalled recovery here.

Worker advanced controls:
- WorkerHandle::cancel_job(job_id) aborts the in-flight processing future (oneshot-raced handler). Unlike Node's cooperative AbortSignal, the future is dropped without cleanup: the job stays active, its lock expires and the stalled checker requeues it.
- Queue::get_next_job(token) wraps moveToActive (non-blocking manual fetch); the caller extends locks and finishes the job via the new Job::move_to_completed / Job::move_to_failed helpers.
- Queue::extend_job_locks ports extendLocks-1.lua (msgpack token/id arrays adapted to JSON arrays; ARGV-boundary only).

Known limitations vs Node: legacy (pre-v5) repeatable jobs are not supported (schedulers are detected via the 'ic' hash field), repeat strategies are not pluggable, and upsert_job_scheduler returns an error instead of undefined when limit/endDate are already exhausted.