### PR TITLE
release: 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] — 2026-06-12
+
 ### Added
 
 - **Typed local worker events** — `WorkerEvent` enum (`Active`, `Completed`,
@@ -204,7 +206,8 @@ The Lua scripts under `lua/` are ports of [BullMQ](https://github.com/taskforces
 
 - First public release.
 
-[Unreleased]: https://github.com/bogardt/bullmq-rs/compare/v2.1.0...HEAD
+[Unreleased]: https://github.com/bogardt/bullmq-rs/compare/v2.2.0...HEAD
+[2.2.0]: https://github.com/bogardt/bullmq-rs/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/bogardt/bullmq-rs/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/bogardt/bullmq-rs/compare/v1.1.0...v2.0.0
 [1.1.0]: https://github.com/bogardt/bullmq-rs/compare/v0.2.2...v1.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bullmq-rs"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bullmq-rs"
-version = "2.1.0"
+version = "2.2.0"
 edition = "2021"
 authors = ["Thomas Bogard <thom.bogard@gmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ ecosystem tooling works out of the box against queues produced by
   handle, `cancel_job`, manual fetch with `get_next_job` + `extend_job_locks`.
 - **Queue events** via Redis Streams — typed `QueueEvent` enum delivered
   through `tokio::broadcast`.
+- **Local worker events** — typed `WorkerEvent` enum (`Active`, `Completed`,
+  `Failed`, `Drained`, …) via `handle.subscribe()`, the Rust answer to
+  Node's worker-level `EventEmitter`.
 - **Flows** — `FlowProducer` for parent/child job trees, same-queue and
   cross-queue, with parent-release on child completion.
 - **Job active-handle API** — `update_progress`, `log`, `retry`,
@@ -60,7 +63,7 @@ Node v5, see [BULLMQ_V5_PARITY.md](BULLMQ_V5_PARITY.md).
 
 ```toml
 [dependencies]
-bullmq-rs = "2"
+bullmq-rs = "2.2"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 ```
@@ -250,6 +253,119 @@ queue.remove_job_scheduler("cleanup").await?;
 Workers process scheduler jobs like any other job and automatically
 enqueue the next iteration on completion.
 
+### 6. Local worker events
+
+```rust
+use bullmq_rs::WorkerEvent;
+
+let handle = worker.start(|_job| async move { Ok(()) }).await?;
+
+let mut events = handle.subscribe();
+tokio::spawn(async move {
+    while let Ok(event) = events.recv().await {
+        match event {
+            WorkerEvent::Active { job }            => println!("▶ {}", job.id),
+            WorkerEvent::Completed { job }         => println!("✅ {}", job.id),
+            WorkerEvent::Failed { job, reason }    => println!("❌ {}: {reason}", job.id),
+            WorkerEvent::Drained                   => println!("queue drained"),
+            _ => {}
+        }
+    }
+});
+```
+
+Process-local equivalent of Node's worker-level `EventEmitter` — for
+cross-process events use `QueueEvents` (section 3).
+
+## More recipes
+
+### Deduplication
+
+```rust
+use bullmq_rs::{DeduplicationOptions, JobOptions};
+
+// While the dedup key lives (TTL or until the job finishes),
+// adds with the same id return the EXISTING job instead of a new one.
+let job = queue.add("sync", data, Some(JobOptions {
+    deduplication: Some(DeduplicationOptions {
+        id: "sync-user-42".into(),
+        ttl: Some(Duration::from_secs(60)),
+    }),
+    ..Default::default()
+})).await?;
+```
+
+### Rate limiting
+
+```rust
+use bullmq_rs::{BullmqError, RateLimiterOptions};
+
+// Max 10 jobs per second, shared across ALL workers of the queue
+// (including Node.js ones).
+let worker = WorkerBuilder::new("emails")
+    .connection(conn)
+    .limiter(RateLimiterOptions { max: 10, duration: Duration::from_secs(1) })
+    .build::<Email>();
+
+// Manual rate limiting from inside a handler: the job goes back to
+// wait WITHOUT consuming an attempt.
+let handle = worker.start(|job| async move {
+    if upstream_api_throttled() {
+        return Err(Box::new(BullmqError::RateLimited));
+    }
+    Ok(())
+}).await?;
+
+// Dynamic, queue-wide: block fetching for 30s.
+queue.rate_limit(Duration::from_secs(30)).await?;
+queue.remove_rate_limit_key().await?;
+```
+
+### Worker pause / cooperative cancellation
+
+```rust
+// Pause this worker (jobs keep accumulating; other workers unaffected).
+handle.pause(false).await;   // waits for in-flight jobs
+handle.resume();
+
+// Cooperative cancellation: the handler receives a CancellationToken.
+let handle = worker.start_with_signal(|job, token| async move {
+    tokio::select! {
+        _ = token.cancelled() => Err("cancelled".into()),
+        _ = do_work(&job) => Ok(()),
+    }
+}).await?;
+handle.cancel_job(&job_id);  // triggers the token, force-aborts after 5s
+```
+
+### Metrics
+
+```rust
+use bullmq_rs::{JobState, MetricsOptions};
+
+let worker = WorkerBuilder::new("emails")
+    .connection(conn)
+    .metrics(MetricsOptions { max_data_points: 60 * 24 })  // 1 day of minutes
+    .build::<Email>();
+
+// Later, from anywhere:
+let metrics = queue.get_metrics(JobState::Completed, 0, -1).await?;
+println!("{} completed, {} data points", metrics.meta.count, metrics.count);
+```
+
+### Retention & bulk operations
+
+```rust
+// Remove completed jobs older than 1h (up to 1000).
+queue.clean(Duration::from_secs(3600), 1000, JobState::Completed).await?;
+
+// Re-enqueue all failed jobs.
+queue.retry_jobs(1000, JobState::Failed, None).await?;
+
+// Nuke the queue entirely (must have no active jobs unless force).
+queue.obliterate(false).await?;
+```
+
 ## Interop with BullMQ Node
 
 Because the Redis wire format matches BullMQ v5, you can mix Rust and
@@ -333,8 +449,10 @@ cd tests/compat && npm install
 ## Examples
 
 ```sh
-cargo run --example basic_queue
-cargo run --example basic_worker
+cargo run --example basic_queue       # add jobs (simple, delayed, prioritized, retried)
+cargo run --example basic_worker      # process jobs with concurrency
+cargo run --example repeatable_jobs   # JobScheduler: every-interval, inspect, remove
+cargo run --example worker_events     # subscribe to typed WorkerEvent stream
 ```
 
 ## Documentation

--- a/examples/repeatable_jobs.rs
+++ b/examples/repeatable_jobs.rs
@@ -1,0 +1,75 @@
+//! Repeatable jobs with a JobScheduler: fixed interval, inspection, removal.
+
+use bullmq_rs::{
+    JobSchedulerTemplate, QueueBuilder, RateLimiterOptions, RedisConnection, RepeatOptions,
+    WorkerBuilder,
+};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct Report {
+    kind: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let redis_url = std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".into());
+    let conn = RedisConnection::new(&redis_url);
+
+    let queue = QueueBuilder::new("reports")
+        .connection(conn.clone())
+        .build::<Report>()
+        .await?;
+
+    // Every 2 seconds, at most 3 iterations.
+    queue
+        .upsert_job_scheduler(
+            "demo-report",
+            RepeatOptions {
+                every: Some(Duration::from_secs(2)),
+                limit: Some(3),
+                ..Default::default()
+            },
+            JobSchedulerTemplate {
+                name: Some("generate".into()),
+                data: Some(Report {
+                    kind: "demo".into(),
+                }),
+                opts: None,
+            },
+        )
+        .await?;
+
+    for scheduler in queue.get_job_schedulers(0, -1).await? {
+        println!(
+            "scheduler '{}': every={:?} next={:?} iterations={:?}",
+            scheduler.id, scheduler.every, scheduler.next, scheduler.iteration_count
+        );
+    }
+
+    let worker = WorkerBuilder::new("reports")
+        .connection(conn)
+        .limiter(RateLimiterOptions {
+            max: 10,
+            duration: Duration::from_secs(1),
+        })
+        .build::<Report>();
+
+    let handle = worker
+        .start(|job| async move {
+            println!("generated {} ({})", job.id, job.data.kind);
+            Ok(())
+        })
+        .await?;
+
+    // Let the 3 iterations run (~6s), then clean up.
+    tokio::time::sleep(Duration::from_secs(8)).await;
+    handle.shutdown();
+    handle.wait().await?;
+
+    queue.remove_job_scheduler("demo-report").await?;
+    println!("scheduler removed");
+
+    Ok(())
+}

--- a/examples/worker_events.rs
+++ b/examples/worker_events.rs
@@ -1,0 +1,68 @@
+//! Subscribe to typed local worker events (WorkerEvent) while jobs process.
+
+use bullmq_rs::{QueueBuilder, RedisConnection, WorkerBuilder, WorkerEvent};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct Task {
+    payload: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let redis_url = std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".into());
+    let conn = RedisConnection::new(&redis_url);
+
+    let queue = QueueBuilder::new("events-demo")
+        .connection(conn.clone())
+        .build::<Task>()
+        .await?;
+
+    for i in 0..3 {
+        queue
+            .add(
+                "demo",
+                Task {
+                    payload: format!("task {}", i),
+                },
+                None,
+            )
+            .await?;
+    }
+
+    let worker = WorkerBuilder::new("events-demo")
+        .connection(conn)
+        .build::<Task>();
+
+    let handle = worker
+        .start(|job| async move {
+            if job.data.payload.ends_with('2') {
+                return Err("task 2 always fails".into());
+            }
+            Ok(())
+        })
+        .await?;
+
+    let mut events = handle.subscribe();
+    let printer = tokio::spawn(async move {
+        while let Ok(event) = events.recv().await {
+            match event {
+                WorkerEvent::Active { job } => println!("[active]    {}", job.id),
+                WorkerEvent::Completed { job } => println!("[completed] {}", job.id),
+                WorkerEvent::Failed { job, reason } => {
+                    println!("[failed]    {}: {}", job.id, reason)
+                }
+                WorkerEvent::Drained => println!("[drained]   no more jobs"),
+                other => println!("[event]     {:?}", other),
+            }
+        }
+    });
+
+    tokio::time::sleep(Duration::from_secs(5)).await;
+    handle.shutdown();
+    handle.wait().await?;
+    printer.abort();
+
+    Ok(())
+}


### PR DESCRIPTION
Cut the 2.2.0 release carrying the typed local worker events:

- Bump crate version to 2.2.0; date the CHANGELOG section and add the version compare links.
- README: new "Local worker events" quick-start and a "More recipes" section covering the previously undocumented APIs (deduplication, rate limiting incl. the RateLimited handler error and dynamic queue.rate_limit, worker pause / cooperative cancellation, metrics, retention & bulk ops); minimum version bumped to `bullmq-rs = "2.2"`.
- Two new runnable examples, both verified against a live Redis: `examples/worker_events.rs` and `examples/repeatable_jobs.rs`.

Validated: clippy -D warnings clean, cargo publish --dry-run OK (92 integration tests green on the feature commit).