### PR TITLE
docs: update README, CHANGELOG and parity doc for the v5 parity roadmap

### DIFF
--- a/BULLMQ_V5_PARITY.md
+++ b/BULLMQ_V5_PARITY.md
@@ -1,178 +1,144 @@
 # BullMQ v5 Parity
 
-This document describes the parity status of the current branch,
-`worktree-v2-bullmq-wire-compat`, relative to BullMQ Node.js v5.x.
-
-It does **not** describe the state of `main`.
+This document describes the parity status of `main` relative to BullMQ
+Node.js v5.x. It is updated as features land; the original v2.0.0 scope and
+the follow-up roadmap were tracked in
+[#4](https://github.com/bogardt/bullmq-rs/issues/4).
 
 ## Goal
 
-The goal of this branch is BullMQ v5 wire compatibility plus the core queue,
-worker, events, and flow behavior needed for real interoperability between
-Rust and Node.
-
-In practice, that means:
+BullMQ v5 wire compatibility plus the queue, worker, events, scheduler and
+flow behavior needed for real interoperability between Rust and Node:
 
 - Node BullMQ producers can enqueue work that Rust workers can process
 - Rust producers can enqueue work that Node BullMQ can inspect and process
 - Bull Board and other BullMQ ecosystem tools can operate against Redis data
   created by `bullmq-rs`
-- Core parent/child flow state uses BullMQ-compatible Redis structures
+- Rust and Node workers can cohabit on the same queues (shared locks,
+  rate limits, schedulers)
 
-## Implemented on This Branch
+## Implemented
 
 ### Wire-compatible Redis layout
 
 - BullMQ-compatible queue keys and data structures:
   - `wait`, `active`, `paused` as lists
   - `prioritized`, `delayed`, `completed`, `failed`, `waiting-children`,
-    `marker` as sorted sets
-  - `meta` as hash
-  - `events` as stream
-- BullMQ-compatible job hash fields such as:
-  - `atm`, `ats`, `processedOn`, `finishedOn`, `failedReason`,
-    `returnvalue`, `pb`, `opts`
+    `marker`, `repeat` as sorted sets
+  - `meta`, `repeat:<id>`, `metrics:<state>` as hashes
+  - `events` as stream; `limiter`, `de:<id>` as strings
+- BullMQ-compatible job hash fields (`atm`, `ats`, `processedOn`,
+  `finishedOn`, `failedReason`, `returnvalue`, `pb`, `opts`, `rjk`, `deid`,
+  `nrjid`)
 
 ### Lua-script-driven state transitions
 
-- BullMQ-style atomic Lua script ports for core queue and worker transitions
+- 23 Lua scripts ported from BullMQ v5 (add-job family, moveToActive,
+  moveToFinished, moveToDelayed, retryJob, moveStalledJobsToWait,
+  extendLock/extendLocks, pause, changePriority, promote, addLog,
+  moveJobsToWait, cleanJobsInSet, obliterate, getMetrics,
+  addJobScheduler, updateJobScheduler, getJobScheduler, removeJobScheduler)
+  plus their `includes/` dependencies
 - Script loader with BullMQ-style include resolution
 - Marker-based wakeup model for workers
 
 ### Queue surface
 
-- `add`
-- `get_job`
-- `get_job_counts`
-- `count`
-- `get_job_ids`
-- `get_jobs`
-- `get_waiting`
-- `get_active`
-- `get_delayed`
-- `get_prioritized`
-- `get_completed`
-- `get_failed`
-- `get_waiting_children`
-- `remove`
-- `drain`
-- `pause`
-- `resume`
-- `is_paused`
-- `add_log`
-- `get_logs`
+- `add`, `add_bulk`, `get_job`, `get_job_counts`, `count`
+- `get_job_ids`, `get_jobs`, `get_waiting`, `get_active`, `get_delayed`,
+  `get_prioritized`, `get_completed`, `get_failed`, `get_waiting_children`
+- `remove`, `drain`, `clean`, `obliterate`
+- `retry_jobs`, `promote_jobs`
+- `pause`, `resume`, `is_paused`
+- `add_log`, `get_logs`
+- `get_metrics`
+- `upsert_job_scheduler`, `get_job_scheduler`, `get_job_schedulers`,
+  `remove_job_scheduler`
+- `get_next_job`, `extend_job_locks` (manual processing)
 
 ### Worker/runtime behavior
 
 - Marker-based blocking loop using `BZPOPMIN`
-- Token-based job locks with lock extension
-- Stalled job recovery
-- `moveToFinished` fast-path
-- Startup recovery for pre-existing backlog
-- Timeout recovery for missed marker wakeups
-- Prefetch-channel fixes so prefetched jobs are not orphaned in `active`
+- Token-based job locks with lock extension and stalled job recovery
+- `moveToFinished` fast-path with prefetch-safe dispatch
+- Startup and timeout recovery for missed markers / pre-existing backlog
+- Rate limiting (`WorkerOptions::limiter`, shared `limiter` key)
+- Metrics collection (`WorkerOptions::metrics`)
+- Automatic rescheduling of repeatable jobs (next iteration on finish)
+- `WorkerHandle`: `pause(do_not_wait_active)`, `resume`, `is_paused`,
+  `is_running`, `cancel_job`, graceful `shutdown`/`wait`
+- Callbacks: `on_completed`, `on_failed`, `on_active`, `on_error`
+
+### Job options
+
+- Priorities, delays, attempts with fixed/exponential backoff
+- Custom job ids, deduplication (`DeduplicationOptions { id, ttl }`)
+- Repeat metadata on scheduler-produced jobs
 
 ### Job active-handle methods
 
-- `update_progress`
-- `log`
-- `update_data`
-- `clear_logs`
-- `get_state`
-- state helpers (`is_completed`, `is_failed`, etc.)
-- `change_delay`
-- `retry`
-- `remove`
-- `change_priority`
-- `promote`
-- `wait_until_finished`
+- `update_progress`, `log`, `update_data`, `clear_logs`
+- `get_state` and state helpers (`is_completed`, `is_failed`, …)
+- `change_delay`, `retry`, `remove`, `change_priority`, `promote`
+- `wait_until_finished`, `get_dependencies`, `get_children_values`
+- `move_to_completed`, `move_to_failed` (manual processing)
 
 ### Queue events
 
-- `QueueEvents` stream consumer via `XREAD BLOCK`
-- typed `QueueEvent` enum
+- `QueueEvents` stream consumer via `XREAD BLOCK`, typed `QueueEvent` enum
 - `QueueEventsProducer` custom event publishing
 
 ### Core Flows parity
 
-- `FlowProducer`
-- same-queue flow creation
-- cross-queue flow creation
-- `waiting-children` lifecycle
-- parent release on child completion
-- delayed parent release
-- prioritized parent release
-- paused parent release
-- `Job::get_dependencies()`
-- `Job::get_children_values()`
+- `FlowProducer` — same-queue and cross-queue trees
+- `waiting-children` lifecycle, parent release on child completion
+  (including delayed / prioritized / paused parents)
+- `Job::get_dependencies()`, `Job::get_children_values()`
 
-## Deliberately Excluded From This Branch
+### Conformance
 
-This branch does **not** try to implement every BullMQ v5 subsystem.
-The following areas are intentionally left out of scope for this pass:
+- Automated cross-language harness in CI (`compat` job): Rust producer →
+  Node reader and Node producer → Rust worker against `bullmq@5.x` on
+  Redis 7
 
-- `JobScheduler` / repeatable jobs
-- advanced Flows APIs and policies such as:
-  - `getFlow(...)`
-  - dependency pagination / cursors
-  - ignored-dependency-on-failure and related failure-policy variants
-- rate limiting
-- metrics / Prometheus-style reporting
-- deduplication
-- debounce
-- automated Node.js conformance harness
+## Known gaps
 
-## Still Missing for Broader BullMQ v5 Parity
+### Rate limiting
 
-These are the main gaps that remain if the goal is broader BullMQ API parity,
-not just wire compatibility and core runtime behavior:
+- Dynamic `queue.rateLimit()` / `worker.rateLimit()` and the manual
+  rate-limit error are not ported (worker-level `limiter` option only)
 
-### Scheduler / repeatable jobs
+### Deduplication
 
-- `JobScheduler`
-- repeatable job support
-- cron / interval scheduling semantics
+- `replace` / `extend` / `keepLastIfActive` modes are not exposed
+- Removing a job does not proactively clear a still-live TTL'd dedup key
 
-### Remaining Queue API surface
+### Scheduler
 
-- `addBulk`
-- `clean`
-- `obliterate`
-- `retryJobs`
-- `promoteJobs`
+- Repeat strategy is not pluggable (default cron/every strategy only)
+- Legacy (pre-Job-Scheduler) repeatable key format is not supported
 
-### Remaining Worker API/control surface
+### Worker
 
-- Worker pause / resume controls
-- Worker status helpers such as `isPaused` / `isRunning`
-- richer close / cancellation / rate-limit controls
-- BullMQ-style listener / emitter surface beyond current Rust APIs
+- `cancel_job` aborts the processing future; there is no cooperative
+  `AbortSignal` equivalent — the cancelled job is requeued via stalled
+  recovery
+- No BullMQ-style listener/event-emitter surface beyond the provided
+  callbacks (use `QueueEvents` for the stream)
 
 ### Advanced Flows surface
 
-- `getFlow(...)`
-- richer dependency introspection
-- ignored / failed dependency buckets
-- failure-policy variants for parent/child flows
+- `getFlow(...)`, dependency pagination / cursors
+- ignored / failed dependency buckets and failure-policy variants
 
-### Conformance / confidence work
+### Out of scope (design discussion first)
 
-- broader automated Node.js conformance testing
-- more end-to-end compatibility coverage beyond the current targeted checks
+- Sandboxed processors (separate-process handlers)
 
-## What This Branch Should Be Considered
+## Verification
 
-This branch should be considered:
-
-- BullMQ v5 wire-compatible for the implemented queue, worker, events, and
-  core flow behavior
-- suitable for Rust <-> Node interoperability on the implemented surface
-- not yet full BullMQ v5 API parity
-
-## Verification Snapshot
-
-Latest branch-local verification for the flow slice:
-
-- `cargo test --test unit_tests`
-- `cargo test --test integration_tests -- --ignored --test-threads=1 test_flow_`
-- `cargo test --test integration_tests -- --ignored --test-threads=1 test_job_get_dependencies_and_children_values`
+- `cargo test --test unit_tests` — 39 tests
+- `cargo test --lib` — 9 tests
+- `cargo test --test integration_tests -- --ignored --test-threads=1` —
+  82 tests against a live Redis 7
+- CI `compat` job — cross-language wire checks in both directions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+This cycle closes the [BullMQ v5 parity roadmap (#4)](https://github.com/bogardt/bullmq-rs/issues/4):
+everything listed under "Deliberately not in this release" for 2.0.0 has landed,
+except sandboxed processors (out of scope pending a design discussion).
+
+### Added
+
+- **JobScheduler / repeatable jobs** — `Queue::upsert_job_scheduler`,
+  `get_job_scheduler`, `get_job_schedulers`, `remove_job_scheduler`, with
+  cron `pattern` (via `croner`, IANA `tz` support), fixed `every` intervals,
+  `limit`, `start_date` / `end_date`, `immediately` and `offset`. Workers
+  automatically schedule the next iteration when a scheduler job finishes
+  (`addJobScheduler-11` / `updateJobScheduler-12` Lua ports, `repeat` zset +
+  `repeat:<id>` scheduler hashes, wire-identical to Node).
+- **Queue retention** — `Queue::clean(grace, limit, state)` and
+  `Queue::obliterate(force)` (`cleanJobsInSet-3` / `obliterate-2` Lua ports).
+- **Bulk operations** — `Queue::add_bulk`, `Queue::retry_jobs`,
+  `Queue::promote_jobs` (`moveJobsToWait-8` Lua port).
+- **Rate limiting** — `WorkerOptions::limiter` / `WorkerBuilder::limiter`
+  with `RateLimiterOptions { max, duration }`; limiter logic restored in
+  `moveToActive-11` / `moveToFinished-14` (shared `limiter` key, Node-compatible).
+- **Deduplication** — `JobOptions::deduplication` with
+  `DeduplicationOptions { id, ttl }`; restored in the add-job scripts and
+  `storeJob`; dedup key cleared on finalization; deduplicated adds return
+  the existing job's id, mirroring Node.
+- **Metrics** — `WorkerOptions::metrics` / `WorkerBuilder::metrics`
+  (`MetricsOptions { max_data_points }`) and `Queue::get_metrics(state, start, end)`
+  (`getMetrics-2` Lua port, per-minute data points).
+- **Worker control surface** — `WorkerHandle::pause(do_not_wait_active)`,
+  `resume`, `is_paused`, `is_running`; `WorkerHandle::cancel_job` (aborts the
+  in-flight processing future; the job is requeued via stalled-job recovery);
+  `WorkerBuilder::on_active` / `on_error` callbacks.
+- **Manual processing** — `Queue::get_next_job(token)`,
+  `Job::move_to_completed` / `move_to_failed`,
+  `Queue::extend_job_locks(job_ids, tokens, duration)` (`extendLocks-1` Lua port).
+- **Automated cross-language conformance in CI** — the `compat` job runs the
+  `tests/compat/` harness against `bullmq@5.x` on a Redis 7 service container
+  in both directions (Rust producer → Node reader, Node producer → Rust worker).
+
+### Known limitations
+
+- Dynamic `queue.rateLimit()` / manual rate-limit errors are not ported
+  (only the worker-level `limiter` option).
+- Deduplication `replace` / `extend` / `keepLastIfActive` modes are not exposed.
+- `cancel_job` aborts the future without cooperative `AbortSignal` semantics.
+- The repeat strategy is not pluggable (default cron/every strategy only).
+
 ## [2.0.0] — BullMQ v5 wire compatibility
 
 This is a **breaking release** that brings `bullmq-rs` in line with the

--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ ecosystem tooling works out of the box against queues produced by
 - **Priorities** (sorted-set backed), **delays**, **retries** with fixed or
   exponential backoff.
 - **Concurrency** with prefetch-safe job dispatch.
+- **Repeatable jobs / JobScheduler** — cron patterns (with IANA timezones)
+  or fixed intervals, `limit`, start/end dates; workers reschedule the next
+  iteration automatically.
+- **Rate limiting** — `max` jobs per `duration` window, shared across all
+  workers of a queue (including Node.js ones).
+- **Deduplication** — `JobOptions::deduplication { id, ttl }`; duplicate adds
+  return the existing job.
+- **Queue retention** — `clean(grace, limit, state)` and `obliterate(force)`.
+- **Bulk operations** — `add_bulk`, `retry_jobs`, `promote_jobs`.
+- **Metrics** — per-minute finished-job counts (`get_metrics`), collected by
+  workers opted in via `WorkerBuilder::metrics`.
+- **Worker controls** — `pause`/`resume`/`is_paused`/`is_running` on the
+  handle, `cancel_job`, manual fetch with `get_next_job` + `extend_job_locks`.
 - **Queue events** via Redis Streams — typed `QueueEvent` enum delivered
   through `tokio::broadcast`.
 - **Flows** — `FlowProducer` for parent/child job trees, same-queue and
@@ -204,6 +217,39 @@ let root = producer.add(tree).await?;
 println!("Parent {} will run once both children complete", root.job.id);
 ```
 
+### 5. Repeatable jobs
+
+```rust
+use bullmq_rs::{JobSchedulerTemplate, RepeatOptions};
+use std::time::Duration;
+
+// Every 5 minutes, forever
+queue.upsert_job_scheduler(
+    "cleanup",
+    RepeatOptions { every: Some(Duration::from_secs(300)), ..Default::default() },
+    JobSchedulerTemplate { name: Some("cleanup".into()), data: None, opts: None },
+).await?;
+
+// Weekdays at 08:00 Paris time, 10 runs max
+queue.upsert_job_scheduler(
+    "daily-report",
+    RepeatOptions {
+        pattern: Some("0 8 * * 1-5".into()),
+        tz: Some("Europe/Paris".into()),
+        limit: Some(10),
+        ..Default::default()
+    },
+    JobSchedulerTemplate::default(),
+).await?;
+
+// Inspect / remove
+let schedulers = queue.get_job_schedulers(0, -1).await?;
+queue.remove_job_scheduler("cleanup").await?;
+```
+
+Workers process scheduler jobs like any other job and automatically
+enqueue the next iteration on completion.
+
 ## Interop with BullMQ Node
 
 Because the Redis wire format matches BullMQ v5, you can mix Rust and
@@ -252,6 +298,12 @@ All keys use `{prefix}:{queue_name}:{suffix}` (default prefix: `bull`):
 | `bull:<q>:<job_id>:logs` | List | Per-job logs (`job.log(...)`) |
 | `bull:<q>:<job_id>:lock` | String | Worker lock token, PX TTL |
 | `bull:<q>:<job_id>:dependencies` | Sorted Set | Flow children of this job |
+| `bull:<q>:repeat` | Sorted Set | Job schedulers (score = next run, ms) |
+| `bull:<q>:repeat:<id>` | Hash | Scheduler template + iteration count |
+| `bull:<q>:limiter` | String | Rate-limiter window counter (PX TTL) |
+| `bull:<q>:de:<dedup_id>` | String | Deduplication key (optional TTL) |
+| `bull:<q>:metrics:<state>` | Hash | Metrics meta (count, prevTS, prevCount) |
+| `bull:<q>:metrics:<state>:data` | List | Per-minute metrics data points |
 
 ## Requirements
 


### PR DESCRIPTION
  The docs still described the 2.0.0 state, before the parity roadmap (#4)
  landed. Bring them in line with main:

  - CHANGELOG: document the Unreleased cycle — JobScheduler/repeatable jobs, clean/obliterate, bulk ops, rate limiting, deduplication, metrics, worker control surface (pause/resume/cancel_job/callbacks), manual processing APIs, and the automated compat CI job — plus the known limitations.
  - README: extend the features list, add a repeatable-jobs quick-start section, and complete the Redis key schema table (repeat, limiter, de:, metrics keys).
  - BULLMQ_V5_PARITY: rewrite against current main (was describing the old wire-compat branch): implemented surface, known gaps, and verification status (82 integration tests).