### PR TITLE
fix(worker): double execution when a claimed job outwaits its lock at the concurrency limit

### DIFF
--- a/src/worker.rs
+++ b/src/worker.rs
@@ -500,6 +500,11 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                         break;
                     }
 
+                    // Concurrency slot reserved by the fetch path before it
+                    // claims a job; consumed by the spawn below. Dropping it
+                    // (any `continue`) releases the slot.
+                    let mut fetch_permit: Option<tokio::sync::OwnedSemaphorePermit> = None;
+
                     // Check fast-path channel first (next job from moveToFinished).
                     let fast_path_result = {
                         let mut rx = next_job_rx.lock().await;
@@ -532,6 +537,26 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                             }
                             continue;
                         }
+
+                        // Reserve a concurrency slot BEFORE fetching. Claiming
+                        // a job (moveToActive) locks it in Redis, but lock
+                        // renewal only starts once the job task is spawned:
+                        // claiming first and then blocking on the semaphore
+                        // left the claimed job's lock to expire while it waited
+                        // for a permit, so the stalled checker re-queued it and
+                        // the job ran twice. Permit-first means a claimed job
+                        // always starts immediately, and a saturated worker
+                        // leaves markers for other workers instead of consuming
+                        // them.
+                        fetch_permit = Some(tokio::select! {
+                            p = semaphore.clone().acquire_owned() => {
+                                match p {
+                                    Ok(permit) => permit,
+                                    Err(_) => break, // Semaphore closed
+                                }
+                            },
+                            _ = shutdown_rx.changed() => break,
+                        });
 
                         // BZPOPMIN on the marker key with 5-second timeout.
                         let bzpopmin_result: redis::RedisResult<redis::Value> =
@@ -761,6 +786,8 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                     // If we have a job result from moveToActive, process it.
                     if let Some(result) = move_result {
                         if let Some(ttl) = result.rate_limit_ttl {
+                            // No job was claimed; free the slot before sleeping.
+                            drop(fetch_permit.take());
                             let _ = events_tx.send(WorkerEvent::RateLimited { ttl_ms: ttl });
                             // Rate limited: sleep until the limiter window expires
                             // (bounded; the next moveToActive re-checks the TTL).
@@ -792,6 +819,15 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                                             job_id,
                                             e
                                         );
+                                        // A prefetched job was registered for
+                                        // lock renewal at claim time; unregister
+                                        // it so its lock can expire and the
+                                        // stalled checker can recover it.
+                                        // (No-op for fetch-path jobs.)
+                                        {
+                                            let mut set = active_jobs.lock().await;
+                                            set.remove(&job_id);
+                                        }
                                         continue;
                                     }
                                 };
@@ -807,15 +843,23 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                             job.lock_token = Some(token.clone());
                             job.state = crate::types::JobState::Active;
 
-                            // Acquire a semaphore permit (may block if at concurrency limit).
-                            let permit = tokio::select! {
-                                p = semaphore.clone().acquire_owned() => {
-                                    match p {
-                                        Ok(permit) => permit,
-                                        Err(_) => break, // Semaphore closed
-                                    }
+                            // The fetch path reserved its slot before claiming.
+                            // Fast-path (prefetched) jobs arrive without one and
+                            // may block here at the concurrency limit: that is
+                            // safe because they were registered in active_jobs
+                            // when prefetched, so their lock keeps being renewed
+                            // while they wait.
+                            let permit = match fetch_permit.take() {
+                                Some(permit) => permit,
+                                None => tokio::select! {
+                                    p = semaphore.clone().acquire_owned() => {
+                                        match p {
+                                            Ok(permit) => permit,
+                                            Err(_) => break, // Semaphore closed
+                                        }
+                                    },
+                                    _ = shutdown_rx.changed() => break,
                                 },
-                                _ = shutdown_rx.changed() => break,
                             };
 
                             // Spawn the job processing task.
@@ -928,7 +972,18 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                                                 ),
                                             ) => {
                                                 // Fast-path: send next job via channel.
-                                                if next.job_id.is_some() {
+                                                if let Some(next_id) = next.job_id.clone() {
+                                                    // The prefetched job is already
+                                                    // claimed and locked in Redis, but
+                                                    // it may wait in the channel longer
+                                                    // than lock_duration before the main
+                                                    // loop gets a permit. Register it
+                                                    // for lock renewal now, before it
+                                                    // is spawned.
+                                                    {
+                                                        let mut set = active_jobs.lock().await;
+                                                        set.insert(next_id.clone());
+                                                    }
                                                     task_prefetched.fetch_add(
                                                         1,
                                                         std::sync::atomic::Ordering::SeqCst,
@@ -938,6 +993,10 @@ impl<T: Serialize + DeserializeOwned + Clone + Send + Sync + 'static> Worker<T> 
                                                             1,
                                                             std::sync::atomic::Ordering::SeqCst,
                                                         );
+                                                        {
+                                                            let mut set = active_jobs.lock().await;
+                                                            set.remove(&next_id);
+                                                        }
                                                         tracing::warn!(
                                                             "Fast-path channel full, prefetched job will be recovered via stalled check: {:?}",
                                                             e.into_inner().job_id

--- a/tests/lock_renewal_race.rs
+++ b/tests/lock_renewal_race.rs
@@ -1,0 +1,185 @@
+//! Regression test for the claim-before-semaphore / lock-renewal race in the
+//! worker fetch loop.
+//!
+//! THE BUG (present up to and including v2.2.0):
+//!
+//! The fetch loop called `move_to_active` (job becomes ACTIVE + locked in Redis,
+//! lock token assigned) and ONLY THEN blocked on `semaphore.acquire_owned()`.
+//! The job id was inserted into `active_jobs` — the set the lock-extender renews
+//! every `lock_duration/2` — only AFTER the permit was granted, inside the
+//! spawned task. So a job claimed while the worker was at its concurrency limit
+//! was never renewed while it waited for a permit. If that wait exceeded
+//! `lock_duration`, its Redis lock expired; the stalled checker re-queued it;
+//! another worker (or the stalled path) picked it up and ran it, and the
+//! original worker *also* ran its now-stale in-memory copy once a permit freed
+//! up -> double execution.
+//!
+//! THE FIX (mirroring the official client): reserve capacity FIRST, then claim.
+//! The fetch loop now acquires a semaphore permit before fetching, so a claimed
+//! job always starts (and starts being renewed) immediately. Jobs prefetched by
+//! `moveToFinished(fetchNext)` are registered in `active_jobs` at prefetch time,
+//! so their lock keeps being renewed while they wait for a permit.
+//!
+//! This test is `#[ignore]` because it needs a live Redis. Run it with a Redis
+//! server available:
+//!
+//!     redis-server &                                   # or: docker run --rm -p 6379:6379 redis
+//!     RUST_LOG=debug cargo test --test lock_renewal_race -- --ignored --nocapture
+//!
+//! On the buggy ordering the assertion FAILS — `victim` is processed twice
+//! (once by worker2 after the stall re-queue, once by worker1's stale copy).
+//! On fixed code it PASSES: the saturated worker1 never claims the victim, so
+//! the free worker2 processes it exactly once.
+
+use bullmq_rs::{QueueBuilder, RedisConnection, WorkerBuilder};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct TestJob {
+    tag: String,
+}
+
+#[tokio::test]
+#[ignore = "needs Redis; regression test for the lock-renewal race (see module docs)"]
+async fn claim_before_semaphore_can_double_execute_a_job() {
+    let url = std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string());
+
+    // Force the race window to be small and observable.
+    let lock_duration = Duration::from_secs(2);
+    let stalled_interval = Duration::from_secs(1);
+
+    // Shared, append-only record of (job_id, started_at) for every handler run.
+    let processed: Arc<Mutex<Vec<(String, Instant)>>> = Arc::new(Mutex::new(Vec::new()));
+
+    let queue_name = format!("race_repro_{}", uuid::Uuid::new_v4());
+
+    // worker1: claims the blocker, then claims the victim and stalls on its permit.
+    let w1 = WorkerBuilder::new(&queue_name)
+        .connection(RedisConnection::new(&url))
+        .concurrency(1)
+        .lock_duration(lock_duration)
+        .stalled_interval(stalled_interval)
+        .build::<TestJob>();
+
+    let processed_w1 = processed.clone();
+    let h1 = w1
+        .start(move |job| {
+            let processed = processed_w1.clone();
+            async move {
+                match job.data.tag.as_str() {
+                    "blocker" => {
+                        // Hold worker1's single permit well past lock_duration.
+                        tokio::time::sleep(Duration::from_secs(6)).await;
+                    }
+                    "victim" => {
+                        let mut log = processed.lock().await;
+                        println!(
+                            "[handler] worker1 victim {} started at {:?}",
+                            job.id,
+                            Instant::now()
+                        );
+                        log.push((job.id.clone(), Instant::now()));
+                    }
+                    _ => {}
+                }
+                Ok(())
+            }
+        })
+        .await
+        .expect("worker1 start");
+
+    let queue = QueueBuilder::new(&queue_name)
+        .connection(RedisConnection::new(&url))
+        .build::<TestJob>()
+        .await
+        .expect("queue build");
+    queue.drain().await.ok();
+
+    // 1) worker1 (the ONLY worker so far) claims the blocker and occupies its permit.
+    queue
+        .add(
+            "a",
+            TestJob {
+                tag: "blocker".into(),
+            },
+            None,
+        )
+        .await
+        .expect("enqueue blocker");
+    tokio::time::sleep(Duration::from_millis(400)).await;
+
+    // 2) worker1 is the sole worker and is at capacity. On the buggy ordering it
+    //    claims the victim via moveToActive and then blocks on the semaphore
+    //    (permit held by the blocker), leaving the victim's lock ticking down
+    //    with NO renewal. On fixed code it does not claim the victim at all
+    //    until it has a free permit.
+    queue
+        .add(
+            "b",
+            TestJob {
+                tag: "victim".into(),
+            },
+            None,
+        )
+        .await
+        .expect("enqueue victim");
+    tokio::time::sleep(Duration::from_millis(400)).await;
+
+    // 3) Bring worker2 online. On the buggy ordering: once the stalled checker
+    //    re-queues the victim (lock expired at ~2s, stalled_interval 1s), worker2
+    //    claims and runs it -> handler run #1; later, when the blocker finishes at
+    //    ~6s, worker1's stale in-memory victim also runs -> handler run #2. On
+    //    fixed code: the victim is still unclaimed in wait, so worker2 simply
+    //    processes it exactly once.
+    let w2 = WorkerBuilder::new(&queue_name)
+        .connection(RedisConnection::new(&url))
+        .concurrency(1)
+        .lock_duration(lock_duration)
+        .stalled_interval(stalled_interval)
+        .build::<TestJob>();
+    let processed_w2 = processed.clone();
+    let h2 = w2
+        .start(move |job| {
+            let processed = processed_w2.clone();
+            async move {
+                if job.data.tag == "victim" {
+                    let mut log = processed.lock().await;
+                    println!(
+                        "[handler] worker2 victim {} started at {:?}",
+                        job.id,
+                        Instant::now()
+                    );
+                    log.push((job.id.clone(), Instant::now()));
+                }
+                Ok(())
+            }
+        })
+        .await
+        .expect("worker2 start");
+
+    // Let the full timeline play out: stall + worker2 re-run, then worker1 stale run.
+    tokio::time::sleep(Duration::from_secs(10)).await;
+
+    h1.shutdown();
+    h2.shutdown();
+    let _ = h1.wait().await;
+    let _ = h2.wait().await;
+    queue.drain().await.ok();
+
+    let log = processed.lock().await;
+    let victim_runs: Vec<&(String, Instant)> = log.iter().collect();
+    println!("[result] victim handler runs: {}", victim_runs.len());
+
+    // Correct behavior: the victim is processed exactly once.
+    // On the buggy code this is 2 (double execution after lock loss).
+    assert_eq!(
+        victim_runs.len(),
+        1,
+        "victim was processed {} times — expected 1. \
+         If this is 2, the claim-before-semaphore race reproduced.",
+        victim_runs.len()
+    );
+}


### PR DESCRIPTION
## The bug

The worker fetch loop claims a job via `moveToActive` — the job becomes active and locked in Redis — and **only then** blocks on the concurrency semaphore. The job id enters `active_jobs` (the set the lock extender renews every `lock_duration/2`) only after a permit is granted, inside the spawned task.

So a job claimed while the worker is at its concurrency limit sits **claimed but unrenewed**. If the permit wait exceeds `lock_duration`:

1. the job's Redis lock expires,
2. the stalled checker re-queues it,
3. another worker claims and runs it → handler run #1,
4. the original worker's stale in-memory copy runs once a permit frees → handler run #2.

**One job, two handler executions.** With default settings (`lock_duration` 30s) the trigger is "worker at capacity + a job waiting > 30s for a permit" — uncommon, but entirely real under sustained saturation.

## Deterministic repro

`tests/lock_renewal_race.rs` (included) reproduces this reliably with `lock_duration=2s`: worker1 (concurrency 1) is saturated by a 6s blocker job, claims the victim anyway, and a second worker re-runs it after the stall re-queue. On the code before this PR:

```
[handler] worker2 victim 2 started at Instant { tv_sec: 1577374, ... }
[handler] worker1 victim 2 started at Instant { tv_sec: 1577379, ... }   ← same job, ~5s later
[result] victim handler runs: 2
assertion `left == right` failed: victim was processed 2 times — expected 1.
```

## The fix

Mirror the official client's ordering: **reserve capacity first, then claim.**

- The fetch loop now acquires a semaphore permit *before* `BZPOPMIN`/`moveToActive`, so a claimed job always starts (and starts being renewed) immediately. A saturated worker no longer claims jobs — or consumes wait markers other workers could use — while it has no capacity to run them.
- Jobs prefetched by `moveToFinished(fetchNext)` are already claimed when they enter the fast-path channel, so they are registered in `active_jobs` at prefetch time — their lock keeps being renewed while they wait for a permit — and unregistered again if the channel send or deserialization fails.

After the fix the same test passes: the saturated worker never claims the victim, and the free worker processes it exactly once. The test stays in the repo as a regression test (`#[ignore]`, needs Redis, like the other integration tests).

## Testing

- `cargo test` — all unit tests pass
- `cargo test --test lock_renewal_race -- --ignored` — fails before, passes after
- `cargo test -- --ignored` (92 Redis integration tests) — same results as unmodified `main` on my machine (83 pass; 9 fail with `Redis(broken pipe)` under full parallel load both before and after this change, and all 9 pass when run in isolation — pre-existing local-environment flakiness, not related to this PR)
- `cargo clippy --tests` and `cargo fmt --check` are clean