### PR TITLE
fix: serialize exponential backoff delay as `delay`, not `base`

### DIFF
--- a/BULLMQ_V5_PARITY.md
+++ b/BULLMQ_V5_PARITY.md
@@ -79,7 +79,8 @@ flow behavior needed for real interoperability between Rust and Node:
 
 ### Job options
 
-- Priorities, delays, attempts with fixed/exponential backoff
+- Priorities, delays, attempts with fixed/exponential backoff (see
+  "Exponential backoff cap" below)
 - Custom job ids, deduplication (`DeduplicationOptions { id, ttl }`)
 - Repeat metadata on scheduler-produced jobs
 
@@ -110,6 +111,13 @@ flow behavior needed for real interoperability between Rust and Node:
   Redis 7
 
 ## Known gaps
+
+### Exponential backoff cap
+
+- `BackoffStrategy::Exponential`'s `max` field has no equivalent in BullMQ
+  Node.js's backoff engine. A bullmq-rs worker honors it as a delay cap; a
+  Node.js worker retrying the same job reads only `delay` and applies its
+  native, uncapped exponential backoff.
 
 ### Global concurrency
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Exponential backoff wire compatibility** — `BackoffStrategy::Exponential`
+  now serializes its delay as `delay` instead of `base`, matching BullMQ
+  Node.js's native `BackoffOptions`. Jobs with exponential backoff produced
+  by bullmq-rs were previously retried without delay by Node.js workers,
+  which don't read `base`
+  ([#23](https://github.com/bogardt/bullmq-rs/issues/23)).
+
 ## [2.2.0] — 2026-06-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ ecosystem tooling works out of the box against queues produced by
 - **Marker-based worker loop** with `BZPOPMIN` — no polling, no missed jobs.
 - **Token-based job locks** with TTL, lock extension, and stalled-job recovery.
 - **Priorities** (sorted-set backed), **delays**, **retries** with fixed or
-  exponential backoff.
+  exponential backoff (the `max` delay cap is a bullmq-rs extension, only
+  honored by bullmq-rs workers).
 - **Concurrency** with prefetch-safe job dispatch.
 - **Repeatable jobs / JobScheduler** — cron patterns (with IANA timezones)
   or fixed intervals, `limit`, start/end dates; workers reschedule the next

--- a/examples/compat_producer.rs
+++ b/examples/compat_producer.rs
@@ -2,7 +2,7 @@
 //!
 //! See tests/compat/README.md for the full cross-language flow.
 
-use bullmq_rs::{JobOptions, JobState, QueueBuilder, RedisConnection};
+use bullmq_rs::{BackoffStrategy, JobOptions, JobState, QueueBuilder, RedisConnection};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
@@ -69,6 +69,26 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
     println!("Added prioritized job {}", prioritized.id);
+
+    let retrying = queue
+        .add(
+            "retrying",
+            Email {
+                to: "user@example.com".into(),
+                subject: "Retry".into(),
+                body: "Produced by bullmq-rs (exponential backoff)".into(),
+            },
+            Some(JobOptions {
+                attempts: Some(3),
+                backoff: Some(BackoffStrategy::Exponential {
+                    base: Duration::from_secs(1),
+                    max: Duration::from_secs(60),
+                }),
+                ..Default::default()
+            }),
+        )
+        .await?;
+    println!("Added job with exponential backoff {}", retrying.id);
 
     let counts = queue.get_job_counts().await?;
     let wait = *counts.get(&JobState::Wait).unwrap_or(&0);

--- a/src/types.rs
+++ b/src/types.rs
@@ -242,8 +242,11 @@ pub enum BackoffStrategy {
         delay: Duration,
     },
     /// Exponential backoff with a maximum delay cap.
+    ///
+    /// Serializes as `delay` to match BullMQ Node.js's `BackoffOptions`;
+    /// `max` is a bullmq-rs extension only honored by bullmq-rs workers.
     Exponential {
-        #[serde(with = "duration_millis")]
+        #[serde(with = "duration_millis", rename = "delay")]
         base: Duration,
         #[serde(with = "duration_millis")]
         max: Duration,

--- a/tests/compat/rust_producer_node_reader.js
+++ b/tests/compat/rust_producer_node_reader.js
@@ -42,6 +42,7 @@ async function main() {
     if (!byName.welcome) fail("missing plain job 'welcome'");
     if (!byName.reminder) fail("missing delayed job 'reminder'");
     if (!byName.urgent) fail("missing prioritized job 'urgent'");
+    if (!byName.retrying) fail("missing retrying job 'retrying'");
 
     if (!byName.reminder.opts || !byName.reminder.opts.delay) {
       fail("delayed job 'reminder' has no delay in opts");
@@ -49,6 +50,13 @@ async function main() {
     if (!byName.urgent.opts || byName.urgent.opts.priority !== 5) {
       fail(`prioritized job 'urgent' has priority ${byName.urgent.opts && byName.urgent.opts.priority}, expected 5`);
     }
+
+    const backoff = byName.retrying.opts && byName.retrying.opts.backoff;
+    if (!backoff || backoff.type !== 'exponential') {
+      fail(`retrying job has no exponential backoff in opts: ${JSON.stringify(backoff)}`);
+    }
+    if (backoff.delay !== 1000) fail(`retrying job backoff.delay is ${backoff.delay}, expected 1000`);
+    if ('base' in backoff) fail("retrying job backoff has a 'base' key, BullMQ Node.js can't read it");
 
     console.log('SUCCESS: all bullmq-rs jobs readable by BullMQ Node.js');
   } finally {

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -149,6 +149,23 @@ fn test_backoff_strategy_serialization() {
     assert_eq!(restored.delay_for_attempt(5), Duration::from_secs(32));
 }
 
+#[test]
+fn test_backoff_exponential_wire_format_uses_delay_key() {
+    let strategy = BackoffStrategy::Exponential {
+        base: Duration::from_secs(1),
+        max: Duration::from_secs(60),
+    };
+    let value: serde_json::Value = serde_json::to_value(&strategy).unwrap();
+
+    assert_eq!(value["type"], "exponential");
+    assert_eq!(value["delay"], 1000);
+    assert_eq!(value["max"], 60000);
+    assert!(value.get("base").is_none());
+
+    let restored: BackoffStrategy = serde_json::from_value(value).unwrap();
+    assert_eq!(restored.delay_for_attempt(0), Duration::from_secs(1));
+}
+
 // ---------------------------------------------------------------------------
 // JobOptions tests
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
BullMQ Node.js's native exponential backoff only reads `delay` in `BackoffOptions`. bullmq-rs serialized `BackoffStrategy::Exponential` as `{ type: "exponential", base, max }`, so jobs with exponential backoff produced by bullmq-rs retried without delay on Node.js workers.

- Serialize the delay field as `delay` (Rust field name `base` unchanged)
- Extend the compat harness with a job using exponential backoff
- Document that `max` only applies when a bullmq-rs worker retries the job

Fixes #23