### PR TITLE
feat(worker): typed local worker events via tokio::broadcast

### DIFF
--- a/BULLMQ_V5_PARITY.md
+++ b/BULLMQ_V5_PARITY.md
@@ -68,6 +68,10 @@ flow behavior needed for real interoperability between Rust and Node:
 - `WorkerHandle`: `pause(do_not_wait_active)`, `resume`, `is_paused`,
   `is_running`, `cancel_job`, graceful `shutdown`/`wait`
 - Callbacks: `on_completed`, `on_failed`, `on_active`, `on_error`
+- Typed local worker events: `WorkerHandle::subscribe()` returns a
+  `tokio::sync::broadcast` receiver of `WorkerEvent` (`Active`, `Completed`,
+  `Failed`, `Error`, `Drained`, `Paused`, `Resumed`, `Cancelled`,
+  `RateLimited`)
 
 ### Job options
 
@@ -123,8 +127,10 @@ flow behavior needed for real interoperability between Rust and Node:
 - `cancel_job` aborts the processing future; there is no cooperative
   `AbortSignal` equivalent — the cancelled job is requeued via stalled
   recovery
-- No BullMQ-style listener/event-emitter surface beyond the provided
-  callbacks (use `QueueEvents` for the stream)
+- Node's stringly-typed worker `EventEmitter` is replaced by the typed
+  `WorkerEvent` broadcast (`WorkerHandle::subscribe`); lagging subscribers
+  skip events (broadcast semantics, `RecvError::Lagged`) — use
+  `QueueEvents` for the cross-process stream
 
 ### Advanced Flows surface
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Typed local worker events** — `WorkerEvent` enum (`Active`, `Completed`,
+  `Failed`, `Error`, `Drained`, `Paused`, `Resumed`, `Cancelled`,
+  `RateLimited`) emitted alongside the existing callbacks over a
+  `tokio::sync::broadcast` channel; subscribe with
+  `WorkerHandle::subscribe()`. Process-local equivalent of Node BullMQ's
+  worker-level `EventEmitter`; lagging receivers skip the oldest events
+  (`RecvError::Lagged`).
+
 ## [2.1.0] — 2026-06-12
 
 This release closes the [BullMQ v5 parity roadmap (#4)](https://github.com/bogardt/bullmq-rs/issues/4):

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,4 +84,4 @@ pub use types::{
     JobSchedulerTemplate, JobState, Metrics, MetricsMeta, MetricsOptions, RateLimiterOptions,
     RepeatOptions, WorkerOptions,
 };
-pub use worker::{Worker, WorkerBuilder, WorkerHandle};
+pub use worker::{Worker, WorkerBuilder, WorkerEvent, WorkerHandle};

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use tokio::sync::{watch, Mutex, Semaphore};
+use tokio::sync::{broadcast, watch, Mutex, Semaphore};
 use tokio_util::sync::CancellationToken;
 
 use crate::connection::RedisConnection;
@@ -36,6 +36,46 @@ const CANCEL_GRACE_PERIOD: Duration = Duration::from_secs(5);
 
 /// Registry of cancellation tokens for in-flight jobs, keyed by job id.
 type Cancellations = Arc<std::sync::Mutex<HashMap<String, CancellationToken>>>;
+
+/// Process-local worker lifecycle events, broadcast to every receiver
+/// obtained via [`WorkerHandle::subscribe`].
+///
+/// This is the typed, Rust-idiomatic equivalent of Node BullMQ's worker-level
+/// `EventEmitter` (`worker.on('completed' | 'failed' | ...)`). Events are
+/// delivered over a [`tokio::sync::broadcast`] channel: a receiver that falls
+/// behind the channel capacity misses the oldest events and observes
+/// [`tokio::sync::broadcast::error::RecvError::Lagged`] before resuming. For
+/// cross-process events use [`QueueEvents`](crate::QueueEvents) instead.
+#[derive(Debug, Clone)]
+pub enum WorkerEvent {
+    /// A job was fetched and processing starts.
+    Active { job: Job<serde_json::Value> },
+    /// A job completed successfully.
+    Completed { job: Job<serde_json::Value> },
+    /// A job failed (per delivery — fires on retryable failures too, like the
+    /// `on_failed` callback).
+    Failed {
+        job: Job<serde_json::Value>,
+        reason: String,
+    },
+    /// Internal worker error (fetch loop, moveToActive, BZPOPMIN failures).
+    Error { message: String },
+    /// The worker found no more jobs to fetch (queue drained from this
+    /// worker's perspective).
+    Drained,
+    /// Worker-local pause ([`WorkerHandle::pause`]).
+    Paused,
+    /// Worker-local resume ([`WorkerHandle::resume`]).
+    Resumed,
+    /// A job's processing future was cancelled via
+    /// [`WorkerHandle::cancel_job`].
+    Cancelled { job_id: String },
+    /// The worker is rate limited; next fetch attempt at the embedded TTL
+    /// (milliseconds).
+    RateLimited { ttl_ms: u64 },
+}
+
+const EVENTS_CHANNEL_CAPACITY: usize = 1024;
 
 /// A worker that processes jobs from a queue.
 ///
@@ -90,10 +130,22 @@ pub struct WorkerHandle {
     cancellations: Cancellations,
     conn: redis::aio::ConnectionManager,
     limiter_key: String,
+    events_tx: broadcast::Sender<WorkerEvent>,
     join_handle: tokio::task::JoinHandle<()>,
 }
 
 impl WorkerHandle {
+    /// Subscribe to this worker's local [`WorkerEvent`] stream.
+    ///
+    /// Each call returns an independent receiver; every subscriber sees every
+    /// event emitted after it subscribed. A slow receiver that lags behind
+    /// the channel capacity misses the oldest events and gets
+    /// [`tokio::sync::broadcast::error::RecvError::Lagged`] before catching
+    /// up — emission never blocks the worker.
+    pub fn subscribe(&self) -> broadcast::Receiver<WorkerEvent> {
+        self.events_tx.subscribe()
+    }
+
     /// Pause the worker: stop fetching new jobs from the queue.
     ///
     /// Jobs already fetched keep processing. If `do_not_wait_active` is
@@ -103,7 +155,10 @@ impl WorkerHandle {
     /// This is local to the worker and does not pause the queue itself —
     /// other workers keep processing. Use `Queue::pause` for global pause.
     pub async fn pause(&self, do_not_wait_active: bool) {
-        let _ = self.paused_tx.send(true);
+        let was_paused = self.paused_tx.send_replace(true);
+        if !was_paused {
+            let _ = self.events_tx.send(WorkerEvent::Paused);
+        }
 
         if do_not_wait_active {
             return;
@@ -123,7 +178,10 @@ impl WorkerHandle {
 
     /// Resume fetching jobs after a [`pause`](Self::pause).
     pub fn resume(&self) {
-        let _ = self.paused_tx.send(false);
+        let was_paused = self.paused_tx.send_replace(false);
+        if was_paused {
+            let _ = self.events_tx.send(WorkerEvent::Resumed);
+        }
     }
 
     /// Whether the worker is currently paused.
@@ -163,6 +221,9 @@ impl WorkerHandle {
         match token {
             Some(token) => {
                 token.cancel();
+                let _ = self.events_tx.send(WorkerEvent::Cancelled {
+                    job_id: job_id.to_string(),
+                });
                 true
             }
             None => false,
@@ -254,6 +315,8 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
         // Cancellation signals for in-flight jobs (used by cancel_job).
         let cancellations: Cancellations = Arc::new(std::sync::Mutex::new(HashMap::new()));
 
+        let (events_tx, _) = broadcast::channel::<WorkerEvent>(EVENTS_CHANNEL_CAPACITY);
+
         // Shutdown channel.
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
@@ -294,6 +357,7 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
         let cancellations_handle = cancellations.clone();
         let handle_conn = cmd_conn.clone();
         let limiter_key = format!("{}:{}:limiter", prefix, name);
+        let handle_events_tx = events_tx.clone();
 
         let join_handle = tokio::spawn({
             let scripts = scripts.clone();
@@ -302,6 +366,7 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
             let token = token.clone();
             let active_jobs = active_jobs.clone();
             let cancellations = cancellations.clone();
+            let events_tx = events_tx.clone();
             let shutdown_rx_main = shutdown_rx.clone();
             let paused_rx_main = paused_rx.clone();
             let prefetched = prefetched.clone();
@@ -417,6 +482,7 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                 let mut paused_rx = paused_rx_main;
                 let mut blocking_conn = blocking_conn;
                 let mut cmd_conn = cmd_conn;
+                let mut was_drained = false;
                 let marker_key = format!("{}:{}:marker", prefix, name);
 
                 // Bootstrap: add a marker so BZPOPMIN picks up pre-existing jobs.
@@ -509,6 +575,11 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                                 if let Some(ref cb) = on_error {
                                     cb(&BullmqError::Other(format!("BZPOPMIN error: {}", e)));
                                 }
+                                if events_tx.receiver_count() > 0 {
+                                    let _ = events_tx.send(WorkerEvent::Error {
+                                        message: format!("BZPOPMIN error: {}", e),
+                                    });
+                                }
                                 tokio::select! {
                                     _ = tokio::time::sleep(Duration::from_secs(1)) => {},
                                     _ = shutdown_rx.changed() => break,
@@ -548,6 +619,11 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                                             tracing::warn!("moveToActive error: {}", e);
                                             if let Some(ref cb) = on_error {
                                                 cb(&e);
+                                            }
+                                            if events_tx.receiver_count() > 0 {
+                                                let _ = events_tx.send(WorkerEvent::Error {
+                                                    message: format!("moveToActive error: {}", e),
+                                                });
                                             }
                                             None
                                         }
@@ -593,6 +669,14 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                                             if let Some(ref cb) = on_error {
                                                 cb(&e);
                                             }
+                                            if events_tx.receiver_count() > 0 {
+                                                let _ = events_tx.send(WorkerEvent::Error {
+                                                    message: format!(
+                                                        "moveToActive error after delay: {}",
+                                                        e
+                                                    ),
+                                                });
+                                            }
                                             continue;
                                         }
                                     }
@@ -625,6 +709,11 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                                             if let Some(ref cb) = on_error {
                                                 cb(&e);
                                             }
+                                            if events_tx.receiver_count() > 0 {
+                                                let _ = events_tx.send(WorkerEvent::Error {
+                                                    message: format!("moveToActive error: {}", e),
+                                                });
+                                            }
                                             None
                                         }
                                     }
@@ -654,6 +743,10 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                                         Some(result)
                                     }
                                     Ok(_) => {
+                                        if !was_drained {
+                                            was_drained = true;
+                                            let _ = events_tx.send(WorkerEvent::Drained);
+                                        }
                                         continue;
                                     }
                                     Err(e) => {
@@ -668,6 +761,7 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                     // If we have a job result from moveToActive, process it.
                     if let Some(result) = move_result {
                         if let Some(ttl) = result.rate_limit_ttl {
+                            let _ = events_tx.send(WorkerEvent::RateLimited { ttl_ms: ttl });
                             // Rate limited: sleep until the limiter window expires
                             // (bounded; the next moveToActive re-checks the TTL).
                             let wait_ms = ttl.clamp(10, 30_000);
@@ -687,6 +781,7 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                             continue;
                         }
                         if let Some(job_id) = result.job_id {
+                            was_drained = false;
                             // Deserialize the job from the hash data returned by moveToActive.
                             let mut job: Job<T> =
                                 match Job::from_redis_hash(&job_id, &result.job_data) {
@@ -740,6 +835,7 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                             let task_prefetched = prefetched.clone();
                             let task_cancellations = cancellations.clone();
                             let task_limit_until = limit_until.clone();
+                            let task_events_tx = events_tx.clone();
 
                             tokio::spawn(async move {
                                 let _permit = permit;
@@ -752,9 +848,13 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                                 }
 
                                 // Invoke on_active callback.
-                                if let Some(ref cb) = on_active {
+                                if on_active.is_some() || task_events_tx.receiver_count() > 0 {
                                     if let Ok(val_job) = convert_job_to_value(&job) {
-                                        cb(&val_job);
+                                        if let Some(ref cb) = on_active {
+                                            cb(&val_job);
+                                        }
+                                        let _ = task_events_tx
+                                            .send(WorkerEvent::Active { job: val_job });
                                     }
                                 }
 
@@ -880,9 +980,15 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                                         }
 
                                         // Invoke on_completed callback.
-                                        if let Some(ref cb) = on_completed {
+                                        if on_completed.is_some()
+                                            || task_events_tx.receiver_count() > 0
+                                        {
                                             if let Ok(val_job) = convert_job_to_value(&job) {
-                                                cb(&val_job);
+                                                if let Some(ref cb) = on_completed {
+                                                    cb(&val_job);
+                                                }
+                                                let _ = task_events_tx
+                                                    .send(WorkerEvent::Completed { job: val_job });
                                             }
                                         }
 
@@ -987,11 +1093,20 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                                             }
 
                                             // Invoke on_failed callback even for retries.
-                                            if let Some(ref cb) = on_failed {
+                                            if on_failed.is_some()
+                                                || task_events_tx.receiver_count() > 0
+                                            {
                                                 if let Ok(val_job) = convert_job_to_value(&job) {
-                                                    let bullmq_err =
-                                                        BullmqError::Other(err.to_string());
-                                                    cb(&val_job, &bullmq_err);
+                                                    if let Some(ref cb) = on_failed {
+                                                        let bullmq_err =
+                                                            BullmqError::Other(err.to_string());
+                                                        cb(&val_job, &bullmq_err);
+                                                    }
+                                                    let _ =
+                                                        task_events_tx.send(WorkerEvent::Failed {
+                                                            job: val_job,
+                                                            reason: err.to_string(),
+                                                        });
                                                 }
                                             }
                                         } else {
@@ -1053,11 +1168,20 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                                             }
 
                                             // Invoke on_failed callback.
-                                            if let Some(ref cb) = on_failed {
+                                            if on_failed.is_some()
+                                                || task_events_tx.receiver_count() > 0
+                                            {
                                                 if let Ok(val_job) = convert_job_to_value(&job) {
-                                                    let bullmq_err =
-                                                        BullmqError::Other(err.to_string());
-                                                    cb(&val_job, &bullmq_err);
+                                                    if let Some(ref cb) = on_failed {
+                                                        let bullmq_err =
+                                                            BullmqError::Other(err.to_string());
+                                                        cb(&val_job, &bullmq_err);
+                                                    }
+                                                    let _ =
+                                                        task_events_tx.send(WorkerEvent::Failed {
+                                                            job: val_job,
+                                                            reason: err.to_string(),
+                                                        });
                                                 }
                                             }
 
@@ -1106,6 +1230,7 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
             cancellations: cancellations_handle,
             conn: handle_conn,
             limiter_key,
+            events_tx: handle_events_tx,
             join_handle,
         })
     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -5644,3 +5644,294 @@ async fn test_worker_on_error_fires_and_worker_recovers() {
     handle.wait().await.unwrap();
     queue.drain().await.unwrap();
 }
+
+// ---------------------------------------------------------------------------
+// Worker local event broadcast (WorkerHandle::subscribe)
+// ---------------------------------------------------------------------------
+
+fn spawn_event_collector(
+    mut rx: tokio::sync::broadcast::Receiver<WorkerEvent>,
+) -> Arc<Mutex<Vec<WorkerEvent>>> {
+    let events: Arc<Mutex<Vec<WorkerEvent>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = events.clone();
+    tokio::spawn(async move {
+        loop {
+            match rx.recv().await {
+                Ok(ev) => sink.lock().await.push(ev),
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    });
+    events
+}
+
+async fn wait_for_event(
+    events: &Arc<Mutex<Vec<WorkerEvent>>>,
+    timeout: Duration,
+    what: &str,
+    predicate: impl Fn(&WorkerEvent) -> bool,
+) {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        if events.lock().await.iter().any(&predicate) {
+            return;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "{} event should arrive within {:?}",
+            what,
+            timeout
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_worker_events_lifecycle() {
+    let qname = unique_queue_name();
+    let queue = QueueBuilder::new(&qname)
+        .connection(redis_conn())
+        .build::<TestJob>()
+        .await
+        .unwrap();
+
+    let worker = WorkerBuilder::new(&qname)
+        .connection(redis_conn())
+        .skip_stalled_check(true)
+        .build::<TestJob>();
+    let handle = worker.start(|_job| async move { Ok(()) }).await.unwrap();
+
+    let events = spawn_event_collector(handle.subscribe());
+
+    let job = queue
+        .add(
+            "evt",
+            TestJob {
+                value: "events".into(),
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    wait_for_event(
+        &events,
+        Duration::from_secs(10),
+        "Completed",
+        |e| matches!(e, WorkerEvent::Completed { job: j } if j.id == job.id),
+    )
+    .await;
+
+    let evs = events.lock().await;
+    let active_idx = evs
+        .iter()
+        .position(|e| matches!(e, WorkerEvent::Active { job: j } if j.id == job.id))
+        .expect("Active event for the job");
+    let completed_idx = evs
+        .iter()
+        .position(|e| matches!(e, WorkerEvent::Completed { job: j } if j.id == job.id))
+        .expect("Completed event for the job");
+    assert!(active_idx < completed_idx, "Active must precede Completed");
+    drop(evs);
+
+    handle.shutdown();
+    handle.wait().await.unwrap();
+    queue.drain().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_worker_events_failed() {
+    let qname = unique_queue_name();
+    let queue = QueueBuilder::new(&qname)
+        .connection(redis_conn())
+        .build::<TestJob>()
+        .await
+        .unwrap();
+
+    let worker = WorkerBuilder::new(&qname)
+        .connection(redis_conn())
+        .skip_stalled_check(true)
+        .build::<TestJob>();
+    let handle = worker
+        .start(|_job| async move { Err("boom".into()) })
+        .await
+        .unwrap();
+
+    let events = spawn_event_collector(handle.subscribe());
+
+    let job = queue
+        .add(
+            "failing",
+            TestJob {
+                value: "fail-me".into(),
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    wait_for_event(&events, Duration::from_secs(10), "Failed", |e| {
+        matches!(
+            e,
+            WorkerEvent::Failed { job: j, reason } if j.id == job.id && reason.contains("boom")
+        )
+    })
+    .await;
+
+    handle.shutdown();
+    handle.wait().await.unwrap();
+    queue.drain().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_worker_events_paused_resumed_drained() {
+    let qname = unique_queue_name();
+    let queue = QueueBuilder::new(&qname)
+        .connection(redis_conn())
+        .build::<TestJob>()
+        .await
+        .unwrap();
+
+    let worker = WorkerBuilder::new(&qname)
+        .connection(redis_conn())
+        .skip_stalled_check(true)
+        .build::<TestJob>();
+    let handle = worker.start(|_job| async move { Ok(()) }).await.unwrap();
+
+    let events = spawn_event_collector(handle.subscribe());
+
+    // Empty queue: the BZPOPMIN timeout (5s) plus the moveToActive recovery
+    // check must produce a single Drained.
+    wait_for_event(&events, Duration::from_secs(15), "Drained", |e| {
+        matches!(e, WorkerEvent::Drained)
+    })
+    .await;
+
+    handle.pause(false).await;
+    wait_for_event(&events, Duration::from_secs(5), "Paused", |e| {
+        matches!(e, WorkerEvent::Paused)
+    })
+    .await;
+
+    handle.resume();
+    wait_for_event(&events, Duration::from_secs(5), "Resumed", |e| {
+        matches!(e, WorkerEvent::Resumed)
+    })
+    .await;
+
+    handle.shutdown();
+    handle.wait().await.unwrap();
+    queue.drain().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_worker_events_cancelled() {
+    let qname = unique_queue_name();
+    let queue = QueueBuilder::new(&qname)
+        .connection(redis_conn())
+        .build::<TestJob>()
+        .await
+        .unwrap();
+
+    let job = queue
+        .add(
+            "slow",
+            TestJob {
+                value: "cancel-me".into(),
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    let worker = WorkerBuilder::new(&qname)
+        .connection(redis_conn())
+        .skip_stalled_check(true)
+        .build::<TestJob>();
+    let handle = worker
+        .start_with_signal(|_job, token| async move {
+            tokio::select! {
+                _ = token.cancelled() => Err("cancelled".into()),
+                _ = tokio::time::sleep(Duration::from_secs(10)) => Ok(()),
+            }
+        })
+        .await
+        .unwrap();
+
+    let events = spawn_event_collector(handle.subscribe());
+
+    wait_for_event(
+        &events,
+        Duration::from_secs(10),
+        "Active",
+        |e| matches!(e, WorkerEvent::Active { job: j } if j.id == job.id),
+    )
+    .await;
+
+    assert!(
+        handle.cancel_job(&job.id),
+        "cancel_job should signal the job"
+    );
+
+    wait_for_event(
+        &events,
+        Duration::from_secs(5),
+        "Cancelled",
+        |e| matches!(e, WorkerEvent::Cancelled { job_id } if *job_id == job.id),
+    )
+    .await;
+
+    handle.shutdown();
+    handle.wait().await.unwrap();
+    queue.drain().await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires running Redis"]
+async fn test_worker_events_multiple_subscribers() {
+    let qname = unique_queue_name();
+    let queue = QueueBuilder::new(&qname)
+        .connection(redis_conn())
+        .build::<TestJob>()
+        .await
+        .unwrap();
+
+    let worker = WorkerBuilder::new(&qname)
+        .connection(redis_conn())
+        .skip_stalled_check(true)
+        .build::<TestJob>();
+    let handle = worker.start(|_job| async move { Ok(()) }).await.unwrap();
+
+    let events_a = spawn_event_collector(handle.subscribe());
+    let events_b = spawn_event_collector(handle.subscribe());
+
+    let job = queue
+        .add(
+            "fanout",
+            TestJob {
+                value: "both".into(),
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    for (name, events) in [("first", &events_a), ("second", &events_b)] {
+        wait_for_event(
+            events,
+            Duration::from_secs(10),
+            name,
+            |e| matches!(e, WorkerEvent::Completed { job: j } if j.id == job.id),
+        )
+        .await;
+    }
+
+    handle.shutdown();
+    handle.wait().await.unwrap();
+    queue.drain().await.unwrap();
+}


### PR DESCRIPTION
Add a process-local, typed event stream to the worker: a WorkerEvent enum (Active, Completed, Failed, Error, Drained, Paused, Resumed, Cancelled, RateLimited) broadcast over a tokio::sync::broadcast channel (capacity 1024), subscribed via WorkerHandle::subscribe(). This is the Rust answer to Node BullMQ's worker-level EventEmitter (worker.on('completed'|...)): instead of a stringly-typed on(event, handler) surface, consumers match on a typed enum, getting exhaustiveness checking and payloads carried by the variants. The existing on_completed/on_failed/on_active/on_error callbacks keep working unchanged; events are emitted alongside them, and the Redis-stream QueueEvents remains the cross-process channel.

Emission is cheap and infallible: send errors are ignored (no subscribers is fine) and jobs are converted to Job<serde_json::Value> only when at least one receiver exists. Drained fires once per drain (reset when a job is fetched) instead of on every 5s BZPOPMIN timeout. Paused/Resumed only fire on actual state transitions. Lag semantics follow tokio broadcast: a receiver that falls behind the channel capacity misses the oldest events and observes RecvError::Lagged before resuming; emission never blocks the worker.

Covered by five new integration tests (lifecycle ordering, failure reason, paused/resumed/drained, cancellation, multi-subscriber fan-out); parity doc and changelog updated.